### PR TITLE
Implement `Display` instead of `Into<String>`.

### DIFF
--- a/apps/vault/src/actions.rs
+++ b/apps/vault/src/actions.rs
@@ -551,14 +551,13 @@ impl ActionManager {
                     }
                 };
 
-                let alg: String = pw.algorithm.into();
                 let edit_data = self.modals
                     .alert_builder(t!("vault.edit_dialog", xous::LANG))
                     .field(Some(pw.name), Some(password_validator))
                     .field(Some(pw.secret), Some(password_validator))
                     .field(Some(pw.notes), Some(password_validator))
                     .field(Some(pw.timestep.to_string()), Some(password_validator))
-                    .field(Some(alg), Some(password_validator))
+                    .field(Some(pw.algorithm.to_string()), Some(password_validator))
                     .field(Some(pw.digits.to_string()), Some(password_validator))
                     .field(Some(if pw.is_hotp {"HOTP".to_string()} else {"TOTP".to_string()}), Some(password_validator))
                     .build().expect("modals error in edit");
@@ -845,12 +844,11 @@ impl ActionManager {
                             match record.read_exact(&mut data) {
                                 Ok(_len) => {
                                     if let Some(totp) = storage::TotpRecord::try_from(data).ok() {
-                                        let alg: String = totp.algorithm.into();
                                         let extra = format!("{}:{}:{}:{}:{}",
                                             totp.secret,
                                             totp.digits,
                                             totp.timestep,
-                                            alg,
+                                            totp.algorithm,
                                             if totp.is_hotp {"HOTP"} else {"TOTP"}
                                         );
                                         let desc = format!("{}", totp.name);

--- a/apps/vault/src/storage.rs
+++ b/apps/vault/src/storage.rs
@@ -427,7 +427,6 @@ impl StorageContent for TotpRecord {
         Ok(())
     }
     fn to_vec(&self) -> Vec<u8> {
-        let ta: String = self.algorithm.into();
         format!(
             "{}:{}\n{}:{}\n{}:{}\n{}:{}\n{}:{}\n{}:{}\n{}:{}\n{}:{}\n{}:{}\n",
             "version",
@@ -437,7 +436,7 @@ impl StorageContent for TotpRecord {
             "name",
             self.name,
             "algorithm",
-            ta,
+            self.algorithm,
             "notes",
             self.notes,
             "digits",
@@ -551,7 +550,6 @@ impl TryFrom<Vec<u8>> for TotpRecord {
 
 impl From<TotpRecord> for Vec<u8> {
     fn from(tr: TotpRecord) -> Self {
-        let ta: String = tr.algorithm.into();
         format!(
             "{}:{}\n{}:{}\n{}:{}\n{}:{}\n{}:{}\n{}:{}\n{}:{}\n{}:{}\n{}:{}\n",
             "version",
@@ -561,7 +559,7 @@ impl From<TotpRecord> for Vec<u8> {
             "name",
             tr.name,
             "algorithm",
-            ta,
+            tr.algorithm,
             "notes",
             tr.notes,
             "digits",

--- a/apps/vault/src/totp.rs
+++ b/apps/vault/src/totp.rs
@@ -48,13 +48,13 @@ impl TryFrom<&str> for TotpAlgorithm {
         }
     }
 }
-impl Into<String> for TotpAlgorithm {
-    fn into(self) -> String {
+impl core::fmt::Display for TotpAlgorithm {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
-            TotpAlgorithm::HmacSha1 => "SHA1".to_string(),
-            TotpAlgorithm::HmacSha256 => "SHA256".to_string(),
-            TotpAlgorithm::HmacSha512 => "SHA512".to_string(),
-            TotpAlgorithm::None => "None".to_string(),
+            TotpAlgorithm::HmacSha1 => write!(f, "SHA1"),
+            TotpAlgorithm::HmacSha256 => write!(f, "SHA256"),
+            TotpAlgorithm::HmacSha512 => write!(f, "SHA512"),
+            TotpAlgorithm::None => write!(f, "None"),
         }
     }
 }

--- a/apps/vault/src/ux/framework.rs
+++ b/apps/vault/src/ux/framework.rs
@@ -836,12 +836,11 @@ impl VaultUx {
                                     }
                                 }
                                 // update the "extra" field, because the timestep field has been altered
-                                let alg: String = hotp_rec.algorithm.into();
                                 self.filtered_list[self.selection_index].extra = format!("{}:{}:{}:{}:{}",
                                     hotp_rec.secret,
                                     hotp_rec.digits,
                                     hotp_rec.timestep,
-                                    alg,
+                                    hotp_rec.algorithm,
                                     if hotp_rec.is_hotp {"HOTP"} else {"TOTP"}
                                 );
                                 self.filtered_list[self.selection_index].dirty = true;

--- a/xous-rs/src/arch/hosted/process.rs
+++ b/xous-rs/src/arch/hosted/process.rs
@@ -12,13 +12,13 @@ impl ProcessKey {
     }
 }
 
-impl Into<String> for ProcessKey {
-    fn into(self) -> String {
-        let mut out = String::new();
+impl core::fmt::Display for ProcessKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for i in self.0 {
-            out.push_str(&format!("{:02x}", i));
+            write!(f, "{:02x}", i)?;
         }
-        out
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Avoid allocations in some cases, for example, when formatting to an I/O buffer. Or when formatting an string on a pre-allocated buffer.

Also implicitly implements `ToString`.