### PR TITLE
Pass register_name two args

### DIFF
--- a/services/cb-test-c1/src/main.rs
+++ b/services/cb-test-c1/src/main.rs
@@ -33,7 +33,7 @@ fn xmain() -> ! {
 
     let xns = xous_names::XousNames::new().unwrap();
     let sid = xns
-        .register_name(SERVER_NAME)
+        .register_name(SERVER_NAME, None)
         .expect("can't register server");
     log::trace!("registered with NS -- {:?}", sid);
 

--- a/services/cb-test-c2/src/main.rs
+++ b/services/cb-test-c2/src/main.rs
@@ -33,7 +33,7 @@ fn xmain() -> ! {
 
     let xns = xous_names::XousNames::new().unwrap();
     let sid = xns
-        .register_name(SERVER_NAME)
+        .register_name(SERVER_NAME, None)
         .expect("can't register server");
     log::trace!("registered with NS -- {:?}", sid);
 

--- a/services/cb-test-srv/src/main.rs
+++ b/services/cb-test-srv/src/main.rs
@@ -43,7 +43,7 @@ fn shell_main() -> ! {
 
     let xns = xous_names::XousNames::new().unwrap();
     let server = xns
-        .register_name(api::SERVER_NAME)
+        .register_name(api::SERVER_NAME, None)
         .expect("can't register server");
 
     xous::create_thread_0(pump_thread).unwrap();


### PR DESCRIPTION
Looks like the cb-test-xxx services need to call `register_name` with two args vs one.