### PR TITLE
chore: ignore anything called "target"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-/target
-/kernel/target
-/loader/target
-/locales/target
+target
 **/*.rs.bk
 /emulation/peripherals.csproj
 /emulation/obj


### PR DESCRIPTION
Makes life of VSCode users much easier.