### PR TITLE
Add a basic 'hello world' app example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hello"
+version = "0.1.0"
+dependencies = [
+ "gam",
+ "graphics-server",
+ "log",
+ "log-server",
+ "num-derive",
+ "num-traits",
+ "xous",
+ "xous-ipc 0.9.7",
+ "xous-names",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ default-members = [
   "services/dns",
   "services/modals",
   "apps/ball",
+  "apps/hello",
   "apps/repl",
 ]
 members = [
@@ -88,6 +89,7 @@ members = [
   "services/dns",
   "services/modals",
   "apps/ball",
+  "apps/hello",
   "apps/repl",
   "services/libstd-test",
   "services/ffi-test",

--- a/apps/hello/Cargo.toml
+++ b/apps/hello/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hello"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+log = "0.4.14"
+num-derive = {version = "0.3.3", default-features = false}
+num-traits = {version = "0.2.14", default-features = false}
+xous = { path = "../../xous-rs" }
+xous-ipc = { path = "../../xous-ipc" }
+log-server = { path = "../../services/log-server" }
+xous-names = { path = "../../services/xous-names" }
+gam = {path = "../../services/gam" }
+graphics-server = {path = "../../services/graphics-server" }

--- a/apps/hello/src/main.rs
+++ b/apps/hello/src/main.rs
@@ -1,0 +1,146 @@
+#![cfg_attr(target_os = "none", no_std)]
+#![cfg_attr(target_os = "none", no_main)]
+
+use core::fmt::Write;
+use graphics_server::api::GlyphStyle;
+use graphics_server::{DrawStyle, Gid, PixelColor, Point, Rectangle, TextBounds, TextView};
+use num_traits::*;
+
+/// Basic 'Hello World!' application that draws a simple
+/// TextView to the screen.
+
+pub(crate) const SERVER_NAME_HELLO: &str = "_Hello World_";
+
+/// Top level application events.
+#[derive(Debug, num_derive::FromPrimitive, num_derive::ToPrimitive)]
+pub(crate) enum HelloOp {
+    /// Redraw the screen
+    Redraw = 0,
+
+    /// Quit the application
+    Quit,
+}
+
+struct Hello {
+    content: Gid,
+    gam: gam::Gam,
+    _gam_token: [u32; 4],
+    screensize: Point,
+}
+
+impl Hello {
+    fn new(xns: &xous_names::XousNames, sid: xous::SID) -> Self {
+        let gam = gam::Gam::new(&xns).expect("Can't connect to GAM");
+        let gam_token = gam
+            .register_ux(gam::UxRegistration {
+                app_name: xous_ipc::String::<128>::from_str(gam::APP_NAME_HELLO),
+                ux_type: gam::UxType::Chat,
+                predictor: None,
+                listener: sid.to_array(),
+                redraw_id: HelloOp::Redraw.to_u32().unwrap(),
+                gotinput_id: None,
+                audioframe_id: None,
+                rawkeys_id: None,
+                focuschange_id: None,
+            })
+            .expect("Could not register GAM UX")
+            .unwrap();
+
+        let content = gam
+            .request_content_canvas(gam_token)
+            .expect("Could not get content canvas");
+        let screensize = gam
+            .get_canvas_bounds(content)
+            .expect("Could not get canvas dimensions");
+        Self {
+            gam,
+            _gam_token: gam_token,
+            content,
+            screensize,
+        }
+    }
+
+    /// Clear the entire screen.
+    fn clear_area(&self) {
+        self.gam
+            .draw_rectangle(
+                self.content,
+                Rectangle::new_with_style(
+                    Point::new(0, 0),
+                    self.screensize,
+                    DrawStyle {
+                        fill_color: Some(PixelColor::Light),
+                        stroke_color: None,
+                        stroke_width: 0,
+                    },
+                ),
+            )
+            .expect("can't clear content area");
+    }
+
+    /// Redraw the text view onto the screen.
+    fn redraw(&mut self) {
+        self.clear_area();
+
+        let mut text_view = TextView::new(
+            self.content,
+            TextBounds::GrowableFromBr(
+                Point::new(
+                    self.screensize.x - (self.screensize.x / 2),
+                    self.screensize.y - (self.screensize.y / 2),
+                ),
+                (self.screensize.x / 5 * 4) as u16,
+            ),
+        );
+
+        text_view.border_width = 1;
+        text_view.draw_border = true;
+        text_view.clear_area = true;
+        text_view.rounded_border = Some(3);
+        text_view.style = GlyphStyle::Regular;
+        write!(text_view.text, "{}", "Hello world!").expect("Could not write to text view");
+
+        self.gam
+            .post_textview(&mut text_view)
+            .expect("Could not render text view");
+        self.gam.redraw().expect("Could not redraw screen");
+    }
+}
+
+#[xous::xous_main]
+fn xmain() -> ! {
+    log_server::init_wait().unwrap();
+    log::set_max_level(log::LevelFilter::Info);
+    log::info!("Hello world PID is {}", xous::process::id());
+
+    let xns = xous_names::XousNames::new().unwrap();
+
+    // Register the server with xous
+    let sid = xns
+        .register_name(SERVER_NAME_HELLO, None)
+        .expect("can't register server");
+
+    let mut hello = Hello::new(&xns, sid);
+
+    loop {
+        let msg = xous::receive_message(sid).unwrap();
+        log::debug!("Got message: {:?}", msg);
+
+        match FromPrimitive::from_usize(msg.body.id()) {
+            Some(HelloOp::Redraw) => {
+                log::debug!("Got redraw");
+                hello.redraw();
+            }
+            Some(HelloOp::Quit) => {
+                log::info!("Quitting application");
+                break;
+            }
+            _ => {
+                log::error!("Got unknown message");
+            }
+        }
+    }
+
+    log::info!("Quitting");
+    xous::terminate_process(0)
+}

--- a/apps/manifest.json
+++ b/apps/manifest.json
@@ -10,6 +10,17 @@
             }
         }
     },
+    "hello": {
+        "context_name": "Hello World",
+        "menu_name": {
+            "appmenu.hello": {
+                "en": "Hello World!",
+                "ja": "",
+                "zh": "",
+                "en-tts": "Hello World!"
+            }
+        }
+    },
     "repl": {
         "context_name": "repl demo app",
         "menu_name": {


### PR DESCRIPTION
I just got my Precursor yesterday (woohoo!). The first thing I did was write a simple "Hello World" application for it. It helped me to write out the most bare-bones Xous application I could, to understand some of the moving pieces. I thought others might also be able to benefit from a more paired-down example.

It's just a simple "Hello World!" TextView. Here's what it looks like in the simulator:
![Screenshot from 2022-03-18 12-41-06](https://user-images.githubusercontent.com/44368/159056157-a68e2dc2-fbb3-4b1f-a0d0-25573e5cd032.png)
![Screenshot from 2022-03-18 12-41-11](https://user-images.githubusercontent.com/44368/159056166-16aa4377-9da2-4059-8e5c-17c30f5f30f3.png)

And on device:


![IMG20220318122217](https://user-images.githubusercontent.com/44368/159056395-956bd600-7a7a-48c6-af90-8d011fa61469.jpg)

Compile with the following command to run it in the simulator:

```
cargo xtask run hello
```

And to compile the app-image and flash via USB:

```
cargo xtask app-image hello
cargo xtask burn-kernel
```

For posterity's sake: I dug through the `BetrustedKdb` source to learn that the "Home" button on the keyboard is what brings up the main context menu, if that's useful for anyone.

Super excited to dig deeper into my Precursor! Thanks for all the hard work fighting supply chain monsters to bring this beauty to me. :clap: 

