### PR TITLE
Compile for hosted and real hardware on main push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches:
+      - main
+
+name: Build xous-core
+
+jobs:
+  build:
+    name: Setup Rust
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task: ["hosted-ci", "renode-image"]
+    steps:
+      - name: Install Ubuntu dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libxkbcommon-dev
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: "1.59.0"
+          default: true
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Install RISC-V toolkit
+        run: cargo xtask install-toolkit
+
+      - name: Build hosted-ci
+        run: cargo xtask ${{ matrix.task }}


### PR DESCRIPTION
This PR adds a small Github CI action to build hosted mode and real hardware image (Renode image in this case) on any `main` push.

Works fine with 4GB RAM but Github doesn't allow setting an arbitrary amount of memory for CI's, so it must be tested.