### PR TITLE
Add current app name in security notes

### DIFF
--- a/services/status/src/main.rs
+++ b/services/status/src/main.rs
@@ -727,11 +727,14 @@ fn xmain() -> ! {
             }),
             Some(StatusOpcode::SwitchToShellchat) => {
                 ticktimer.sleep_ms(100).ok();
+                sec_notes.lock().unwrap().remove(&"current_app".to_string());
                 gam.switch_to_app(gam::APP_NAME_SHELLCHAT, security_tv.token.unwrap()).expect("couldn't raise shellchat");
             },
             Some(StatusOpcode::SwitchToApp) => msg_scalar_unpack!(msg, index, _, _, _, {
                 ticktimer.sleep_ms(100).ok();
-                app_autogen::app_dispatch(&gam, security_tv.token.unwrap(), index);
+                let app_name = app_autogen::app_index_to_name(index).expect("app index not found");
+                app_autogen::app_dispatch(&gam, security_tv.token.unwrap(), index).expect("cannot switch to app");
+                sec_notes.lock().unwrap().insert("current_app".to_string(), format!("Current app: {}", app_name).to_string());
             }),
             Some(StatusOpcode::TrySuspend) => {
                 if ((llio.adc_vbus().unwrap() as f64) * 0.005033) > 1.5 {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1279,16 +1279,49 @@ fn generate_app_menus(apps: &Vec::<String>) {
 use gam::{{MenuItem, MenuPayload}};
 use locales::t;
 use num_traits::*;
+use std::{{error::Error, fmt}};
 
-pub(crate) fn app_dispatch(gam: &gam::Gam, token: [u32; 4], index: usize) {{
+#[derive(Debug)]
+pub enum AppDispatchError {{
+    IndexNotFound(usize),
+}}
+
+impl Error for AppDispatchError {{}}
+
+impl fmt::Display for AppDispatchError {{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{
+        match self {{
+            AppDispatchError::IndexNotFound(app_index) => write!(f, "Index {{}} not found", app_index),
+        }}
+    }}
+}}
+
+pub(crate) fn app_dispatch(gam: &gam::Gam, token: [u32; 4], index: usize) -> Result<(), AppDispatchError> {{
     match index {{"####).unwrap();
     for (index, (app_name, _manifest)) in working_set.iter().enumerate() {
-        writeln!(menu, "        {} => gam.switch_to_app(gam::APP_NAME_{}, token).expect(\"couldn't raise app\"),",
+        writeln!(menu, "        {} => {{
+            gam.switch_to_app(gam::APP_NAME_{}, token).expect(\"couldn't raise app\");
+            Ok(())
+        }},",
             index,
             app_name.to_uppercase()
         ).unwrap();
     }
-    writeln!(menu, r####"        _ => log::error!("Invalid index for app dispatch: {{}}. Ignoring!", index),
+    writeln!(menu, r####"        _ => Err(AppDispatchError::IndexNotFound(index)),
+    }}
+}}
+
+pub(crate) fn app_index_to_name(index: usize) -> Result<&'static str, AppDispatchError> {{
+    match index {{"####).unwrap();
+    for (index, (_, _manifest)) in working_set.iter().enumerate() {
+        for name in _manifest.menu_name.keys() {
+            writeln!(menu, "        {} => Ok(t!(\"{}\", xous::LANG)),",
+                index,
+                name,
+            ).unwrap();
+        }  
+    }
+    writeln!(menu, r####"        _ => Err(AppDispatchError::IndexNotFound(index)),
     }}
 }}
 


### PR DESCRIPTION
This commit adds the current's app name to the security bar at the top
of the screen, just beneath the status bar.
I had to add a new generated function to map app index back to its name,
along with an enum to signal whether or not the id is valid.

Signed-off-by: Gianguido Sorà <me@gsora.xyz>