### PR TITLE
feat(vault): support Bitwarden export formatting for Vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,6 +3292,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_with"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4201,6 +4212,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "serde_repr",
 ]
 
 [[package]]

--- a/apps/vault/libraries/backup/src/lib.rs
+++ b/apps/vault/libraries/backup/src/lib.rs
@@ -202,7 +202,7 @@ impl TryFrom<cbor::Value> for PasswordEntry {
     type Error = CborConversionError;
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct PasswordEntries(pub Vec<PasswordEntry>);
 
 impl From<&PasswordEntries> for cbor::Value {

--- a/apps/vault/tools/vaultbackup-rs/Cargo.toml
+++ b/apps/vault/tools/vaultbackup-rs/Cargo.toml
@@ -18,3 +18,4 @@ clap = { version = "3.2.12", features = ["derive"] }
 anyhow = "1.0.58"
 log = "0.4.17"
 env_logger = "0.9.0"
+serde_repr = "0.1.9"

--- a/apps/vault/tools/vaultbackup-rs/README.md
+++ b/apps/vault/tools/vaultbackup-rs/README.md
@@ -44,6 +44,7 @@ OPTIONS:
 
 SUBCOMMANDS:
     backup     Backup data from device
+    format     Format a known password manager export for Vault
     help       Print this message or the help of the given subcommand(s)
     restore    Restore data to device
 ```
@@ -64,3 +65,18 @@ vaultbackup-rs <ACTION> <TARGET> <PATH>
 `PATH` specifies the path where `vaultbackup-rs` reads/writes data.
 
 The output format is JSON.
+
+## Importing other password manager's exports
+
+`vaultbackup-rs` supports importing other password manager's export data in Vault, but to do so, you have to format it to Vault's format first.
+
+The `subcommand` does this for you.
+
+Supported password managers:
+ - Bitwarden: TOTP, logins
+
+Example:
+
+```bash
+$ vaultbackup-rs format bitwarden your-bitwarden-export.json
+```

--- a/apps/vault/tools/vaultbackup-rs/src/bitwarden.rs
+++ b/apps/vault/tools/vaultbackup-rs/src/bitwarden.rs
@@ -1,0 +1,123 @@
+use serde::{Deserialize, Serialize};
+use serde_json;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+#[derive(Serialize_repr, Debug, Deserialize_repr, PartialEq)]
+#[repr(u8)]
+pub enum EntryType {
+    Login = 1,
+    SecureNote = 2,
+    Card = 3,
+    Identity = 4,
+}
+
+#[derive(Serialize, Debug, Deserialize)]
+pub struct Entry {
+    #[serde(rename = "type")]
+    pub entry_type: EntryType,
+    pub name: String,
+    pub login: Option<Login>,
+    pub notes: Option<String>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Login {
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub totp: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum LoginSanificationError {
+    BadUsername,
+    BadPassword,
+}
+
+impl std::fmt::Display for LoginSanificationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadUsername => write!(f, "bad username format"),
+            Self::BadPassword => write!(f, "bad password format"),
+        }
+    }
+}
+
+impl std::error::Error for LoginSanificationError {}
+
+impl Login {
+    pub fn sane(&self) -> Result<(), LoginSanificationError> {
+        if self.username.is_none() {
+            return Err(LoginSanificationError::BadUsername);
+        } else {
+            if self.username.as_ref().unwrap_or(&String::new()).is_empty() {
+                return Err(LoginSanificationError::BadUsername);
+            }
+        }
+
+        if self.password.is_none() {
+            return Err(LoginSanificationError::BadPassword);
+        } else {
+            if self.password.as_ref().unwrap_or(&String::new()).is_empty() {
+                return Err(LoginSanificationError::BadPassword);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Items {
+    pub items: Vec<Entry>,
+}
+
+impl Items {
+    pub fn logins(&self) -> Vec<&Entry> {
+        let ret: Vec<&Entry> = self
+            .items
+            .iter()
+            .filter(|element| element.entry_type == EntryType::Login && element.login.is_some())
+            .collect();
+        ret
+    }
+}
+
+#[derive(Debug)]
+pub enum FormatError {
+    SerdeError(serde_json::Error),
+}
+
+impl std::fmt::Display for FormatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SerdeError(err) => write!(f, "bitwarden deserialization error, {:?}", err),
+        }
+    }
+}
+
+impl std::error::Error for FormatError {}
+
+impl From<serde_json::Error> for FormatError {
+    fn from(e: serde_json::Error) -> FormatError {
+        FormatError::SerdeError(e)
+    }
+}
+
+impl TryFrom<Vec<u8>> for Items {
+    type Error = FormatError;
+
+    fn try_from(data: Vec<u8>) -> Result<Items, Self::Error> {
+        let ret: Items = serde_json::from_slice(&data)?;
+        Ok(ret)
+    }
+}
+
+impl TryFrom<std::fs::File> for Items {
+    type Error = FormatError;
+
+    fn try_from(data: std::fs::File) -> Result<Items, Self::Error> {
+        let ret: Items = serde_json::from_reader(data)?;
+        Ok(ret)
+    }
+}


### PR DESCRIPTION
Allows folks with Bitwarden data to (mostly) import it in Vault, both passwords and TOTPs.

`README.md` has been updated accordingly.

It works like this:
1. acquire a Bitwarden JSON export
2. format it in TOTP and password export with `vaultbackup-rs format bitwarden your-file.json`
3. restore either with `vaultbackup-rs restore {totp, password} bitwarden_to_vault_{totps, passwords}.json`

Seems to be working fine for me, further testing is definitely needed.