### PR TITLE
Fix typo in the tool description : 'Rebide' -> 'Renode'

### DIFF
--- a/svd2repl/src/main.rs
+++ b/svd2repl/src/main.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Write};
 
 fn main() -> anyhow::Result<()> {
     let matches = App::new("svd2repl")
-        .about("Generate a Rebide Platform description from SVD files")
+        .about("Generate a Renode Platform description from SVD files")
         .arg(
             Arg::with_name("input")
                 .help("Input SVD file")


### PR DESCRIPTION
As the REPL format comes from [Renode Platform](https://github.com/renode/renode), I believe the word 'Rebide' to be a typo for 'Renode' (given the proximity of the letters on a keyboard).

Let's hope it'll make this tool more prominent in search results.

Signed-off-by: Ludovic LANGE <llange@users.noreply.github.com>