### PR TITLE
#41: Stop iterator when y exceeds one pixel beyond quadrant bounds.

### DIFF
--- a/services/graphics-server/src/op.rs
+++ b/services/graphics-server/src/op.rs
@@ -317,8 +317,8 @@ impl Iterator for QuadrantIterator {
                         self.p.x = -(self.radius as i16);
                         self.p.y += 1;
                     }
-                    if self.p.y > 0 as i16 {
-                        break item;
+                    if self.p.y > 1 as i16 {
+                        break None;
                     }
                     if item.is_some() {
                         break item;
@@ -329,8 +329,8 @@ impl Iterator for QuadrantIterator {
                         self.p.x = 0;
                         self.p.y += 1;
                     }
-                    if self.p.y > 0 as i16 {
-                        break item;
+                    if self.p.y > 1 as i16 {
+                        break None;
                     }
                     if item.is_some() {
                         break item;


### PR DESCRIPTION
It looks like there is a bug in the quadrant iterator.  For the example related to this ticket, the quadrant iterator is proceeding far enough through the arc of the circle to paint a pixel in the stroke color that is inside the rectangle.  It looks like that's the source of the spurious pixel.  By stopping the iterator one pixel past the bounds of the quadrant region, that part of the arc will not be reached and so that spurious pixel will not be drawn.  There might be a better solution involving further investigation of the quadrant iterator.