### PR TITLE
Document dependencies on libssl-dev libxkbcommon-dev, newer rustc

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ from source.  It consists of the following projects:
 - You may need to remove the `target/` directory before building, if `rustc` continues to behave like it can't find the `xous` target even after it is installed.
 - If you plan on doing USB firmware updates, you'll need `progressbar2` (updates) and `pyusb` (updates). Note that `pyusb` has name space conflicts with similarly named packages, so if updates aren't working you may need to create a `venv` or uninstall conflicting packages.
 - If you are doing development on the digital signatures with the Python helper scripts, you will need: `pycryptodome` (signing - PEM read), `cryptography` (signing - x509 read), `pynacl` (signing - ed25519 signatures) (most users won't need this).
+- Some system packages are needed, which can be installed with `sudo apt install libssl-dev libxkbcommon-dev` or similar
+- If you receive an error about `feature resolver is required`, try installing a newer version of `rustc` and `cargo` via [rustup](https://rustup.rs)
 
 ## Quickstart using Hosted Mode
 


### PR DESCRIPTION
Without these two packages, `cargo xtask run` failed for me on Debian 11 (bullseye).

The version of `cargo` and `rustc` provided by the apt package `rustc` also threw the error mentioned about `feature resolver is required`. With the install script from https://rustup.rs a much newer version was provided, `rustc 1.57.0 (f1edd0429 2021-11-29)`, compared to [`rustc (1.48.0+dfsg1-2`)](https://packages.debian.org/bullseye/rustc) provided by `apt install rustc`.