### PR TITLE
Update minifb to 0.23.0

### DIFF
--- a/services/graphics-server/Cargo.toml
+++ b/services/graphics-server/Cargo.toml
@@ -25,7 +25,7 @@ rkyv = {version = "0.4.3", default-features = false, features = ["const_generics
 utralib = {path = "../../utralib"}
 
 [target.'cfg(any(windows,unix))'.dependencies]
-minifb = "0.22.0"
+minifb = "0.23.0"
 
 [features]
 debugprint = []


### PR DESCRIPTION
Update minifb to 0.23, which fixes a serious wayland keyboard issue.
CHANGELOG: https://github.com/emoon/rust_minifb/blob/master/CHANGELOG.md#v023-2022-04-19