### PR TITLE
add as_qrcode to Notification modal

### DIFF
--- a/services/gam/Cargo.toml
+++ b/services/gam/Cargo.toml
@@ -32,6 +32,8 @@ locales = {path = "../../locales"}
 
 tts-frontend = {path="../tts"}
 
+qrcode = { version = "0.12", default-features = false }
+
 [target.'cfg(not(any(windows,unix)))'.dependencies]
 utralib = {path = "../../utralib"}
 

--- a/services/gam/src/modal.rs
+++ b/services/gam/src/modal.rs
@@ -14,6 +14,8 @@ mod progressbar;
 pub use progressbar::*;
 mod consoleinput;
 pub use consoleinput::*;
+mod qrcode;
+pub use self::qrcode::*;
 
 use enum_dispatch::enum_dispatch;
 
@@ -37,6 +39,7 @@ pub enum ActionType {
     CheckBoxes,
     Slider,
     Notification,
+    Qrcode,
     ConsoleInput
 }
 

--- a/services/gam/src/modal/notification.rs
+++ b/services/gam/src/modal/notification.rs
@@ -5,12 +5,19 @@ use graphics_server::api::*;
 use locales::t;
 use core::fmt::Write;
 
-#[derive(Debug, Copy, Clone)]
+use qrcode::{Color, QrCode};
+use std::convert::TryInto;
+
+pub(crate) const QUIET_MODULES: i16 = 2;
+
+#[derive(Debug)]
 pub struct Notification {
     pub action_conn: xous::CID,
     pub action_opcode: u32,
     pub is_password: bool,
     pub manual_dismiss: bool,
+    pub qrcode: Vec<bool>,
+    pub qrwidth: usize,
 }
 impl Notification {
     pub fn new(action_conn: xous::CID, action_opcode: u32) -> Self {
@@ -19,6 +26,8 @@ impl Notification {
             action_opcode,
             is_password: false,
             manual_dismiss: true,
+            qrcode: Vec::new(),
+            qrwidth: 0,
         }
     }
     pub fn set_is_password(&mut self, setting: bool) {
@@ -30,49 +39,119 @@ impl Notification {
     pub fn set_manual_dismiss(&mut self, setting: bool) {
         self.manual_dismiss = setting;
     }
+    pub fn set_as_qrcode(&mut self, setting: Option<&str>) {
+        match setting {
+            Some(setting) => {
+               let qrcode = QrCode::new(setting).unwrap();
+               self.qrwidth = qrcode.width();
+               self.qrcode = Vec::new();
+               for color in qrcode.to_colors().iter() {
+                   match color {
+                      Color::Dark => self.qrcode.push(true),
+                      Color::Light => self.qrcode.push(false),
+                   }
+               }
+            },
+            None => {
+                self.qrcode = Vec::new();
+                self.qrwidth = 0;
+            },            
+        }
+    }
+    fn draw_text(&self, at_height: i16, modal: &Modal) {
+        // prime a textview with the correct general style parameters
+        let mut tv = TextView::new(
+            modal.canvas,
+            TextBounds::BoundingBox(Rectangle::new_coords(0, 0, 1, 1)),
+        );
+        tv.ellipsis = true;
+        tv.style = modal.style;
+        tv.invert = self.is_password;
+        tv.draw_border = false;
+        tv.margin = Point::new(0, 0);
+        tv.insertion = None;
+
+        tv.bounds_computed = None;
+        tv.bounds_hint = TextBounds::GrowableFromTl(
+            Point::new(modal.margin, at_height + modal.margin * 2),
+            (modal.canvas_width - modal.margin * 2) as u16,
+        );
+        write!(tv, "{}", t!("notification.dismiss", xous::LANG)).unwrap();
+        modal
+            .gam
+            .bounds_compute_textview(&mut tv)
+            .expect("couldn't simulate text size");
+        let textwidth = if let Some(bounds) = tv.bounds_computed {
+            bounds.br.x - bounds.tl.x
+        } else {
+            modal.canvas_width - modal.margin * 2
+        };
+        let offset = (modal.canvas_width - textwidth) / 2;
+        tv.bounds_computed = None;
+        tv.bounds_hint = TextBounds::BoundingBox(Rectangle::new(
+            Point::new(offset, at_height + modal.margin * 2),
+            Point::new(
+                modal.canvas_width - modal.margin,
+                at_height + modal.line_height + modal.margin * 2,
+            ),
+        ));
+        modal.gam.post_textview(&mut tv).expect("couldn't post tv");
+    }
+    fn draw_qrcode(&self, at_height: i16, modal: &Modal) {
+        // calculate pixel size of each module in the qrcode
+        let qrcode_modules: i16 = self.qrwidth.try_into().unwrap();
+        let modules: i16 = qrcode_modules + 2 * QUIET_MODULES;
+        let canvas_width = modal.canvas_width - 2 * modal.margin;
+        let mod_size_px: i16 = canvas_width / modules;
+        let qrcode_width_px = qrcode_modules * mod_size_px;
+        let quiet_px: i16 = (canvas_width - qrcode_width_px) / 2;
+        
+        // Iterate thru qrcode and draw each module as a rectangle (square)
+        let black = DrawStyle::new(PixelColor::Dark, PixelColor::Dark, 1);
+        let top = at_height + 4 * modal.margin + quiet_px;
+        let left = modal.margin + quiet_px;
+        let mut top_left;
+        let mut bot_right;
+        let mut x: i16;
+        let mut y: i16;
+        let mut j: i16;        
+        for (i, module) in self.qrcode.iter().enumerate() {
+            j = i.try_into().unwrap();
+            x = left + (j % qrcode_modules) * mod_size_px;
+            y = top + (j / qrcode_modules) * mod_size_px;
+            if *module {
+                top_left = Point::new(x, y);
+                bot_right = Point::new(x + mod_size_px, y + mod_size_px);
+                modal
+                    .gam
+                    .draw_rectangle(
+                        modal.canvas,
+                        Rectangle::new_with_style(top_left, bot_right, black),
+                    )
+                    .expect("couldn't draw qrcode module");
+            }
+        }
+    }
 }
 impl ActionApi for Notification {
-    fn set_action_opcode(&mut self, op: u32) {self.action_opcode = op}
+    fn set_action_opcode(&mut self, op: u32) {
+        self.action_opcode = op
+    }
     fn height(&self, glyph_height: i16, margin: i16) -> i16 {
         if self.manual_dismiss {
-            glyph_height + margin * 2 + 5
+            let qr_height = if self.qrwidth > 0 { 300 } else { 0 };
+            glyph_height + margin * 2 + 5 + qr_height
         } else {
             margin + 5
         }
     }
     fn redraw(&self, at_height: i16, modal: &Modal) {
         if self.manual_dismiss {
-            // prime a textview with the correct general style parameters
-            let mut tv = TextView::new(
-                modal.canvas,
-                TextBounds::BoundingBox(Rectangle::new_coords(0, 0, 1, 1))
-            );
-            tv.ellipsis = true;
-            tv.style = modal.style;
-            tv.invert = self.is_password;
-            tv.draw_border= false;
-            tv.margin = Point::new(0, 0,);
-            tv.insertion = None;
+            self.draw_text(at_height, modal);
 
-            tv.bounds_computed = None;
-            tv.bounds_hint = TextBounds::GrowableFromTl(
-                Point::new(modal.margin, at_height + modal.margin * 2),
-                (modal.canvas_width - modal.margin * 2) as u16
-            );
-            write!(tv, "{}", t!("notification.dismiss", xous::LANG)).unwrap();
-            modal.gam.bounds_compute_textview(&mut tv).expect("couldn't simulate text size");
-            let textwidth = if let Some(bounds) = tv.bounds_computed {
-                bounds.br.x - bounds.tl.x
-            } else {
-                modal.canvas_width - modal.margin * 2
-            };
-            let offset = (modal.canvas_width - textwidth) / 2;
-            tv.bounds_computed = None;
-            tv.bounds_hint = TextBounds::BoundingBox(Rectangle::new(
-                Point::new(offset, at_height + modal.margin * 2),
-                Point::new(modal.canvas_width - modal.margin, at_height + modal.line_height + modal.margin * 2)
-            ));
-            modal.gam.post_textview(&mut tv).expect("couldn't post tv");
+            if self.qrwidth > 0 {
+                self.draw_qrcode(at_height, modal);
+            }
 
             // divider lines
             let color = if self.is_password {
@@ -81,11 +160,17 @@ impl ActionApi for Notification {
                 PixelColor::Dark
             };
 
-            modal.gam.draw_line(modal.canvas, Line::new_with_style(
-                Point::new(modal.margin, at_height + modal.margin),
-                Point::new(modal.canvas_width - modal.margin, at_height + modal.margin),
-                DrawStyle::new(color, color, 1))
-            ).expect("couldn't draw entry line");
+            modal
+                .gam
+                .draw_line(
+                    modal.canvas,
+                    Line::new_with_style(
+                        Point::new(modal.margin, at_height + modal.margin),
+                        Point::new(modal.canvas_width - modal.margin, at_height + modal.margin),
+                        DrawStyle::new(color, color, 1),
+                    ),
+                )
+                .expect("couldn't draw entry line");
         }
     }
     fn key_action(&mut self, k: char) -> (Option<ValidatorErr>, bool) {
@@ -96,8 +181,12 @@ impl ActionApi for Notification {
             }
             _ => {
                 if self.manual_dismiss {
-                    send_message(self.action_conn, xous::Message::new_scalar(self.action_opcode as usize, 0, 0, 0, 0)).expect("couldn't pass on dismissal");
-                    return(None, true)
+                    send_message(
+                        self.action_conn,
+                        xous::Message::new_scalar(self.action_opcode as usize, 0, 0, 0, 0),
+                    )
+                    .expect("couldn't pass on dismissal");
+                    return (None, true);
                 }
             }
         }

--- a/services/modals/src/api.rs
+++ b/services/modals/src/api.rs
@@ -36,6 +36,7 @@ pub struct ManagedPromptWithTextResponse {
 pub struct ManagedNotification {
     pub token: [u32; 4],
     pub message: xous_ipc::String::<1024>,
+    pub as_qrcode: bool,
 }
 #[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Copy, Clone)]
 pub struct ManagedProgress {

--- a/services/modals/src/lib.rs
+++ b/services/modals/src/lib.rs
@@ -92,6 +92,20 @@ impl Modals {
         let spec = ManagedNotification {
             token: self.token,
             message: xous_ipc::String::from_str(notification),
+            as_qrcode: false,
+        };
+        let buf = Buffer::into_buf(spec).or(Err(xous::Error::InternalError))?;
+        buf.lend(self.conn, Opcode::Notification.to_u32().unwrap()).or(Err(xous::Error::InternalError))?;
+        Ok(())
+    }
+
+    /// this blocks until the qrcode has been acknowledged.
+    pub fn show_qrcode(&self, text: &str) -> Result<(), xous::Error> {
+        self.lock();
+        let spec = ManagedNotification {
+            token: self.token,
+            message: xous_ipc::String::from_str(text),
+            as_qrcode: true,
         };
         let buf = Buffer::into_buf(spec).or(Err(xous::Error::InternalError))?;
         buf.lend(self.conn, Opcode::Notification.to_u32().unwrap()).or(Err(xous::Error::InternalError))?;

--- a/services/modals/src/main.rs
+++ b/services/modals/src/main.rs
@@ -100,15 +100,6 @@ fn xmain() -> ! {
                 validator: None,
             };
             let mut fixed_items = Vec::<ItemName>::new();
-            let notification = gam::modal::Notification::new(
-                renderer_cid,
-                RendererOp::NotificationReturn.to_u32().unwrap()
-            );
-            let mut gutter = gam::modal::Notification::new(
-                renderer_cid,
-                RendererOp::Gutter.to_u32().unwrap()
-            );
-            gutter.set_manual_dismiss(false);
             let mut progress_action = Slider::new(renderer_cid, RendererOp::Gutter.to_u32().unwrap(),
                 0, 100, 1, Some("%"), 0, true, true
             );
@@ -151,11 +142,19 @@ fn xmain() -> ! {
                                 log::debug!("should be active!");
                             },
                             RendererState::RunNotification(config) => {
+                                let mut notification = gam::modal::Notification::new(
+                                    renderer_cid,
+                                    RendererOp::NotificationReturn.to_u32().unwrap()
+                                );
+                                let text = config.message.as_str().unwrap();
+                                if config.as_qrcode {
+                                    notification.set_as_qrcode(Some(text));
+                                }
                                 #[cfg(feature="tts")]
                                 tts.tts_simple(config.message.as_str().unwrap()).unwrap();
                                 renderer_modal.modify(
                                     Some(ActionType::Notification(notification)),
-                                    Some(config.message.as_str().unwrap()), false,
+                                    Some(text), false,
                                     None, true, None
                                 );
                                 renderer_modal.activate();
@@ -230,8 +229,13 @@ fn xmain() -> ! {
                                     #[cfg(feature="tts")]
                                     tts.tts_simple(text.as_str().unwrap()).unwrap();
                                     bot_text.push_str(text.as_str().unwrap());
-                                }
-                                renderer_modal.modify(
+                                }                                                              
+                                let mut gutter = gam::modal::Notification::new(
+                                    renderer_cid,
+                                    RendererOp::Gutter.to_u32().unwrap()
+                                );
+                                gutter.set_manual_dismiss(false);
+                                renderer_modal.modify(  
                                     Some(ActionType::Notification(gutter)),
                                     Some(&top_text), config.title.is_none(),
                                     Some(&bot_text), config.text.is_none(),

--- a/services/modals/src/tests.rs
+++ b/services/modals/src/tests.rs
@@ -95,6 +95,11 @@ pub(crate) fn spawn_test() {
             log::info!("testing notification");
             modals.show_notification("这是一个测验!").expect("notification failed");
             log::info!("notification test done");
+
+            // 4. test qrcode
+            log::info!("testing qrcode");
+            modals.show_qrcode("https://github.com/betrusted-io/xous-core").expect("qrcode failed");
+            log::info!("qrcode test done");
         }
     });
 }


### PR DESCRIPTION
I think a qrcode will be critical for blockchain apps and handy for many others to hand off urls or small text snippets to other devices

note there is a breaking change with an additional parameter in show_notification()
```
pub fn show_notification(&self, notification: &str, as_qrcode: bool) -> Result<(), xous::Error> { ... }

```