### PR TITLE
Fix jtag peripheral for emulation of xous-release

### DIFF
--- a/emulation/betrusted.resc
+++ b/emulation/betrusted.resc
@@ -25,7 +25,7 @@ i @peripherals/ComSoC.cs
 i @peripherals/ec_power.cs
 i @peripherals/EcWifi.cs
 i @peripherals/engine.cs
-i @peripherals/jtag.cs
+i @peripherals/Jtag.cs
 i @peripherals/keyboard.cs
 i @peripherals/keyrom.cs
 i @peripherals/LiteX_Timer_32.cs


### PR DESCRIPTION
Closes #146. Jtag.cs was misspelled in betrusted.resc

Signed-off-by: Daniel Reusche <code@degregat.net>