### PR TITLE
root-keys: gracefully handle cases where gateware signature is malformed, invalid public key or signature type

### DIFF
--- a/services/root-keys/src/main.rs
+++ b/services/root-keys/src/main.rs
@@ -41,6 +41,9 @@ pub enum SignatureResult {
     ThirdPartyOk,
     DevKeyOk,
     Invalid,
+    MalformedSignature,
+    InvalidSignatureType,
+    InvalidPubKey,
 }
 #[allow(dead_code)]
 pub enum GatewareRegion {


### PR DESCRIPTION
Fixes corner case when user runs menu command to sign gateware from Renode.