### PR TITLE
Update various README links to top-level documentation

### DIFF
--- a/kernel/README.md
+++ b/kernel/README.md
@@ -28,13 +28,13 @@ _TBD_
 
 ## Contribution Guidelines
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](../CODE_OF_CONDUCT.md)
 
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details on
+Please see [CONTRIBUTING](../CONTRIBUTING.md) for details on
 how to make a contribution.
 
 Please note that this project is released with a
-[Contributor Code of Conduct](CODE_OF_CONDUCT.md).
+[Contributor Code of Conduct](../CODE_OF_CONDUCT.md).
 By participating in this project you agree to abide its terms.
 
 ## License

--- a/loader/README.md
+++ b/loader/README.md
@@ -91,13 +91,13 @@ test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 ## Contribution Guidelines
 
 [![Contributor
-Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](../CODE_OF_CONDUCT.md)
 
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details on how to make a
+Please see [CONTRIBUTING](../CONTRIBUTING.md) for details on how to make a
 contribution.
 
 Please note that this project is released with a [Contributor Code of
-Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree
+Conduct](../CODE_OF_CONDUCT.md). By participating in this project you agree
 to abide its terms.
 
 ## License

--- a/tools/README.md
+++ b/tools/README.md
@@ -76,13 +76,13 @@ _TBD_
 
 ## Contribution Guidelines
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](../CODE_OF_CONDUCT.md)
 
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details on
+Please see [CONTRIBUTING](../CONTRIBUTING.md) for details on
 how to make a contribution.
 
 Please note that this project is released with a
-[Contributor Code of Conduct](CODE_OF_CONDUCT.md).
+[Contributor Code of Conduct](../CODE_OF_CONDUCT.md).
 By participating in this project you agree to abide its terms.
 
 ## License


### PR DESCRIPTION
Fixes links in sub-directory READMEs to top-level documentation.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>