### PR TITLE
`cargo xtask run` tries to execute non-existing binary.

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "llio",
         "susres",
         "codec",
-        "sha2:0.9.8",
+        "sha2",
         "engine-25519",
         "spinor",
         "root-keys",


### PR DESCRIPTION
When `cargo xtask` is run, one of the arguments passed to the `kernel` is `sha2:0.9.8`, which is not something produced during the build:

```rust
[ana@architect xous-core]$ cargo xtask run --release
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/xtask run --release`
No apps specified, adding default apps...
Building gam status shellchat ime-frontend ime-plugin-shell graphics-server ticktimer-server log-server com xous-names keyboard trng llio susres codec sha2:0.9.8 engine-25519 spinor root-keys jtag net dns pddb modals usb-device-xous ball repl
    Command: cargo build --features pddbtest --package gam --package status --package shellchat --package ime-frontend --package ime-plugin-shell --package graphics-server --package ticktimer-server --package log-server --package com --package xous-names --package keyboard --package trng --package llio --package susres --package codec --package sha2:0.9.8 --package engine-25519 --package spinor --package root-keys --package jtag --package net --package dns --package pddb --package modals --package usb-device-xous --package ball --package repl --release
   Compiling ticktimer-server v0.1.0 (/home/ana/git/betrusted-io/xous-core/services/ticktimer-server)
    Finished release [optimized] target(s) in 6.20s
Building and running kernel...
    Command: cargo run --release -- ../target/release/gam ../target/release/status ../target/release/shellchat ../target/release/ime-frontend ../target/release/ime-plugin-shell ../target/release/graphics-server ../target/release/ticktimer-server ../target/release/log-server ../target/release/com ../target/release/xous-names ../target/release/keyboard ../target/release/trng ../target/release/llio ../target/release/susres ../target/release/codec ../target/release/sha2:0.9.8 ../target/release/engine-25519 ../target/release/spinor ../target/release/root-keys ../target/release/jtag ../target/release/net ../target/release/dns ../target/release/pddb ../target/release/modals ../target/release/usb-device-xous ../target/release/ball ../target/release/repl
    Finished release [optimized] target(s) in 0.09s
     Running `/home/ana/git/betrusted-io/xous-core/target/release/kernel ../target/release/gam ../target/release/status ../target/release/shellchat ../target/release/ime-frontend ../target/release/ime-plugin-shell ../target/release/graphics-server ../target/release/ticktimer-server ../target/release/log-server ../target/release/com ../target/release/xous-names ../target/release/keyboard ../target/release/trng ../target/release/llio ../target/release/susres ../target/release/codec '../target/release/sha2:0.9.8' ../target/release/engine-25519 ../target/release/spinor ../target/release/root-keys ../target/release/jtag ../target/release/net ../target/release/dns ../target/release/pddb ../target/release/modals ../target/release/usb-device-xous ../target/release/ball ../target/release/repl`
KERNEL: Xous server listening on 127.0.0.1:39597
KERNEL: Starting initial processes:
  PID  |  Command
-------+------------------
 2 |  ../target/release/gam
 3 |  ../target/release/status
 4 |  ../target/release/shellchat
 5 |  ../target/release/ime-frontend
 6 |  ../target/release/ime-plugin-shell
 7 |  ../target/release/graphics-server
 8 |  ../target/release/ticktimer-server
 9 |  ../target/release/log-server
 10 |  ../target/release/com
 11 |  ../target/release/xous-names
 12 |  ../target/release/keyboard
 13 |  ../target/release/trng
 14 |  ../target/release/llio
 15 |  ../target/release/susres
 16 |  ../target/release/codec
 17 |  ../target/release/sha2:0.9.8
 18 |  ../target/release/engine-25519
 19 |  ../target/release/spinor
 20 |  ../target/release/root-keys
 21 |  ../target/release/jtag
 22 |  ../target/release/net
 23 |  ../target/release/dns
 24 |  ../target/release/pddb
 25 |  ../target/release/modals
 26 |  ../target/release/usb-device-xous
 27 |  ../target/release/ball
 28 |  ../target/release/repl
sh: line 1: ../target/release/sha2:0.9.8: No such file or directory
LOG: my PID is 9
LOG: Creating the reader thread
LOG: Running the output
```

It occurs I presume due to this line:

https://github.com/betrusted-io/xous-core/blob/01fbc1e8b75959a1dc14cd18422da1a0b8cd28a6/xtask/src/main.rs#L65

This appears to fix the issue.

Post patch:

```rust
[ana@architect xous-core]$ cargo xtask run --release
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/xtask run --release`
No apps specified, adding default apps...
Building gam status shellchat ime-frontend ime-plugin-shell graphics-server ticktimer-server log-server com xous-names keyboard trng llio susres codec sha2 engine-25519 spinor root-keys jtag net dns pddb modals usb-device-xous ball repl
    Command: cargo build --features pddbtest --package gam --package status --package shellchat --package ime-frontend --package ime-plugin-shell --package graphics-server --package ticktimer-server --package log-server --package com --package xous-names --package keyboard --package trng --package llio --package susres --package codec --package sha2 --package engine-25519 --package spinor --package root-keys --package jtag --package net --package dns --package pddb --package modals --package usb-device-xous --package ball --package repl --release
   Compiling ticktimer-server v0.1.0 (/home/ana/git/betrusted-io/xous-core/services/ticktimer-server)
    Finished release [optimized] target(s) in 6.17s
Building and running kernel...
    Command: cargo run --release -- ../target/release/gam ../target/release/status ../target/release/shellchat ../target/release/ime-frontend ../target/release/ime-plugin-shell ../target/release/graphics-server ../target/release/ticktimer-server ../target/release/log-server ../target/release/com ../target/release/xous-names ../target/release/keyboard ../target/release/trng ../target/release/llio ../target/release/susres ../target/release/codec ../target/release/sha2 ../target/release/engine-25519 ../target/release/spinor ../target/release/root-keys ../target/release/jtag ../target/release/net ../target/release/dns ../target/release/pddb ../target/release/modals ../target/release/usb-device-xous ../target/release/ball ../target/release/repl
    Finished release [optimized] target(s) in 0.09s
     Running `/home/ana/git/betrusted-io/xous-core/target/release/kernel ../target/release/gam ../target/release/status ../target/release/shellchat ../target/release/ime-frontend ../target/release/ime-plugin-shell ../target/release/graphics-server ../target/release/ticktimer-server ../target/release/log-server ../target/release/com ../target/release/xous-names ../target/release/keyboard ../target/release/trng ../target/release/llio ../target/release/susres ../target/release/codec ../target/release/sha2 ../target/release/engine-25519 ../target/release/spinor ../target/release/root-keys ../target/release/jtag ../target/release/net ../target/release/dns ../target/release/pddb ../target/release/modals ../target/release/usb-device-xous ../target/release/ball ../target/release/repl`
KERNEL: Xous server listening on 127.0.0.1:35551
KERNEL: Starting initial processes:
  PID  |  Command
-------+------------------
 2 |  ../target/release/gam
 3 |  ../target/release/status
 4 |  ../target/release/shellchat
 5 |  ../target/release/ime-frontend
 6 |  ../target/release/ime-plugin-shell
 7 |  ../target/release/graphics-server
 8 |  ../target/release/ticktimer-server
 9 |  ../target/release/log-server
 10 |  ../target/release/com
 11 |  ../target/release/xous-names
 12 |  ../target/release/keyboard
 13 |  ../target/release/trng
 14 |  ../target/release/llio
 15 |  ../target/release/susres
 16 |  ../target/release/codec
 17 |  ../target/release/sha2
 18 |  ../target/release/engine-25519
 19 |  ../target/release/spinor
 20 |  ../target/release/root-keys
 21 |  ../target/release/jtag
 22 |  ../target/release/net
 23 |  ../target/release/dns
 24 |  ../target/release/pddb
 25 |  ../target/release/modals
 26 |  ../target/release/usb-device-xous
 27 |  ../target/release/ball
 28 |  ../target/release/repl
LOG: my PID is 9
LOG: Creating the reader thread
LOG: Running the output
LOG: Xous Logging Server starting up...
LOG: Server listening on address SID([1937076088, 1735355437, 1919251245, 544367990])
```
