### PR TITLE
add drain and can_play stubs to hostaudio backend

### DIFF
--- a/services/codec/src/backend/hostaudio.rs
+++ b/services/codec/src/backend/hostaudio.rs
@@ -26,6 +26,14 @@ impl Codec {
     pub fn free_play_frames(&self) -> usize {
         0
     }
+
+    pub fn can_play(&self) -> bool {
+        false
+    }
+
+    pub fn drain(&mut self) {
+    }
+
     pub fn available_rec_frames(&self) -> usize {
         0
     }


### PR DESCRIPTION
these methods were added to tlv320aic3100 and are called from services/codec/src/main.rs