### PR TITLE
Xtask ureq assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,36 +696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
-name = "curl"
-version = "0.4.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a872858e9cb9e3b96c80dd78774ad9e32e44d3b05dc31e142b858d14aebc82c"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2",
- "winapi",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.45+curl-7.78.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9e5a72b1c744eb5dd20b2be4d7eb84625070bb5c4ab9b347b70464ab1e62eb"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "winapi",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "3.1.0"
 source = "git+https://github.com/betrusted-io/curve25519-dalek.git?branch=main#c0ee5bf18c606b51bbffb02fde5801ac129b4e7d"
@@ -1503,18 +1473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "llio"
 version = "0.1.0"
 dependencies = [
@@ -1809,25 +1767,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "orbclient"
@@ -2400,16 +2339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,17 +2587,6 @@ dependencies = [
  "libc",
  "log",
  "managed",
-]
-
-[[package]]
-name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -3141,12 +3059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,7 +3468,6 @@ version = "0.1.0"
 dependencies = [
  "atty",
  "chrono",
- "curl",
  "filetime",
  "rustc_version 0.4.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,6 +3034,8 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
+ "serde",
+ "serde_json",
  "url",
  "webpki",
  "webpki-roots",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,7 @@ description = "Cargo-based build system for Xous"
 version = "0.1.0"
 authors = ["Sean Cross <sean@xobs.io>"]
 edition = "2018"
+rust-version = "1.59"
 
 # Dependency policy: fully specify dependencies to the minor version number
 [dependencies]
@@ -15,4 +16,4 @@ chrono = "0.4"
 serde_json = "1.0.41"
 serde = { version = "1.0.130", features = ["derive"] }
 tempfile = "3.3.0"
-ureq = "2.4.0"
+ureq = { version = "2.4.0", features = ["json"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,13 +7,12 @@ edition = "2018"
 
 # Dependency policy: fully specify dependencies to the minor version number
 [dependencies]
-curl = "0.4.35"
 atty = "0.2.14"
 filetime = "0.2.14"
 rustc_version = "0.4.0"
 zip = "0.5.13"
 chrono = "0.4"
 serde_json = "1.0.41"
-serde = {version = "1.0.130", features = ["derive"]}
+serde = { version = "1.0.130", features = ["derive"] }
 tempfile = "3.3.0"
 ureq = "2.4.0"


### PR DESCRIPTION
This replaces `curl` with `ureq`. One downside is that we no longer get progress updates for the download because `ureq` doesn't support it.

This also parses the assets JSON file to determine the correct URL to download the zipfile from, rather than guessing the correct one.