### PR TITLE
Update Renode models with new ClockEntry API

### DIFF
--- a/emulation/peripherals/BetrustedEcI2C.cs
+++ b/emulation/peripherals/BetrustedEcI2C.cs
@@ -28,7 +28,7 @@ namespace Antmicro.Renode.Peripherals.I2C
             dataFromSlave = new Queue<byte>();
             IRQ = new GPIO();
 
-            irqTimeoutCallback = new ClockEntry((ulong)5, ClockEntry.FrequencyToRatio(machine, 1000), this.FinishTransaction, machine, "Irq Scheduler");
+            irqTimeoutCallback = new ClockEntry((ulong)5, 1000, this.FinishTransaction, machine, "Irq Scheduler");
 
             var registersMap = new Dictionary<long, DoubleWordRegister>()
             {

--- a/emulation/peripherals/BetrustedSocI2C.cs
+++ b/emulation/peripherals/BetrustedSocI2C.cs
@@ -27,7 +27,7 @@ namespace Antmicro.Renode.Peripherals.I2C
             dataFromSlave = new Queue<byte>();
             IRQ = new GPIO();
 
-            irqTimeoutCallback = new ClockEntry((ulong)5, ClockEntry.FrequencyToRatio(machine, 1000), this.FinishTransaction, machine, "Irq Scheduler");
+            irqTimeoutCallback = new ClockEntry((ulong)5, 1000, this.FinishTransaction, machine, "Irq Scheduler");
 
             var registersMap = new Dictionary<long, DoubleWordRegister>()
             {

--- a/emulation/peripherals/BetrustedWatchdog.cs
+++ b/emulation/peripherals/BetrustedWatchdog.cs
@@ -19,7 +19,7 @@ namespace Antmicro.Renode.Peripherals.Timers
     {
         public BetrustedWatchdog(Machine machine) : base(machine)
         {
-            machine.ClockSource.AddClockEntry(new ClockEntry(10, ClockEntry.FrequencyToRatio(this, 1000), OnTick, this, String.Empty));
+            machine.ClockSource.AddClockEntry(new ClockEntry(10, 1000, OnTick, this, String.Empty));
             var registersMap = new Dictionary<long, DoubleWordRegister>()
             {
                 {(long)Registers.Watchdog, new DoubleWordRegister(this)

--- a/emulation/peripherals/ticktimer.cs
+++ b/emulation/peripherals/ticktimer.cs
@@ -23,7 +23,7 @@ namespace Antmicro.Renode.Peripherals.Timers
     {
         public TickTimer(Machine machine, ulong periodInMs = 1) : base(machine)
         {
-            machine.ClockSource.AddClockEntry(new ClockEntry(periodInMs, ClockEntry.FrequencyToRatio(this, 1000), OnTick, this, "TickTimer"));
+            machine.ClockSource.AddClockEntry(new ClockEntry(periodInMs, 1000, OnTick, this, "TickTimer"));
             this.IRQ = new GPIO();
             DefineRegisters();
         }


### PR DESCRIPTION
ClockEntry now accepts frequency instead of ratio, making the models a tad simpler.