### PR TITLE
Image processing as Adaptor Iterators

### DIFF
--- a/services/gam/src/bitmap.rs
+++ b/services/gam/src/bitmap.rs
@@ -57,6 +57,56 @@ impl Bitmap {
         }
     }
 
+    pub fn new_resize(image: &Img, width: usize) -> Self {
+        let (img_width, _, _) = image.size();
+        let pixels = image.iter().shrink(img_width, width).collect();
+        let image = Img::new(pixels, width, PixelType::U8);
+        let (img_width, img_height, _) = image.size();
+
+        let bm_bottom = img_height - 1;
+        let bm_right = img_width - 1;
+        let bm_br = Point::new(bm_right as i16, bm_bottom as i16);
+        let bound = Rectangle::new(Point::new(0, 0), bm_br);
+
+        let (tile_size, tile_width_words) = Bitmap::tile_spec(bm_br);
+        let tile_height: usize = tile_size.y.try_into().unwrap();
+        let tile_count = match img_height % tile_height {
+            0 => img_height / tile_height,
+            _ => img_height / tile_height + 1,
+        };
+        let mut mosaic: Vec<Tile> = Vec::new();
+
+        let words = Dither::new(BURKES.to_vec()).dither(&image);
+        let mut wd_index = 0;
+        let bits_per_word: i16 = BITS_PER_WORD.try_into().unwrap();
+        for t in 0..tile_count {
+            let t_top = t * tile_height;
+            let t_left = 0;
+            let t_bottom = min(bm_bottom, (t + 1) * tile_height - 1);
+            let t_right = tile_size.x - 1;
+            let t_tl = Point::new(t_left, t_top.try_into().unwrap());
+            let t_br = Point::new(t_right, t_bottom.try_into().unwrap());
+            let t_bound = Rectangle::new(t_tl, t_br);
+            let mut tile = Tile::new(t_bound, tile_width_words.try_into().unwrap());
+            for y in t_top..=t_bottom {
+                let mut x = t_left;
+                while x <= t_right {
+                    let word = words[wd_index];
+                    wd_index += 1;
+                    let anchor = Point::new(x.try_into().unwrap(), y.try_into().unwrap());
+                    tile.set_word(anchor, word.try_into().unwrap());
+                    x += bits_per_word;
+                }
+            }
+            mosaic.push(tile);
+        }
+        Self {
+            bound,
+            tile_size,
+            mosaic,
+        }
+    }
+
     fn tile_spec(bm_size: Point) -> (Point, i16) {
         let bm_width_bits = 1 + bm_size.x as usize;
         let mut tile_width_bits = bm_width_bits;
@@ -237,51 +287,12 @@ impl From<[Option<Tile>; 6]> for Bitmap {
 
 impl From<&Img> for Bitmap {
     fn from(image: &Img) -> Self {
-        let (bm_width, bm_height, _) = image.size();
-        let bm_bottom = bm_height - 1;
-        let bm_right = bm_width - 1;
-        let bm_br = Point::new(bm_right as i16, bm_bottom as i16);
-        let bound = Rectangle::new(Point::new(0, 0), bm_br);
-
-        let (tile_size, tile_width_words) = Bitmap::tile_spec(bm_br);
-        let tile_height: usize = tile_size.y.try_into().unwrap();
-        let tile_count = match bm_height % tile_height {
-            0 => bm_height / tile_height,
-            _ => bm_height / tile_height + 1,
-        };
-        let mut mosaic: Vec<Tile> = Vec::new();
-
-        let words = Dither::new(BURKES.to_vec()).dither(&image);
-        let mut wd_index = 0;
-        let bits_per_word: i16 = BITS_PER_WORD.try_into().unwrap();
-        for t in 0..tile_count {
-            let t_top = t * tile_height;
-            let t_left = 0;
-            let t_bottom = min(bm_bottom, (t + 1) * tile_height - 1);
-            let t_right = tile_size.x - 1;
-            let t_tl = Point::new(t_left, t_top.try_into().unwrap());
-            let t_br = Point::new(t_right, t_bottom.try_into().unwrap());
-            let t_bound = Rectangle::new(t_tl, t_br);
-            let mut tile = Tile::new(t_bound, tile_width_words.try_into().unwrap());
-            for y in t_top..=t_bottom {
-                let mut x = t_left;
-                while x <= t_right {
-                    let word = words[wd_index];
-                    wd_index += 1;
-                    let anchor = Point::new(x.try_into().unwrap(), y.try_into().unwrap());
-                    tile.set_word(anchor, word.try_into().unwrap());
-                    x += bits_per_word;
-                }
-            }
-            mosaic.push(tile);
-        }
-        Self {
-            bound,
-            tile_size,
-            mosaic,
-        }
+        let (img_width, _, _) = image.size();
+        Bitmap::new_resize(image, img_width)
     }
 }
+
+// **********************************************************************
 
 pub enum PixelType {
     U8,
@@ -310,12 +321,10 @@ impl<'a, I: Iterator<Item = &'a u8>> Iterator for GreyScale<I> {
         const B: u32 = 722;
         const BLACK: u32 = R + G + B;
         match self.px_type {
-            PixelType::U8 => {
-                match self.iter.next() {
-                    Some(gr) => Some(*gr),
-                    None => None,
-                }
-            }
+            PixelType::U8 => match self.iter.next() {
+                Some(gr) => Some(*gr),
+                None => None,
+            },
             PixelType::U8x3 => {
                 let r = self.iter.next();
                 let g = self.iter.next();
@@ -347,6 +356,139 @@ pub trait GreyScaleIterator<'a>: Iterator<Item = &'a u8> + Sized {
 
 impl<'a, I: Iterator<Item = &'a u8>> GreyScaleIterator<'a> for I {}
 
+// **********************************************************************
+
+pub struct Shrink<I> {
+    /// iterator over inbound pixels
+    iter: I,
+    /// width of the outbound image
+    out_width: usize,
+    /// the scale factor between inbound and outbound images (ie in_width/out_width)
+    scale: f32,
+    /// a pre-tabulated list of the trailing edge of each inbound strip of pixels
+    in_x_cap: Vec<u16>,
+    /// the current y coord of the inbound image
+    in_y: usize,
+    /// the current x coord of the outbound image
+    out_x: usize,
+    /// the current y coord of the outbound image    
+    out_y: usize,
+    /// a buffer the width of the outbound image to stove horizontal averages
+    buf: Vec<u16>,
+    /// the width of the current stri in the inbound image
+    y_div: u16,
+    /// the x coord of the final pixel in the inbound image
+    out_x_last: usize,
+}
+
+impl<'a, I: Iterator<Item = &'a u8>> Shrink<I> {
+    fn new(iter: I, in_width: usize, out_width: usize) -> Shrink<I> {
+        let scale = in_width as f32 / out_width as f32;
+        // set up a buffer to average the surrounding pixels
+        let buf: Vec<u16> = if scale <= 1.0 {
+            Vec::new()
+        } else {
+            vec![0u16; out_width]
+        };
+
+        // Pretabulate horizontal pixel positions
+        let mut in_x_cap: Vec<u16> = Vec::with_capacity(out_width);
+        let max_width: u16 = (in_width - 1).try_into().unwrap();
+        for out_x in 1..=out_width {
+            let in_x: u16 = (scale * out_x as f32) as u16;
+            in_x_cap.push((in_x).min(max_width));
+        }
+        let out_x_last = out_width;
+
+        Self {
+            iter,
+            out_width,
+            scale,
+            in_x_cap,
+            in_y: 0,
+            out_x: 0,
+            out_y: 1,
+            buf,
+            y_div: 0,
+            out_x_last,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn next_xy(&self) -> (usize, usize) {
+        (self.out_x, self.out_y)
+    }
+}
+/// Adaptor Iterator to shrink an image dimensions from in_width to out_width
+impl<'a, I: Iterator<Item = &'a u8>> Iterator for Shrink<I> {
+    type Item = u8;
+
+    /// Shrinks an image from in_width to out_width
+    /// The algorithm divides the inbound image into vertical and horivontal strips,
+    /// correspoding to the columns and rows of the outbound image. Each outbound
+    /// pixel is the average of the pixels contained within each intersaction of
+    /// vertical and horizontal strips. For example, when in_width = 3 x out_width
+    /// each outbound pixel will be the average of 9 pixels in a 3x3 inbound block.
+    /// Note that with a non-integer scale the strips will be of variable width.
+    fn next(&mut self) -> Option<Self::Item> {
+        // if there is no reduction in image size then simple return image as-is
+        if self.scale <= 1.0 {
+            return match self.iter.next() {
+                Some(pixel) => Some(*pixel),
+                None => None,
+            };
+        }
+        // processed the last inbound pixel
+        if self.out_x > self.out_x_last {
+            return None;
+        }
+        // take the average of pixels in the horizontal, and then vertical.
+        let in_y_cap = (self.scale * self.out_y as f32) as usize;
+        while self.in_y < in_y_cap {
+            let mut in_x = 0;
+            for (out_x, in_x_cap) in self.in_x_cap.iter().enumerate() {
+                let mut x_total: u16 = 0;
+                let mut x_div: u16 = 0;
+                while in_x <= *in_x_cap {
+                    x_total += match self.iter.next() {
+                        Some(pixel) => *pixel as u16,
+                        None => {
+                            self.out_x_last = out_x - 1;
+                            0
+                        }
+                    };
+                    in_x += 1;
+                    x_div += 1;
+                }
+                self.buf[out_x] += x_total / x_div;
+            }
+            self.in_y += 1;
+            self.y_div += 1;
+        }
+        // calculate the average of the sum of pixels in the buffer, and reset buffer
+        let pixel: u8 = (self.buf[self.out_x] / self.y_div).try_into().unwrap();
+        self.buf[self.out_x] = 0;
+        // prepare for the next pixel in the row or column
+        self.out_x += 1;
+        if self.out_x >= self.out_width {
+            self.out_x = 0;
+            self.out_y += 1;
+            self.y_div = 0;
+        }
+        Some(pixel)
+    }
+}
+
+pub trait ShrinkIterator<'a>: Iterator<Item = &'a u8> + Sized {
+    fn shrink(self, in_width: usize, out_width: usize) -> Shrink<Self> {
+        Shrink::new(self, in_width, out_width)
+    }
+}
+
+impl<'a, I: Iterator<Item = &'a u8>> ShrinkIterator<'a> for I {}
+
+// **********************************************************************
+
 /*
  * Image as a minimal flat buffer of grey u8 pixels; accessible by (x, y)
  *
@@ -355,8 +497,8 @@ impl<'a, I: Iterator<Item = &'a u8>> GreyScaleIterator<'a> for I {}
 
 #[derive(Debug)]
 pub struct Img {
-    pixels: Vec<u8>,
-    width: usize,
+    pub pixels: Vec<u8>,
+    pub width: usize,
 }
 
 impl Img {
@@ -370,7 +512,7 @@ impl Img {
 
         for pixel in buf.iter().to_grey(px_type) {
             pixels.push(pixel);
-        }       
+        }
         Self { pixels, width }
     }
     pub fn get(&self, x: usize, y: usize) -> Option<&u8> {
@@ -386,30 +528,13 @@ impl Img {
     pub fn as_slice(&self) -> &[u8] {
         self.pixels.as_slice()
     }
-    // simply retains the closest pixel
-    pub fn resize(&self, width: usize, height: usize) -> Img {
-        let mut buf = vec![0u8; (width * height).try_into().unwrap()];
-        let (self_width, self_height, _) = self.size();
-        let x_scale = self_width as f32 / width as f32;
-        let y_scale = self_height as f32 / height as f32;
-        let self_x_base = x_scale * 0.5;
-        let self_y_base = y_scale * 0.5;
+}
 
-        // Pretabulate horizontal pixel positions
-        let mut self_x_tab: Vec<usize> = Vec::with_capacity(width);
-        for buf_x in 0..width {
-            self_x_tab.push(((self_x_base + x_scale * buf_x as f32) as usize).min(self_width - 1));
-        }
+impl Deref for Img {
+    type Target = Vec<u8>;
 
-        for buf_y in 0..height {
-            let self_y = ((self_y_base + y_scale * buf_y as f32) as usize).min(self_height - 1);
-            let self_row = self_y * self_width;
-            let buf_row = buf_y * width;
-            for (buf_x, self_x) in self_x_tab.iter().enumerate() {
-                buf[buf_row + buf_x] = self.pixels[self_row + self_x];
-            }
-        }
-        Img::new(buf, width.try_into().unwrap(), PixelType::U8)
+    fn deref(&self) -> &Self::Target {
+        &self.pixels
     }
 }
 

--- a/services/graphics-server/src/api/tile.rs
+++ b/services/graphics-server/src/api/tile.rs
@@ -1,4 +1,5 @@
 use crate::api::*;
+use std::cmp::max;
 use std::convert::TryInto;
 //////////////////////// Tile -------- author: nworbnhoj
 
@@ -21,23 +22,56 @@ pub(crate) const OUT_OF_BOUNDS: usize = usize::MAX;
 #[derive(Debug, Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct Tile {
     bound: Rectangle,
-    width_words: u16,
+    width_words: i16,
+    max_bound: Rectangle,
     words: [Word; WORDS_PER_TILE],
 }
 
 impl Tile {
-    pub fn new(bound: Rectangle, width_words: u16) -> Self {
+    pub fn new(mut bound: Rectangle) -> Self {
         log::trace!("new Tile {:?}", bound);
-        let words = [0u32; WORDS_PER_TILE];
+        let bits_per_word = BITS_PER_WORD as i16;
+        let bits_per_tile = BITS_PER_TILE as i16;
+        let words_per_tile = WORDS_PER_TILE as i16;
+
+        let width_bits = bound.br.x - bound.tl.x + 1;
+        // establish width limits
+        let width_words = if width_bits > bits_per_tile {
+            log::warn!("Tile max width exceeded");
+            bound.br.x = bound.tl.x + words_per_tile * bits_per_word - 1;
+            words_per_tile
+        } else {
+            match width_bits % bits_per_word {
+                0 => width_bits / bits_per_word,
+                _ => width_bits / bits_per_word + 1,
+            }
+        };
+        let max_x = bound.tl.x + width_words * bits_per_word - 1;
+        // establish height limits
+        let max_height_bits = words_per_tile / width_words;
+        let max_y = bound.tl.y + max_height_bits - 1;
+        if bound.br.y > max_y {
+            log::warn!("Tile max height exceeded {} > {}", max_y, bound.br.y);
+            bound.br.y = max_y;
+        }
         Self {
             bound,
             width_words,
-            words,
+            max_bound: Rectangle::new(bound.tl, Point::new(max_x, max_y)),
+            words: [0u32; WORDS_PER_TILE],
         }
     }
 
     pub fn bound(&self) -> Rectangle {
         self.bound
+    }
+
+    pub fn set_bound(&mut self, bound: Rectangle) {
+        self.bound = bound
+    }
+
+    pub fn max_bound(&self) -> Rectangle {
+        self.max_bound
     }
 
     pub fn area(&self) -> u32 {
@@ -50,10 +84,18 @@ impl Tile {
         Point::new(pos.br.x - pos.tl.x, pos.br.y - pos.tl.y)
     }
 
+    fn word_index_mut(&mut self, point: Point) -> usize {
+        if !self.bound.intersects_point(point) && self.max_bound.intersects_point(point) {
+            self.bound.br.x = max(point.x, self.bound.br.x);
+            self.bound.br.y = max(point.y, self.bound.br.y);
+        }
+        self.word_index(point)
+    }
+
     fn word_index(&self, point: Point) -> usize {
         if self.bound.intersects_point(point) {
-            let tile_line: u16 = (point.y - self.bound.tl.y).try_into().unwrap();
-            let first_word_in_line:usize = (tile_line * self.width_words).try_into().unwrap();
+            let tile_line: i16 = (point.y - self.bound.tl.y).try_into().unwrap();
+            let first_word_in_line: usize = (tile_line * self.width_words).try_into().unwrap();
             let bit_index: usize = (point.x - self.bound.tl.x).try_into().unwrap();
             first_word_in_line + (bit_index / BITS_PER_WORD)
         } else {
@@ -66,8 +108,9 @@ impl Tile {
         self.words[self.word_index(point)]
     }
 
+    /// Adding a word outside of bound (but within max_bound) will expand bound.
     pub fn set_word(&mut self, point: Point, word: Word) {
-        self.words[self.word_index(point)] = word;
+        self.words[self.word_index_mut(point)] = word;
     }
 
     pub fn get_line(&self, point: Point) -> Vec<Word> {
@@ -83,20 +126,22 @@ impl Tile {
         }
     }
 
-    pub fn set_line(&self, _point: Point, _pixels: Vec<PixelColor>){
+    /// Adding a line outside of bound (but within max_bound) will expant bound.
+    pub fn set_line(&self, _point: Point, _pixels: Vec<PixelColor>) {
         log::warn!("not implemented");
     }
 
     pub fn get_pixel(&self, point: Point) -> PixelColor {
         let word: usize = self.get_word(point).try_into().unwrap();
-        let bpw: i16 =  BITS_PER_WORD.try_into().unwrap();
+        let bpw: i16 = BITS_PER_WORD.try_into().unwrap();
         let bit = point.x % bpw;
         PixelColor::from((word >> bit) & 1)
     }
 
+    /// Adding a pixel outside of bound (but within max_bound) will expand bound.
     pub fn set_pixel(&mut self, point: Point, color: PixelColor) {
-        let word_index = self.word_index(point);
-        let bpw: i16 =  BITS_PER_WORD.try_into().unwrap();
+        let word_index = self.word_index_mut(point);
+        let bpw: i16 = BITS_PER_WORD.try_into().unwrap();
         match word_index == OUT_OF_BOUNDS {
             true => {}
             false => {
@@ -115,5 +160,12 @@ impl Tile {
         self.bound.tl.y += offset.y;
         self.bound.br.x += offset.x;
         self.bound.br.y += offset.y;
+        let max_x = self.bound.tl.x + self.width_words * BITS_PER_WORD as i16 - 1;
+        let max_y = self.bound.tl.y + WORDS_PER_TILE as i16 / self.width_words - 1;
+        self.max_bound = Rectangle::new(self.bound.tl, Point::new(max_x, max_y));
+    }
+
+    pub fn crop(&mut self, bound: Rectangle) {
+        self.bound = bound;
     }
 }

--- a/services/modals/src/lib.rs
+++ b/services/modals/src/lib.rs
@@ -204,7 +204,7 @@ impl Modals {
             gam::IMG_MODAL_HEIGHT - 2 * BORDER,
         );
 
-        let (w, h, _) = img.size();
+        let (w, h) = (img.width(), img.height());
         let (img_width, img_height) = (w as f32, h as f32);
 
         let portrait_scale = (modal_width as f32 / img_width).min(modal_height as f32 / img_height);

--- a/services/modals/src/lib.rs
+++ b/services/modals/src/lib.rs
@@ -209,17 +209,9 @@ impl Modals {
         } else if landscape_scale >= 1.0 {
             Bitmap::from(img).rotate90()
         } else if portrait_scale >= landscape_scale {
-            let resized = img.resize(
-                (portrait_scale * img_width) as usize,
-                (portrait_scale * img_height) as usize,
-            );
-            Bitmap::from(&resized)
+            Bitmap::new_resize(img, (portrait_scale * img_width) as usize)
         } else {
-            let resized = img.resize(
-                (landscape_scale * img_width) as usize,
-                (landscape_scale * img_height) as usize,
-            );
-            Bitmap::from(&resized).rotate90()
+            Bitmap::new_resize(img, (landscape_scale * img_width) as usize).rotate90()
         };
 
         let (bm_width, bm_height) = bm.size();

--- a/services/modals/src/lib.rs
+++ b/services/modals/src/lib.rs
@@ -197,30 +197,41 @@ impl Modals {
     pub fn show_image(&self, img: &Img) -> Result<(), xous::Error> {
         self.lock();
         // resize and/or rotate
-        let (modal_width, modal_height) =
-            (gam::IMG_MODAL_WIDTH as f32, gam::IMG_MODAL_HEIGHT as f32);
+        const BORDER: u32 = 3;
+
+        let (modal_width, modal_height) = (
+            gam::IMG_MODAL_WIDTH - 2 * BORDER,
+            gam::IMG_MODAL_HEIGHT - 2 * BORDER,
+        );
+
         let (w, h, _) = img.size();
         let (img_width, img_height) = (w as f32, h as f32);
 
-        let portrait_scale = (modal_width / img_width).min(modal_height / img_height);
-        let landscape_scale = (modal_width / img_height).min(modal_height / img_width);
+        let portrait_scale = (modal_width as f32 / img_width).min(modal_height as f32 / img_height);
+        let landscape_scale =
+            (modal_width as f32 / img_height).min(modal_height as f32 / img_width);
         let mut bm = if portrait_scale >= 1.0 {
+            log::info!("show image as is");
             Bitmap::from(img)
         } else if landscape_scale >= 1.0 {
+            log::info!("rotate image");
             Bitmap::from(img).rotate90()
         } else if portrait_scale >= landscape_scale {
+            log::info!("scale image {}", portrait_scale);
             Bitmap::new_resize(img, (portrait_scale * img_width) as usize)
         } else {
+            log::info!("scale image {} and rotate", landscape_scale);
             Bitmap::new_resize(img, (landscape_scale * img_width) as usize).rotate90()
         };
-
         let (bm_width, bm_height) = bm.size();
         let (bm_width, bm_height) = (bm_width as u32, bm_height as u32);
 
         // center image in modal
         let center = Point::new(
-            ((gam::IMG_MODAL_WIDTH - bm_width) / 2).try_into().unwrap(),
-            ((gam::IMG_MODAL_HEIGHT - bm_height) / 2)
+            (BORDER + (gam::IMG_MODAL_WIDTH - 2 * BORDER - bm_width) / 2)
+                .try_into()
+                .unwrap(),
+            (BORDER + (gam::IMG_MODAL_HEIGHT - 2 * BORDER - bm_height) / 2)
                 .try_into()
                 .unwrap(),
         );

--- a/services/modals/src/tests.rs
+++ b/services/modals/src/tests.rs
@@ -1,9 +1,9 @@
 use super::*;
+#[cfg(feature = "ditherpunk")]
+use bitmap::PixelType;
 use gam::*;
 use std::thread;
 use xous_names::XousNames;
-#[cfg(feature = "ditherpunk")]
-use bitmap::PixelType;
 
 const RADIO_TEST: [&'static str; 4] = ["zebra", "cow", "horse", "cat"];
 
@@ -175,23 +175,33 @@ pub fn spawn_test() {
 // https://sequelaencollection.home.blog/2d-chaotic-attractors/
 #[cfg(feature = "ditherpunk")]
 fn clifford() -> Img {
-    const SIZE: u32 = gam::IMG_MODAL_WIDTH - 10;
-    const CENTER: f32 = (SIZE / 2) as f32;
-    const SCALE: f32 = 60.0;
-    let mut buf = vec![255u8; (SIZE * SIZE).try_into().unwrap()];
+    // IMW+20, IMW-10 Line (resize + rotate)
+    // IMW-20, IMW-10 OK   ()
+    // IMW+10, IMW+20 Line (resize)
+    // IMH-15 IMW-15 Line (rotate)
+
+    // width & height chosen to force resize & rotation
+    const WIDTH: u32 = gam::IMG_MODAL_HEIGHT * 2;
+    const HEIGHT: u32 = gam::IMG_MODAL_WIDTH * 2;
+    const X_CENTER: f32 = (WIDTH / 2) as f32;
+    const Y_CENTER: f32 = (HEIGHT / 2) as f32;
+    const SCALE: f32 = WIDTH as f32 / 5.1; //70.0;
+    const STEP: u8 = 32;
+    const ITERATIONS: u32 = 400000;
+    let mut buf = vec![255u8; (WIDTH * HEIGHT).try_into().unwrap()];
     let (a, b, c, d) = (-2.0, -2.4, 1.1, -0.9);
     let (mut x, mut y): (f32, f32) = (0.0, 0.0);
-    for _ in 0..=4000000 {
+    for _ in 0..=ITERATIONS {
         let x1 = f32::sin(a * y) + c * f32::cos(a * x);
         let y1 = f32::sin(b * x) + d * f32::cos(b * y);
         (x, y) = (x1, y1);
-        let (a, b): (u32, u32) = ((x * SCALE + CENTER) as u32, (y * SCALE + CENTER) as u32);
-        let i: usize = (a + SIZE * b).try_into().unwrap();
-        if buf[i] > 0 {
-            buf[i] -= 1;
+        let (a, b): (u32, u32) = ((x * SCALE + X_CENTER) as u32, (y * SCALE + Y_CENTER) as u32);
+        let i: usize = (a + WIDTH * b).try_into().unwrap();
+        if buf[i] >= STEP {
+            buf[i] -= STEP;
         }
     }
-    Img::new(buf, SIZE.try_into().unwrap(), PixelType::U8)
+    Img::new(buf, WIDTH.try_into().unwrap(), PixelType::U8)
 }
 
 fn test_validator(input: TextEntryPayload) -> Option<xous_ipc::String<256>> {

--- a/services/modals/src/tests.rs
+++ b/services/modals/src/tests.rs
@@ -175,19 +175,14 @@ pub fn spawn_test() {
 // https://sequelaencollection.home.blog/2d-chaotic-attractors/
 #[cfg(feature = "ditherpunk")]
 fn clifford() -> Img {
-    // IMW+20, IMW-10 Line (resize + rotate)
-    // IMW-20, IMW-10 OK   ()
-    // IMW+10, IMW+20 Line (resize)
-    // IMH-15 IMW-15 Line (rotate)
-
     // width & height chosen to force resize & rotation
-    const WIDTH: u32 = gam::IMG_MODAL_HEIGHT * 2;
-    const HEIGHT: u32 = gam::IMG_MODAL_WIDTH * 2;
+    const WIDTH: u32 = gam::IMG_MODAL_HEIGHT + 2;
+    const HEIGHT: u32 = gam::IMG_MODAL_WIDTH + 2;
     const X_CENTER: f32 = (WIDTH / 2) as f32;
     const Y_CENTER: f32 = (HEIGHT / 2) as f32;
-    const SCALE: f32 = WIDTH as f32 / 5.1; //70.0;
-    const STEP: u8 = 32;
-    const ITERATIONS: u32 = 400000;
+    const SCALE: f32 = WIDTH as f32 / 5.1;
+    const STEP: u8 = 16;
+    const ITERATIONS: u32 = 200000;
     let mut buf = vec![255u8; (WIDTH * HEIGHT).try_into().unwrap()];
     let (a, b, c, d) = (-2.0, -2.4, 1.1, -0.9);
     let (mut x, mut y): (f32, f32) = (0.0, 0.0);


### PR DESCRIPTION
These iterators process an image pixel-by-pixel in order to significantly reduce memory requirements over the current batch approach.

- `.to_grey(pixel_type)` converts 3 x `u8` RGB bytes to a single `u8` Grey byte. The iterator state holds only the `PixelType` (1 x byte)
- `.shrink(from_width, to_width)` takes the average of a block of u8 grey pixels to generate a single u8 grey pixel. The iterator state holds only 1 x `f32`, 5 x `usize`, a `vec![u16, to_width]` for performance, and a vec![u16, to_width]` to store the averages: where to_width is the width of the outbound image.
- `.dither(burkes, width)` converts 32 x u8 grey pixels to a u32 bitfield using the Burkes diffusion scheme.  The iterator state holds only 4 x `usize`, 1 x `i16` and a `vec![i16, width + 3]` to store the dither error values.

 

![Screenshot from 2022-06-28 07-43-47](https://user-images.githubusercontent.com/11512866/176327617-d8b6ae32-0555-4f8c-9173-7e8cda9926c3.png)

There is an annoying horizontal line at the base of the resulting image.

