### PR TITLE
fix: on non-TTY terminals, if forced, proceed with toolchain download and install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,7 @@
-#on:
-#  push:
-#    branches:
-#      - main
 on:
   push:
+    branches:
+      - main
 
 name: Build xous-core
 
@@ -13,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        task: ["hosted-ci"] #, "renode-image"]
+        task: ["hosted-ci", "renode-image"]
     steps:
       - name: Install Ubuntu dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
+#on:
+#  push:
+#    branches:
+#      - main
 on:
   push:
-    branches:
-      - main
 
 name: Build xous-core
 
@@ -11,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        task: ["hosted-ci", "renode-image"]
+        task: ["hosted-ci"] #, "renode-image"]
     steps:
       - name: Install Ubuntu dependencies
         run: |
@@ -31,7 +33,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Install RISC-V toolkit
-        run: cargo xtask install-toolkit
-
+        run: cargo xtask install-toolkit --force
+      
       - name: Build hosted-ci
         run: cargo xtask ${{ matrix.task }}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1123,7 +1123,7 @@ fn ensure_compiler(
     let toolchain_path =
         get_sysroot(None)?.ok_or_else(|| "default toolchain not installed".to_owned())?;
     // If the terminal is a tty, offer to download the latest toolchain.
-    if !atty::is(atty::Stream::Stdin) {
+    if !atty::is(atty::Stream::Stdin) && !force_install {
         return Err(format!("Toolchain for {} not found", target));
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1122,7 +1122,8 @@ fn ensure_compiler(
     // Since no sysroot exists, we must download a new one.
     let toolchain_path =
         get_sysroot(None)?.ok_or_else(|| "default toolchain not installed".to_owned())?;
-    // If the terminal is a tty, offer to download the latest toolchain.
+    // If the terminal is a tty, or if toolchain installation is forced,
+    // download the latest toolchain.
     if !atty::is(atty::Stream::Stdin) && !force_install {
         return Err(format!("Toolchain for {} not found", target));
     }


### PR DESCRIPTION
This is a corner case in Github CI.