### PR TITLE
Switch to using env to find the path to bash.

### DIFF
--- a/buildpush.sh
+++ b/buildpush.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e  # exit on any error
 

--- a/imports/riscv-0.5.6/assemble.sh
+++ b/imports/riscv-0.5.6/assemble.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/imports/riscv-0.5.6/check-blobs.sh
+++ b/imports/riscv-0.5.6/check-blobs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Checks that the blobs are up to date with the committed assembly files
 

--- a/kernel/assemble.sh
+++ b/kernel/assemble.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2020 Sean Cross <sean@xobs.io>
 # SPDX-License-Identifier: Apache-2.0

--- a/loader/assemble.sh
+++ b/loader/assemble.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/tools/factory_reset.sh
+++ b/tools/factory_reset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # populate with an invalid default so the equals compares work downstream

--- a/tools/update_ci.sh
+++ b/tools/update_ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # populate with an invalid default so the equals compares work downstream

--- a/tools/upload_audiotest.sh
+++ b/tools/upload_audiotest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SHORT8=short_8khz.wav
 SHORTCD=short_cd.wav

--- a/xous-rs/assemble.sh
+++ b/xous-rs/assemble.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 


### PR DESCRIPTION
Systems like OpenBSD and NixOS have bash in different locations. This
allows the various scripts to be run on those systems.