### PR TITLE
enable notification modal text + qrcode

### DIFF
--- a/apps/ball/src/ball.rs
+++ b/apps/ball/src/ball.rs
@@ -161,7 +161,7 @@ impl Ball {
             keys[0],
             t!("ballapp.notification_b", xous::LANG),
         ).unwrap();
-        self.modals.show_notification(&note, false).unwrap();
+        self.modals.show_notification(&note, None).unwrap();
         self.modals.add_list_item(t!("ballapp.random", xous::LANG)).unwrap();
         self.modals.add_list_item(t!("ballapp.tilt", xous::LANG)).unwrap();
         let mode = self.modals.get_radiobutton(t!("ballapp.mode_prompt", xous::LANG)).unwrap();

--- a/services/gam/src/modal/notification.rs
+++ b/services/gam/src/modal/notification.rs
@@ -39,7 +39,7 @@ impl Notification {
     pub fn set_manual_dismiss(&mut self, setting: bool) {
         self.manual_dismiss = setting;
     }
-    pub fn set_as_qrcode(&mut self, setting: Option<&str>) {
+    pub fn set_qrcode(&mut self, setting: Option<&str>) {
         match setting {
             Some(setting) => {
                let qrcode = QrCode::new(setting).unwrap();

--- a/services/modals/src/api.rs
+++ b/services/modals/src/api.rs
@@ -37,7 +37,7 @@ pub struct ManagedPromptWithTextResponse {
 pub struct ManagedNotification {
     pub token: [u32; 4],
     pub message: xous_ipc::String::<1024>,
-    pub as_qrcode: bool,
+    pub qrtext: Option<xous_ipc::String::<1024>>,
 }
 #[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Copy, Clone)]
 pub struct ManagedProgress {

--- a/services/modals/src/lib.rs
+++ b/services/modals/src/lib.rs
@@ -140,12 +140,16 @@ impl Modals {
     }
 
     /// this blocks until the notification has been acknowledged.
-    pub fn show_notification(&self, notification: &str, as_qrcode: bool) -> Result<(), xous::Error> {
+    pub fn show_notification(&self, notification: &str, qrtext:Option<&str>) -> Result<(), xous::Error> {
         self.lock();
+        let qrtext = match qrtext {
+            Some(text) => Some(xous_ipc::String::from_str(text)),
+            None => None,
+        };
         let spec = ManagedNotification {
             token: self.token,
             message: xous_ipc::String::from_str(notification),
-            as_qrcode,
+            qrtext: qrtext,
         };
         let buf = Buffer::into_buf(spec).or(Err(xous::Error::InternalError))?;
         buf.lend(self.conn, Opcode::Notification.to_u32().unwrap()).or(Err(xous::Error::InternalError))?;

--- a/services/modals/src/main.rs
+++ b/services/modals/src/main.rs
@@ -331,9 +331,15 @@ fn xmain() -> ! {
                             Opcode::NotificationReturn.to_u32().unwrap()
                         );
                         let text = config.message.as_str().unwrap();
-                        if config.as_qrcode {
-                            notification.set_as_qrcode(Some(text));
-                        }
+                        let tmp: String;
+                        let qrtext = match config.qrtext {
+                            Some(text) => {
+                                tmp = text.to_string();
+                                Some(tmp.as_str())
+                            },
+                            None => None,
+                        };
+                        notification.set_qrcode(qrtext);
                         #[cfg(feature="tts")]
                         tts.tts_simple(config.message.as_str().unwrap()).unwrap();
                         renderer_modal.modify(

--- a/services/modals/src/tests.rs
+++ b/services/modals/src/tests.rs
@@ -70,7 +70,7 @@ pub(crate) fn spawn_test() {
 
             // 3. test notificatons
             log::info!("testing notification");
-            modals.show_notification("This is a test!", false).expect("notification failed");
+            modals.show_notification("This is a test!", None).expect("notification failed");
             log::info!("notification test done");
         }
     });
@@ -106,12 +106,12 @@ pub(crate) fn spawn_test() {
 
             // 3. test notificatons
             log::info!("testing notification");
-            modals.show_notification("这是一个测验!", true).expect("notification failed");
+            modals.show_notification("这是一个测验!", Some("这是一个测验!")).expect("notification failed");
             log::info!("notification test done");
 
             // 4. test qrcode
             log::info!("testing qrcode");
-            modals.show_notification("https://github.com/betrusted-io/xous-core", true).expect("qrcode failed");
+            modals.show_notification("Please contribute to xous-core", Some("https://github.com/betrusted-io/xous-core")).expect("qrcode failed");
             log::info!("qrcode test done");
         }
     });

--- a/services/pddb/src/backend/hw.rs
+++ b/services/pddb/src/backend/hw.rs
@@ -600,7 +600,7 @@ impl PddbOs {
             self.clear_password(); // clear the bad password entry
             let xns = xous_names::XousNames::new().unwrap();
             let modals = modals::Modals::new(&xns).expect("can't connect to Modals server");
-            modals.show_notification(t!("pddb.badpass_infallible", xous::LANG), false).expect("notification failed");
+            modals.show_notification(t!("pddb.badpass_infallible", xous::LANG), None).expect("notification failed");
         }
     }
 
@@ -1450,7 +1450,7 @@ impl PddbOs {
                 self.rootkeys.decrypt_block(GenericArray::from_mut_slice(&mut checkblock_a));
 
                 #[cfg(any(target_os = "none", target_os = "xous"))] // skip this dialog in hosted mode
-                modals.show_notification(t!("pddb.checkpass", xous::LANG), false).expect("notification failed");
+                modals.show_notification(t!("pddb.checkpass", xous::LANG), None).expect("notification failed");
 
                 self.clear_password();
                 let mut checkblock_b = [0u8; BLOCK_SIZE];
@@ -1459,7 +1459,7 @@ impl PddbOs {
                 if checkblock_a == checkblock_b {
                     success = true;
                 } else {
-                    modals.show_notification(t!("pddb.checkpass_fail", xous::LANG), false).expect("notification failed");
+                    modals.show_notification(t!("pddb.checkpass_fail", xous::LANG), None).expect("notification failed");
                     self.clear_password();
                 }
             }

--- a/services/pddb/src/main.rs
+++ b/services/pddb/src/main.rs
@@ -1132,7 +1132,7 @@ fn xmain() -> ! {
                 for basis in bases.iter() {
                     note.push_str(basis);
                 }
-                modals.show_notification(&note, false).expect("couldn't show basis list");
+                modals.show_notification(&note, None).expect("couldn't show basis list");
             },
             #[cfg(not(any(target_os = "none", target_os = "xous")))]
             Some(Opcode::DangerousDebug) => {
@@ -1293,7 +1293,7 @@ fn try_mount_or_format(modals: &modals::Modals, pddb_os: &mut PddbOs, basis_cach
                     log::error!("Despite formatting, no PDDB was found!");
                     let mut err = String::from(t!("pddb.internalerror", xous::LANG));
                     err.push_str(" #1"); // punt and leave an error code, because this "should" be rare
-                    modals.show_notification(err.as_str(), false).expect("notification failed");
+                    modals.show_notification(err.as_str(), None).expect("notification failed");
                     false
                 }
             } else {
@@ -1318,7 +1318,7 @@ fn try_mount_or_format(modals: &modals::Modals, pddb_os: &mut PddbOs, basis_cach
                 log::error!("Despite formatting, no PDDB was found!");
                 let mut err = String::from(t!("pddb.internalerror", xous::LANG));
                 err.push_str(" #1"); // punt and leave an error code, because this "should" be rare
-                modals.show_notification(err.as_str(), false).expect("notification failed");
+                modals.show_notification(err.as_str(), None).expect("notification failed");
                 false
             }
         }

--- a/services/root-keys/src/main.rs
+++ b/services/root-keys/src/main.rs
@@ -465,7 +465,7 @@ fn xmain() -> ! {
                     // - pepper
 
                     if keys.is_initialized() {
-                        modals.show_notification(t!("rootkeys.already_init", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.already_init", xous::LANG), None).expect("modals error");
                         #[cfg(feature="tts")]
                         tts.tts_blocking(t!("rootkeys.already_init", xous::LANG)).unwrap();
                         keys.set_ux_password_type(None);
@@ -554,16 +554,16 @@ fn xmain() -> ! {
                         ).expect("couldn't initiate dialog box");
                     }
                     Err(RootkeyResult::AlignmentError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_alignment", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_alignment", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::KeyError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_key", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_key", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::IntegrityError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_verify", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_verify", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::FlashError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_burn", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_burn", xous::LANG), None).expect("modals error");
                     }
                 }
             },
@@ -578,7 +578,7 @@ fn xmain() -> ! {
                 log::info!("Vbus is: {:.3}V", vbus);
                 if vbus > 1.5 {
                     // if power is plugged in, request that it be removed
-                    modals.show_notification(t!("rootkeys.init.unplug_power", xous::LANG), false).expect("modals error");
+                    modals.show_notification(t!("rootkeys.init.unplug_power", xous::LANG), None).expect("modals error");
                     log::info!("vbus is high, holding off on reboot");
                     send_message(main_cid,
                         xous::Message::new_scalar(Opcode::UxTryReboot.to_usize().unwrap(), 0, 0, 0, 0)
@@ -631,7 +631,7 @@ fn xmain() -> ! {
                     SignatureResult::DevKeyOk => t!("rootkeys.gwup.viewinfo_dk", xous::LANG),
                     _ => {
                         modals.dynamic_notification_close().expect("modals error");
-                        modals.show_notification(t!("rootkeys.gwup.no_update_found", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.gwup.no_update_found", xous::LANG), None).expect("modals error");
                         continue;
                     }
                 };
@@ -661,18 +661,18 @@ fn xmain() -> ! {
                 match modals.get_radiobutton(prompt) {
                     Ok(response) => {
                         if response == t!("rootkeys.gwup.short", xous::LANG) {
-                            modals.show_notification(info.as_str(), false).expect("modals error");
+                            modals.show_notification(info.as_str(), None).expect("modals error");
                         } else if response == t!("rootkeys.gwup.details", xous::LANG) {
-                            modals.show_notification(info.as_str(), false).expect("modals error");
+                            modals.show_notification(info.as_str(), None).expect("modals error");
                             let gw_info = keys.fetch_gw_metadata(GatewareRegion::Staging);
                             // truncate the message to better fit in the rendering box
                             let info_len = if gw_info.log_len > 256 { 256 } else {gw_info.log_len};
                             let info = format!("{}", str::from_utf8(&gw_info.log_str[..info_len as usize]).unwrap());
-                            modals.show_notification(info.as_str(), false).expect("modals error");
+                            modals.show_notification(info.as_str(), None).expect("modals error");
                             // truncate the message to better fit in the rendering box
                             let status_len = if gw_info.status_len > 256 { 256 } else {gw_info.status_len};
                             let info = format!("{}", str::from_utf8(&gw_info.status_str[..status_len as usize]).unwrap());
-                            modals.show_notification(info.as_str(), false).expect("modals error");
+                            modals.show_notification(info.as_str(), None).expect("modals error");
                         } else {
                             skip_confirmation = true;
                         }
@@ -762,21 +762,21 @@ fn xmain() -> ! {
 
                 match result {
                     Ok(_) => {
-                        modals.show_notification(t!("rootkeys.gwup.finished", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.gwup.finished", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::AlignmentError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_alignment", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_alignment", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::KeyError) => {
                         // probably a bad password, purge it, so the user can try again
                         keys.purge_password(PasswordType::Update);
-                        modals.show_notification(t!("rootkeys.init.fail_key", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_key", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::IntegrityError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_verify", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_verify", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::FlashError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_burn", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_burn", xous::LANG), None).expect("modals error");
                     }
                 }
             }
@@ -836,21 +836,21 @@ fn xmain() -> ! {
 
                 match result {
                     Ok(_) => {
-                        modals.show_notification(t!("rootkeys.signxous.finished", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.signxous.finished", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::AlignmentError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_alignment", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_alignment", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::KeyError) => {
                         // probably a bad password, purge it, so the user can try again
                         keys.purge_password(PasswordType::Update);
-                        modals.show_notification(t!("rootkeys.init.fail_key", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_key", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::IntegrityError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_verify", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_verify", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::FlashError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_burn", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_burn", xous::LANG), None).expect("modals error");
                     }
                 }
             }
@@ -887,7 +887,7 @@ fn xmain() -> ! {
                     // more keys with more passwords, this policy may need to become markedly more complicated!
 
                     // otherwise, an invalid password request
-                    modals.show_notification(t!("rootkeys.bad_password_request", xous::LANG), false).expect("modals error");
+                    modals.show_notification(t!("rootkeys.bad_password_request", xous::LANG), None).expect("modals error");
 
                     xous::return_scalar(msg.sender, 0).unwrap();
                 }
@@ -979,7 +979,7 @@ fn xmain() -> ! {
             }
 
             Some(Opcode::BbramProvision) => {
-                modals.show_notification(t!("rootkeys.bbram.confirm", xous::LANG), false).expect("modals error");
+                modals.show_notification(t!("rootkeys.bbram.confirm", xous::LANG), None).expect("modals error");
                 let console_input = gam::modal::ConsoleInput::new(
                     main_cid,
                     Opcode::UxBbramCheckReturn.to_u32().unwrap()
@@ -1017,7 +1017,7 @@ fn xmain() -> ! {
                         rootkeys_modal.activate();
                     }
                 } else {
-                    modals.show_notification(t!("rootkeys.bbram.no_helper", xous::LANG), false).expect("modals error");
+                    modals.show_notification(t!("rootkeys.bbram.no_helper", xous::LANG), None).expect("modals error");
                     continue;
                 }
             }
@@ -1040,21 +1040,21 @@ fn xmain() -> ! {
 
                 match result {
                     Ok(_) => {
-                        modals.show_notification(t!("rootkeys.bbram.finished", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.bbram.finished", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::AlignmentError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_alignment", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_alignment", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::KeyError) => {
                         // probably a bad password, purge it, so the user can try again
                         keys.purge_password(PasswordType::Update);
-                        modals.show_notification(t!("rootkeys.init.fail_key", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_key", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::IntegrityError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_verify", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_verify", xous::LANG), None).expect("modals error");
                     }
                     Err(RootkeyResult::FlashError) => {
-                        modals.show_notification(t!("rootkeys.init.fail_burn", xous::LANG), false).expect("modals error");
+                        modals.show_notification(t!("rootkeys.init.fail_burn", xous::LANG), None).expect("modals error");
                     }
                 }
             }

--- a/services/status/src/main.rs
+++ b/services/status/src/main.rs
@@ -639,14 +639,14 @@ fn xmain() -> ! {
             }),
             Some(StatusOpcode::TrySuspend) => {
                 if ((llio.adc_vbus().unwrap() as f64) * 0.005033) > 1.5 {
-                    modals.show_notification(t!("mainmenu.cant_sleep", xous::LANG), false).expect("couldn't notify that power is plugged in");
+                    modals.show_notification(t!("mainmenu.cant_sleep", xous::LANG), None).expect("couldn't notify that power is plugged in");
                 } else {
                     susres.initiate_suspend().expect("couldn't initiate suspend op");
                 }
             },
             Some(StatusOpcode::BatteryDisconnect) => {
                 if ((llio.adc_vbus().unwrap() as f64) * 0.005033) > 1.5 {
-                    modals.show_notification(t!("mainmenu.cant_sleep", xous::LANG), false).expect("couldn't notify that power is plugged in");
+                    modals.show_notification(t!("mainmenu.cant_sleep", xous::LANG), None).expect("couldn't notify that power is plugged in");
                 } else {
                     gam.shipmode_blank_request().ok();
                     ticktimer.sleep_ms(500).unwrap();

--- a/services/status/src/time.rs
+++ b/services/status/src/time.rs
@@ -493,7 +493,7 @@ pub fn start_time_ux(sid: xous::SID) {
                 match FromPrimitive::from_usize(msg.body.id()) {
                     Some(TimeUxOp::SetTime) => xous::msg_scalar_unpack!(msg, _, _, _, _, {
                         if !pddb_poller.is_mounted_nonblocking() {
-                            modals.show_notification(t!("stats.please_mount", xous::LANG), false).expect("couldn't show notification");
+                            modals.show_notification(t!("stats.please_mount", xous::LANG), None).expect("couldn't show notification");
                             continue;
                         }
                         let mut tz_set_handle = pddb::Pddb::new();
@@ -575,7 +575,7 @@ pub fn start_time_ux(sid: xous::SID) {
                                 }
                                 Err(err) => {
                                     log::info!("Err: {:?}", err);
-                                    modals.show_notification(t!("rtc.ntp_fail", xous::LANG), false).expect("couldn't show NTP error");
+                                    modals.show_notification(t!("rtc.ntp_fail", xous::LANG), None).expect("couldn't show NTP error");
                                 },
                             }
                         }
@@ -624,7 +624,7 @@ pub fn start_time_ux(sid: xous::SID) {
                     }),
                     Some(TimeUxOp::SetTimeZone) => xous::msg_scalar_unpack!(msg, _, _, _, _, {
                         if !pddb_poller.is_mounted_nonblocking() {
-                            modals.show_notification(t!("stats.please_mount", xous::LANG), false).expect("couldn't show notification");
+                            modals.show_notification(t!("stats.please_mount", xous::LANG), None).expect("couldn't show notification");
                             continue;
                         }
 


### PR DESCRIPTION
change the notification modal to accept the primary message and an
Option of independent text to display as a qrcode

pub fn show_notification(&self, notification: &str, qrtext:Option<&str>) -> Result<(), xous::Error> {}