### PR TITLE
modal selected index support

### DIFF
--- a/services/modals/Cargo.toml
+++ b/services/modals/Cargo.toml
@@ -20,7 +20,7 @@ gam = {path="../gam"}
 trng = {path="../trng"}
 tts-frontend = {path="../tts"}
 locales = {path = "../../locales"}
-bit_field = "0.10.1"
+bit_field = "0.9.0"
 
 [target.'cfg(not(any(windows,unix)))'.dependencies]
 utralib = { path = "../../utralib"}

--- a/services/modals/Cargo.toml
+++ b/services/modals/Cargo.toml
@@ -20,6 +20,7 @@ gam = {path="../gam"}
 trng = {path="../trng"}
 tts-frontend = {path="../tts"}
 locales = {path = "../../locales"}
+bit_field = "0.10.1"
 
 [target.'cfg(not(any(windows,unix)))'.dependencies]
 utralib = { path = "../../utralib"}

--- a/services/modals/src/api.rs
+++ b/services/modals/src/api.rs
@@ -78,6 +78,8 @@ pub(crate) enum Opcode {
     /// add an item to the radio box or check box. Note that all added items
     /// are cleared after the relevant "action" call happens (PromptWith[Fixed,Multi]Response)
     AddModalItem,
+    /// get the index of the selected radio button / checkboxes
+    GetModalIndex,
     /// raise a progress bar
     StartProgress,
     /// update the progress bar

--- a/services/modals/src/lib.rs
+++ b/services/modals/src/lib.rs
@@ -140,8 +140,8 @@ impl Modals {
         self.unlock();
         Ok(())
     }
-     
-    pub fn add_list(&mut self, items: Vec<&str>) -> Result<(), xous::Error> {
+
+    pub fn add_list(&self, items: Vec<&str>) -> Result<(), xous::Error> {
         for (_, text) in items.iter().enumerate() {
             self.add_list_item(text)
                 .or(Err(xous::Error::InternalError))?;
@@ -172,16 +172,16 @@ impl Modals {
         self.unlock();
         Ok(String::from(itemname.as_str()))
     }
-    
+
     pub fn get_radio_index(&self) -> Result<usize, xous::Error> {
         let msg = Message::new_blocking_scalar(Opcode::GetModalIndex.to_usize().unwrap(), 0, 0, 0, 0);
         match send_message(self.conn, msg) {
             Ok(xous::Result::Scalar1(bitfield)) => {
                 let mut i = 0;
-                while (i < u32::BIT_LENGTH) & !bitfield.get_bit(i) {
+                while (i < u32::bit_length()) & !bitfield.get_bit(i) {
                     i = i + 1;
                 }
-                if i < u32::BIT_LENGTH {
+                if i < u32::bit_length() {
                     Ok(i)
                 } else {
                     Err(xous::Error::InternalError)
@@ -209,14 +209,14 @@ impl Modals {
         self.unlock();
         Ok(ret)
     }
-    
+
     pub fn get_check_index(&self) -> Result<Vec<usize>, xous::Error> {
         let mut ret = Vec::<usize>::new();
         let msg = Message::new_blocking_scalar(Opcode::GetModalIndex.to_usize().unwrap(), 0, 0, 0, 0);
         match send_message(self.conn, msg) {
             Ok(xous::Result::Scalar1(bitfield)) => {
                 let mut i = 0;
-                while i < u32::BIT_LENGTH {
+                while i < u32::bit_length() {
                     if bitfield.get_bit(i) {
                         ret.push(i);
                     }

--- a/services/modals/src/lib.rs
+++ b/services/modals/src/lib.rs
@@ -8,6 +8,7 @@ use xous::{CID, send_message, Message};
 use num_traits::*;
 use xous_ipc::Buffer;
 use core::cell::Cell;
+use bit_field::BitField;
 
 pub struct Modals {
     conn: CID,
@@ -139,6 +140,14 @@ impl Modals {
         self.unlock();
         Ok(())
     }
+     
+    pub fn add_list(&mut self, items: Vec<&str>) -> Result<(), xous::Error> {
+        for (_, text) in items.iter().enumerate() {
+            self.add_list_item(text)
+                .or(Err(xous::Error::InternalError))?;
+        }
+        Ok(())
+    }
 
     pub fn add_list_item(&self, item: &str) -> Result<(), xous::Error> {
         self.lock();
@@ -163,6 +172,24 @@ impl Modals {
         self.unlock();
         Ok(String::from(itemname.as_str()))
     }
+    
+    pub fn get_radio_index(&self) -> Result<usize, xous::Error> {
+        let msg = Message::new_blocking_scalar(Opcode::GetModalIndex.to_usize().unwrap(), 0, 0, 0, 0);
+        match send_message(self.conn, msg) {
+            Ok(xous::Result::Scalar1(bitfield)) => {
+                let mut i = 0;
+                while (i < u32::BIT_LENGTH) & !bitfield.get_bit(i) {
+                    i = i + 1;
+                }
+                if i < u32::BIT_LENGTH {
+                    Ok(i)
+                } else {
+                    Err(xous::Error::InternalError)
+                }
+            }
+            _ => Err(xous::Error::InternalError),
+        }
+    }
 
     pub fn get_checkbox(&self, prompt: &str) -> Result<Vec::<String>, xous::Error> {
         self.lock();
@@ -181,6 +208,24 @@ impl Modals {
         }
         self.unlock();
         Ok(ret)
+    }
+    
+    pub fn get_check_index(&self) -> Result<Vec<usize>, xous::Error> {
+        let mut ret = Vec::<usize>::new();
+        let msg = Message::new_blocking_scalar(Opcode::GetModalIndex.to_usize().unwrap(), 0, 0, 0, 0);
+        match send_message(self.conn, msg) {
+            Ok(xous::Result::Scalar1(bitfield)) => {
+                let mut i = 0;
+                while i < u32::BIT_LENGTH {
+                    if bitfield.get_bit(i) {
+                        ret.push(i);
+                    }
+                    i = i + 1;
+                }
+                Ok(ret)
+            }
+            _ => Err(xous::Error::InternalError),
+        }
     }
 
     pub fn dynamic_notification(&self, title: Option<&str>, text: Option<&str>) -> Result<(), xous::Error> {

--- a/services/modals/src/main.rs
+++ b/services/modals/src/main.rs
@@ -42,6 +42,8 @@ use locales::t;
 const TICK_INTERVAL: u64 = 2500;
 
 use num_traits::*;
+use bit_field::BitField;
+use std::collections::HashMap;
 
 #[derive(Debug)]
 enum RendererState {
@@ -111,6 +113,9 @@ fn xmain() -> ! {
         Opcode::ModalKeypress.to_u32().unwrap(),
         Opcode::ModalDrop.to_u32().unwrap(),
     );
+    
+    let mut list_hash = HashMap::<String, usize>::new();
+    let mut list_selected = 0u32;
 
     if cfg!(feature = "ux_tests") {
         tt.sleep_ms(1000).unwrap();
@@ -243,6 +248,9 @@ fn xmain() -> ! {
                     continue;
                 }
                 fixed_items.push(manageditem.item);
+            }                      
+            Some(Opcode::GetModalIndex) => {
+                xous::return_scalar(msg.sender, list_selected as usize).expect("couldn't return list selected");
             }
             Some(Opcode::DynamicNotification) => {
                 let spec = {
@@ -363,8 +371,11 @@ fn xmain() -> ! {
                             renderer_cid,
                             Opcode::RadioReturn.to_u32().unwrap()
                         );
+                        list_hash.clear();
+                        list_selected = 0u32;
                         for item in fixed_items.iter() {
                             radiobuttons.add_item(*item);
+                            list_hash.insert(item.as_str().to_string(), list_hash.len());
                         }
                         fixed_items.clear();
                         #[cfg(feature="tts")]
@@ -384,8 +395,11 @@ fn xmain() -> ! {
                             renderer_cid,
                             Opcode::CheckBoxReturn.to_u32().unwrap()
                         );
+                        list_hash.clear();
+                        list_selected = 0u32;
                         for item in fixed_items.iter() {
                             checkbox.add_item(*item);
+                            list_hash.insert(item.as_str().to_string(), list_hash.len());
                         }
                         fixed_items.clear();
                         #[cfg(feature="tts")]
@@ -532,6 +546,15 @@ fn xmain() -> ! {
                             let mut response = unsafe { Buffer::from_memory_message_mut(origin.body.memory_message_mut().unwrap()) };
                             response.replace(item).unwrap();
                             op = RendererState::None;
+                            match list_hash.get(item.as_str()){
+                                Some(index) => { 
+                                    match index {
+                                        0...31 => drop(list_selected.set_bit(*index, true)),
+                                        _ => log::warn!("invalid bitfield index"),
+                                    };
+                                },
+                                None => log::warn!("failed to set list_selected index"),
+                            }
                         } else {
                             log::error!("Ux routine returned but no origin was recorded");
                             panic!("Ux routine returned but no origin was recorded");
@@ -554,6 +577,22 @@ fn xmain() -> ! {
                             let mut response = unsafe { Buffer::from_memory_message_mut(origin.body.memory_message_mut().unwrap()) };
                             response.replace(item).unwrap();
                             op = RendererState::None;
+                            for (_, check_item) in item.payload().iter().enumerate() {
+                                match check_item {
+                                    Some(item) => {
+                                            match list_hash.get(item.as_str()){
+                                            Some(index) => {
+                                                match index {
+                                                    0...31 => drop(list_selected.set_bit(*index, true)),
+                                                    _ => log::warn!("invalid bitfield index"),
+                                                };
+                                            },
+                                            None => log::warn!("failed to set list_selected index"),
+                                        }
+                                    },
+                                    None => {},
+                                }
+                            }
                         } else {
                             log::error!("Ux routine returned but no origin was recorded");
                             panic!("Ux routine returned but no origin was recorded");

--- a/services/modals/src/main.rs
+++ b/services/modals/src/main.rs
@@ -113,7 +113,7 @@ fn xmain() -> ! {
         Opcode::ModalKeypress.to_u32().unwrap(),
         Opcode::ModalDrop.to_u32().unwrap(),
     );
-    
+
     let mut list_hash = HashMap::<String, usize>::new();
     let mut list_selected = 0u32;
 
@@ -248,7 +248,7 @@ fn xmain() -> ! {
                     continue;
                 }
                 fixed_items.push(manageditem.item);
-            }                      
+            }
             Some(Opcode::GetModalIndex) => {
                 xous::return_scalar(msg.sender, list_selected as usize).expect("couldn't return list selected");
             }

--- a/services/modals/src/tests.rs
+++ b/services/modals/src/tests.rs
@@ -31,7 +31,7 @@ pub(crate) fn spawn_test() {
     thread::spawn({
         move || {
             let xns = XousNames::new().unwrap();
-            let modals = modals::Modals::new(&xns).unwrap();
+            let mut modals = modals::Modals::new(&xns).unwrap();
             let tt = ticktimer_server::Ticktimer::new().unwrap();
 
             // 1. test progress bar
@@ -45,9 +45,8 @@ pub(crate) fn spawn_test() {
             modals.finish_progress().expect("couldn't dismiss progress bar");
 
             // 2. test check box
-            for item in CHECKBOX_TEST {
-                modals.add_list_item(item).expect("couldn't build checkbox list");
-            }
+            let items: Vec<&str> = CHECKBOX_TEST.iter().map(|s| s.to_owned()).collect();
+            modals.add_list(items).expect("couldn't build checkbox list");
             match modals.get_checkbox("You can have it all:") {
                 Ok(things) => {
                     log::info!("The user picked {} things:", things.len());
@@ -57,6 +56,7 @@ pub(crate) fn spawn_test() {
                 },
                 _ => log::error!("get_checkbox failed"),
             }
+            log::info!("Checkbox indices selected = {:?}", modals.get_check_index());
 
             // 3. test notificatons
             log::info!("testing notification");
@@ -78,6 +78,7 @@ pub(crate) fn spawn_test() {
                 Ok(animal) => log::info!("{} was picked", animal),
                 _ => log::error!("get_radiobutton failed"),
             }
+            log::info!("Radio index selected = {:?}", modals.get_radio_index().unwrap());
 
             // 2. test the modal dialog box function
             log::info!("test text input");

--- a/services/modals/src/tests.rs
+++ b/services/modals/src/tests.rs
@@ -31,7 +31,7 @@ pub(crate) fn spawn_test() {
     thread::spawn({
         move || {
             let xns = XousNames::new().unwrap();
-            let mut modals = modals::Modals::new(&xns).unwrap();
+            let modals = modals::Modals::new(&xns).unwrap();
             let tt = ticktimer_server::Ticktimer::new().unwrap();
 
             // 1. test progress bar


### PR DESCRIPTION
Support for:
- obtaining the index of the selected radiobutton & checkbox
- adding a Vec<&str> of items

These 2 capabilities will allow the developer to:

```
let choices = vec![t!("choice1", xous::LANG), t!("choice2", xous::LANG), t!("choice3", xous::LANG)];
modals.add_list(&choices);
let choice = modals.get_radiobutton(&self, "choose")
match modals.get_radio_index() {
    1 => {}
    2 => {}
    3 => {}
    _ => log::warn!("invalid index"),
}
```