### PR TITLE
don't block if the queue isn't empty

### DIFF
--- a/services/keyboard/src/main.rs
+++ b/services/keyboard/src/main.rs
@@ -791,6 +791,17 @@ fn main() -> ! {
                 else { vibe = false }
             }),
             Some(Opcode::BlockingKeyListener) => {
+                if blocking_queue.len() != 0 {
+                    // we have a pending byte in the queue, return it
+                    let k_prime = blocking_queue.pop_front().unwrap();
+                    xous::return_scalar2(msg.sender, k_prime, 0).unwrap();
+                } else {
+                    // by simply storing the sender address and not returning a value,
+                    // the sender will remain blocked until the return value is generated
+                    blocking_listener.push(msg.sender);
+                }
+            },
+            Some(Opcode::BlockingKeyListener) => {
                 // by simply storing the sender address and not returning a value,
                 // the sender will remain blocked until the return value is generated
                 blocking_listener.push(msg.sender);


### PR DESCRIPTION
Don't block BlockingKeyListener if there are pending bytes in the `blocking_queue`. Instead, dequeue the oldest byte and return it immediately.