### PR TITLE
Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["resolver"]
+
 [workspace]
 resolver = "2"
 members = [


### PR DESCRIPTION
I was trying to execute 'cargo xtask renode-image' and had an error caused for a 'resolver' feature required in this code.
I added to the code and now is working. Hope this could help to improve it.