### PR TITLE
add virt_to_phys syscall

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -35,7 +35,7 @@ gdbserver = ["gdbstub", "gdbstub_arch"]
 print-panics = []
 report-memory = ["stats_alloc"]
 wrap-print = []
-v2p = []
+v2p = ["xous-kernel/v2p"]
 # default = ["print-panics", "debug-print", "wrap-print"]
 default = ["print-panics", "gdbserver"]
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -35,6 +35,7 @@ gdbserver = ["gdbstub", "gdbstub_arch"]
 print-panics = []
 report-memory = ["stats_alloc"]
 wrap-print = []
+v2p = []
 # default = ["print-panics", "debug-print", "wrap-print"]
 default = ["print-panics", "gdbserver"]
 

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -936,6 +936,13 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
             }),
             _ => Err(xous_kernel::Error::InvalidLimit),
         },
+        SysCall::VirtToPhys(vaddr) => {
+            let phys_addr = crate::arch::mem::virt_to_phys(vaddr as usize);
+            match phys_addr {
+                Ok(pa) => Ok(xous_kernel::Result::Scalar1(pa)),
+                Err(_) => Err(xous_kernel::Error::BadAddress),
+            }
+        }
         /* https://github.com/betrusted-io/xous-core/issues/90
         SysCall::SetExceptionHandler(pc, sp) => SystemServices::with_mut(|ss| {
             ss.set_exception_handler(pid, pc, sp)

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -936,6 +936,7 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
             }),
             _ => Err(xous_kernel::Error::InvalidLimit),
         },
+        #[cfg(feature="v2p")]
         SysCall::VirtToPhys(vaddr) => {
             let phys_addr = crate::arch::mem::virt_to_phys(vaddr as usize);
             match phys_addr {

--- a/xous-rs/Cargo.toml
+++ b/xous-rs/Cargo.toml
@@ -13,6 +13,8 @@ core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core
 compiler_builtins = { version = '0.1.0', optional = true }
 
 [features]
+v2p = []
+default = []
 
 # If this is set, then the "Drop" feature of MemoryMessage structs
 # will not be implemented.  This should only be set by the kernel.

--- a/xous-rs/src/syscall.rs
+++ b/xous-rs/src/syscall.rs
@@ -467,6 +467,7 @@ pub enum SysCall {
     ///
     /// ## Errors
     ///     * **BadAddress**: The mapping does not exist
+    #[cfg(feature="v2p")]
     VirtToPhys(
         usize, /* virtual address */
     ),
@@ -515,6 +516,7 @@ pub enum SysCallNumber {
     JoinThread = 36,
     SetExceptionHandler = 37,
     AdjustProcessLimit = 38,
+    #[cfg(feature="v2p")]
     VirtToPhys = 39,
     Invalid,
 }
@@ -560,6 +562,7 @@ impl SysCallNumber {
             36 => JoinThread,
             37 => SetExceptionHandler,
             38 => AdjustProcessLimit,
+            #[cfg(feature="v2p")]
             39 => VirtToPhys,
             _ => Invalid,
         }
@@ -925,6 +928,7 @@ impl SysCall {
                 0,
                 0,
             ],
+            #[cfg(feature="v2p")]
             SysCall::VirtToPhys(vaddr) => [
                 SysCallNumber::VirtToPhys as usize,
                 *vaddr,
@@ -1099,6 +1103,7 @@ impl SysCall {
             SysCallNumber::JoinThread => SysCall::JoinThread(a1 as _),
             SysCallNumber::SetExceptionHandler => SysCall::SetExceptionHandler(a1 as _, a2 as _),
             SysCallNumber::AdjustProcessLimit => SysCall::AdjustProcessLimit(a1, a2, a3),
+            #[cfg(feature="v2p")]
             SysCallNumber::VirtToPhys => SysCall::VirtToPhys(a1 as _),
             SysCallNumber::Invalid => SysCall::Invalid(a1, a2, a3, a4, a5, a6, a7),
         })
@@ -1867,6 +1872,7 @@ pub fn set_exception_handler(
 */
 
 /// Translate a virtual address to a physical address
+#[cfg(feature="v2p")]
 pub fn virt_to_phys(va: usize) -> core::result::Result<usize, Error> {
     rsyscall(SysCall::VirtToPhys(va)).and_then(|result| {
         if let Result::Scalar1(pa) = result {

--- a/xous-rs/src/syscall.rs
+++ b/xous-rs/src/syscall.rs
@@ -457,6 +457,20 @@ pub enum SysCall {
         usize, /* proposed new limit */
     ),
 
+    /// Returns the physical address corresponding to a virtual address, if such a mapping exists.
+    ///
+    /// ## Arguments
+    ///     * **vaddr**: The virtual address to inspect
+    ///
+    /// ## Returns
+    /// Returns a Scalar1 containing the physical address
+    ///
+    /// ## Errors
+    ///     * **BadAddress**: The mapping does not exist
+    VirtToPhys(
+        usize, /* virtual address */
+    ),
+
     /// This syscall does not exist. It captures all possible
     /// arguments so detailed analysis can be performed.
     Invalid(usize, usize, usize, usize, usize, usize, usize),
@@ -501,6 +515,7 @@ pub enum SysCallNumber {
     JoinThread = 36,
     SetExceptionHandler = 37,
     AdjustProcessLimit = 38,
+    VirtToPhys = 39,
     Invalid,
 }
 
@@ -545,6 +560,7 @@ impl SysCallNumber {
             36 => JoinThread,
             37 => SetExceptionHandler,
             38 => AdjustProcessLimit,
+            39 => VirtToPhys,
             _ => Invalid,
         }
     }
@@ -909,6 +925,16 @@ impl SysCall {
                 0,
                 0,
             ],
+            SysCall::VirtToPhys(vaddr) => [
+                SysCallNumber::VirtToPhys as usize,
+                *vaddr,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
             SysCall::Invalid(a1, a2, a3, a4, a5, a6, a7) => [
                 SysCallNumber::Invalid as usize,
                 *a1,
@@ -1073,6 +1099,7 @@ impl SysCall {
             SysCallNumber::JoinThread => SysCall::JoinThread(a1 as _),
             SysCallNumber::SetExceptionHandler => SysCall::SetExceptionHandler(a1 as _, a2 as _),
             SysCallNumber::AdjustProcessLimit => SysCall::AdjustProcessLimit(a1, a2, a3),
+            SysCallNumber::VirtToPhys => SysCall::VirtToPhys(a1 as _),
             SysCallNumber::Invalid => SysCall::Invalid(a1, a2, a3, a4, a5, a6, a7),
         })
     }
@@ -1838,6 +1865,17 @@ pub fn set_exception_handler(
     })
 }
 */
+
+/// Translate a virtual address to a physical address
+pub fn virt_to_phys(va: usize) -> core::result::Result<usize, Error> {
+    rsyscall(SysCall::VirtToPhys(va)).and_then(|result| {
+        if let Result::Scalar1(pa) = result {
+            Ok(pa)
+        } else {
+            Err(Error::BadAddress)
+        }
+    })
+}
 
 /// Perform a raw syscall and return the result. This will transform
 /// `xous::Result::Error(e)` into an `Err(e)`.


### PR DESCRIPTION
this will help speed up performance profiling as we can resolve the physical address of the performance buffer allocated in RAM and use a USB command to read it out, instead of streaming it over serial.