### PR TITLE
Implement From instead of Into.

### DIFF
--- a/apps/vault/src/ctap/ctap1.rs
+++ b/apps/vault/src/ctap/ctap1.rs
@@ -18,7 +18,6 @@ use super::status_code::Ctap2StatusCode;
 use super::CtapState;
 use std::vec::Vec;
 use arrayref::array_ref;
-use core::convert::Into;
 use core::convert::TryFrom;
 use ctap_crypto::rng256::Rng256;
 use crate::shims::ClockValue;
@@ -51,9 +50,9 @@ impl TryFrom<u8> for Ctap1Flags {
     }
 }
 
-impl Into<u8> for Ctap1Flags {
-    fn into(self) -> u8 {
-        self as u8
+impl From<Ctap1Flags> for u8 {
+    fn from(flags: Ctap1Flags) -> u8 {
+        flags as u8
     }
 }
 

--- a/services/com/src/api.rs
+++ b/services/com/src/api.rs
@@ -36,12 +36,12 @@ impl From<[usize; 2]> for BattStats {
     }
 }
 
-impl Into<[usize; 2]> for BattStats {
-    fn into(self) -> [usize; 2] {
+impl From<BattStats> for [usize; 2]{
+    fn from(stats: BattStats) -> [usize; 2] {
         [
-            (self.voltage as usize & 0xffff) | ((self.soc as usize) << 16) & 0xFF_0000,
-            (self.remaining_capacity as usize & 0xffff)
-                | ((self.current as usize) << 16) & 0xffff_0000,
+            (stats.voltage as usize & 0xffff) | ((stats.soc as usize) << 16) & 0xFF_0000,
+            (stats.remaining_capacity as usize & 0xffff)
+                | ((stats.current as usize) << 16) & 0xffff_0000,
         ]
     }
 }

--- a/services/content-plugin-api/src/lib.rs
+++ b/services/content-plugin-api/src/lib.rs
@@ -21,9 +21,9 @@ impl core::convert::TryFrom<&Message> for Opcode {
     }
 }
 
-impl Into<Message> for Opcode {
-    fn into(self) -> Message {
-        match self {
+impl From<Opcode> for Message {
+    fn from(opcode: Opcode) -> Message {
+        match opcode {
             Opcode::Redraw => Message::Scalar(ScalarMessage {
                 id: 0,
                 arg1: 0,
@@ -31,7 +31,7 @@ impl Into<Message> for Opcode {
                 arg3: 0,
                 arg4: 0,
             }),
-            // _ => panic!("SHCH api: Opcode type not handled by Into(), refer to helper method"),
+            // _ => panic!("SHCH api: Opcode type not handled by From<Opcode>, refer to helper method"),
         }
     }
 }

--- a/services/graphics-server/src/api/glyphstyle.rs
+++ b/services/graphics-server/src/api/glyphstyle.rs
@@ -29,9 +29,9 @@ impl From<usize> for GlyphStyle {
 
 /// Convert style to number for use with register-based message passing sytems
 // [by bunnie for Xous]
-impl Into<usize> for GlyphStyle {
-    fn into(self) -> usize {
-        match self {
+impl From<GlyphStyle> for usize {
+    fn from(g: GlyphStyle) -> usize {
+        match g {
             GlyphStyle::Small => 0,
             GlyphStyle::Regular => 1,
             GlyphStyle::Bold => 2,

--- a/services/graphics-server/src/api/points.rs
+++ b/services/graphics-server/src/api/points.rs
@@ -99,9 +99,9 @@ impl From<&Point> for (i16, i16) {
     }
 }
 
-impl Into<usize> for Point {
-    fn into(self) -> usize {
-        (self.x as usize) << 16 | (self.y as usize)
+impl From<Point> for usize {
+    fn from(point: Point) -> usize {
+        (point.x as usize) << 16 | (point.y as usize)
     }
 }
 

--- a/services/graphics-server/src/api/shapes.rs
+++ b/services/graphics-server/src/api/shapes.rs
@@ -248,13 +248,13 @@ impl Rectangle {
     }
 }
 
-impl Into<ClipRect> for Rectangle {
-    fn into(self) -> ClipRect {
+impl From<Rectangle> for ClipRect {
+    fn from(rectangle: Rectangle) -> ClipRect {
         ClipRect::new(
-            self.x0() as _,
-            self.y0() as _,
-            self.x1() as _,
-            self.y1() as _,
+            rectangle.x0() as _,
+            rectangle.y0() as _,
+            rectangle.x1() as _,
+            rectangle.y1() as _,
         )
     }
 }

--- a/services/graphics-server/src/api/styles.rs
+++ b/services/graphics-server/src/api/styles.rs
@@ -16,9 +16,9 @@ impl From<bool> for PixelColor {
     }
 }
 
-impl Into<bool> for PixelColor {
-    fn into(self) -> bool {
-        if self == PixelColor::Dark {
+impl From<PixelColor> for bool {
+    fn from(pc: PixelColor) -> bool {
+        if pc == PixelColor::Dark {
             true
         } else {
             false
@@ -36,9 +36,9 @@ impl From<usize> for PixelColor {
     }
 }
 
-impl Into<usize> for PixelColor {
-    fn into(self) -> usize {
-        if self == PixelColor::Light {
+impl From<PixelColor> for usize {
+    fn from(pc: PixelColor) -> usize {
+        if pc == PixelColor::Light {
             0
         } else {
             1
@@ -103,11 +103,11 @@ impl From<usize> for DrawStyle {
     }
 }
 
-impl Into<usize> for DrawStyle {
-    fn into(self) -> usize {
+impl From<DrawStyle> for usize {
+    fn from(draw_style: DrawStyle) -> usize {
         let sc: usize;
-        if self.stroke_color.is_some() {
-            if self.stroke_color.unwrap() == PixelColor::Dark {
+        if draw_style.stroke_color.is_some() {
+            if draw_style.stroke_color.unwrap() == PixelColor::Dark {
                 sc = 0b11;
             } else {
                 sc = 0b10;
@@ -116,8 +116,8 @@ impl Into<usize> for DrawStyle {
             sc = 0;
         }
         let fc: usize;
-        if self.fill_color.is_some() {
-            if self.fill_color.unwrap() == PixelColor::Dark {
+        if draw_style.fill_color.is_some() {
+            if draw_style.fill_color.unwrap() == PixelColor::Dark {
                 fc = 0b11;
             } else {
                 fc = 0b10;
@@ -126,7 +126,7 @@ impl Into<usize> for DrawStyle {
         } else {
             fc = 0;
         }
-        (self.stroke_width as usize) << 16 | sc << 2 | fc
+        (draw_style.stroke_width as usize) << 16 | sc << 2 | fc
     }
 }
 

--- a/services/graphics-server/src/api/text.rs
+++ b/services/graphics-server/src/api/text.rs
@@ -58,9 +58,9 @@ pub enum TextOp {
     Render,
     ComputeBounds, // maybe we don't need this
 }
-impl Into<usize> for TextOp {
-    fn into(self) -> usize {
-        match self {
+impl From<TextOp> for usize {
+    fn from(op: TextOp) -> usize {
+        match op {
             TextOp::Nop => 0,
             TextOp::Render => 1,
             TextOp::ComputeBounds => 2,

--- a/services/ime-plugin-api/src/lib.rs
+++ b/services/ime-plugin-api/src/lib.rs
@@ -34,16 +34,16 @@ pub struct PredictionTriggers {
     /// trigger word predictions on whitespace
     pub whitespace: bool,
 }
-impl Into<usize> for PredictionTriggers {
-    fn into(self) -> usize {
+impl From<PredictionTriggers> for usize {
+    fn from(pt: PredictionTriggers) -> usize {
         let mut ret: usize = 0;
-        if self.newline {
+        if pt.newline {
             ret |= 0x1;
         }
-        if self.punctuation {
+        if pt.punctuation {
             ret |= 0x2;
         }
-        if self.whitespace {
+        if pt.whitespace {
             ret |= 0x4;
         }
         ret

--- a/services/keyboard/src/api.rs
+++ b/services/keyboard/src/api.rs
@@ -35,9 +35,9 @@ impl From<usize> for KeyMap {
         }
     }
 }
-impl Into<usize> for KeyMap {
-    fn into(self) -> usize {
-        match self {
+impl From<KeyMap> for usize {
+    fn from(map: KeyMap) -> usize {
+        match map {
             // note: these indicese correspond to the position on the keyboard menu
             KeyMap::Qwerty => 0,
             KeyMap::Azerty => 1,

--- a/services/llio/src/api.rs
+++ b/services/llio/src/api.rs
@@ -27,9 +27,9 @@ impl From<usize> for UartType {
         }
     }
 }
-impl Into<usize> for UartType {
-    fn into(self) -> usize {
-        match self {
+impl From<UartType> for usize {
+    fn from(uart_type: UartType) -> usize {
+        match uart_type {
             UartType::Kernel => 0,
             UartType::Log => 1,
             UartType::Application => 2,
@@ -38,9 +38,9 @@ impl Into<usize> for UartType {
     }
 }
 // for the actual bitmask going to hardware
-impl Into<u32> for UartType {
-    fn into(self) -> u32 {
-        match self {
+impl From<UartType> for u32 {
+    fn from(uart_type: UartType) -> u32 {
+        match uart_type {
             UartType::Kernel => 0,
             UartType::Log => 1,
             UartType::Application => 2,

--- a/services/llio/src/api/llio_api.rs
+++ b/services/llio/src/api/llio_api.rs
@@ -15,9 +15,9 @@ impl From<usize> for VibePattern {
         }
     }
 }
-impl Into<usize> for VibePattern {
-    fn into(self) -> usize {
-        match self {
+impl From<VibePattern> for usize {
+    fn from(pat: VibePattern) -> usize {
+        match pat {
             VibePattern::Long => 0,
             VibePattern::Double => 1,
             VibePattern::Short => 0xffff_ffff,
@@ -39,9 +39,9 @@ impl From<usize> for ClockMode {
         }
     }
 }
-impl Into<usize> for ClockMode {
-    fn into(self) -> usize {
-        match self {
+impl From<ClockMode> for usize {
+    fn from(mode: ClockMode) -> usize {
+        match mode {
             ClockMode::Low => 0,
             ClockMode::AllOn => 0xffff_ffff,
         }

--- a/services/root-keys/src/api.rs
+++ b/services/root-keys/src/api.rs
@@ -315,9 +315,9 @@ impl From::<KeyMap> for BackupKeyboardLayout {
         }
     }
 }
-impl Into::<KeyMap> for BackupKeyboardLayout {
-    fn into(self) -> KeyMap {
-        match self {
+impl From<BackupKeyboardLayout> for KeyMap {
+    fn from(layout: BackupKeyboardLayout) -> KeyMap {
+        match layout {
             BackupKeyboardLayout::Qwerty => KeyMap::Qwerty,
             BackupKeyboardLayout::Braille => KeyMap::Braille,
             BackupKeyboardLayout::Dvorak => KeyMap::Dvorak,

--- a/xous-rs/src/arch/hosted/process.rs
+++ b/xous-rs/src/arch/hosted/process.rs
@@ -53,13 +53,13 @@ impl ProcessArgs {
     }
 }
 
-impl Into<[usize; 7]> for &ProcessInit {
-    fn into(self) -> [usize; 7] {
+impl From<&ProcessInit> for [usize; 7] {
+    fn from(init: &ProcessInit) -> [usize; 7] {
         [
-            u32::from_le_bytes(self.key.0[0..4].try_into().unwrap()) as _,
-            u32::from_le_bytes(self.key.0[4..8].try_into().unwrap()) as _,
-            u32::from_le_bytes(self.key.0[8..12].try_into().unwrap()) as _,
-            u32::from_le_bytes(self.key.0[12..16].try_into().unwrap()) as _,
+            u32::from_le_bytes(init.key.0[0..4].try_into().unwrap()) as _,
+            u32::from_le_bytes(init.key.0[4..8].try_into().unwrap()) as _,
+            u32::from_le_bytes(init.key.0[8..12].try_into().unwrap()) as _,
+            u32::from_le_bytes(init.key.0[12..16].try_into().unwrap()) as _,
             0,
             0,
             0,
@@ -120,9 +120,9 @@ impl From<[usize; 8]> for ProcessStartup {
     }
 }
 
-impl Into<[usize; 7]> for &ProcessStartup {
-    fn into(self) -> [usize; 7] {
-        [self.pid.get() as _, 0, 0, 0, 0, 0, 0]
+impl From<&ProcessStartup> for [usize; 7] {
+    fn from(startup: &ProcessStartup) -> [usize; 7] {
+        [startup.pid.get() as _, 0, 0, 0, 0, 0, 0]
     }
 }
 

--- a/xous-rs/src/arch/riscv/process.rs
+++ b/xous-rs/src/arch/riscv/process.rs
@@ -52,7 +52,7 @@ pub struct ProcessInit {
     // 6
 }
 
-impl Into<[usize; 7]> for &ProcessInit {
+impl From<&ProcessInit> for [usize; 7] {
     fn into(self) -> [usize; 7] {
         [
             self.stack.addr.get(),
@@ -121,7 +121,7 @@ impl From<[usize; 8]> for ProcessStartup {
     }
 }
 
-impl Into<[usize; 7]> for &ProcessStartup {
+impl From<&ProcessStartup> for [usize; 7] {
     fn into(self) -> [usize; 7] {
         [self.pid.get() as _, self.connection as _, 0, 0, 0, 0, 0]
     }

--- a/xous-rs/src/arch/test/mod.rs
+++ b/xous-rs/src/arch/test/mod.rs
@@ -20,13 +20,13 @@ impl ProcessKey {
     }
 }
 
-impl Into<String> for ProcessKey {
-    fn into(self) -> String {
-        let mut out = String::new();
+impl core::fmt::Display for ProcessKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for i in self.0 {
-            out.push_str(&format!("{:02x}", i));
+            write!(f, "{:02x}", i)?;
         }
-        out
+
+        Ok(())
     }
 }
 
@@ -184,14 +184,14 @@ impl From<[usize; 8]> for ProcessStartup {
     }
 }
 
-impl Into<[usize; 7]> for &ProcessStartup {
-    fn into(self) -> [usize; 7] {
-        [self.pid.get() as _, 0, 0, 0, 0, 0, 0]
+impl From<&ProcessStartup> for [usize; 7] {
+    fn from(startup: &ProcessStartup) -> [usize; 7] {
+        [startup.pid.get() as _, 0, 0, 0, 0, 0, 0]
     }
 }
 
-impl Into<[usize; 7]> for &ProcessInit {
-    fn into(self) -> [usize; 7] {
+impl From<&ProcessInit> for [usize; 7] {
+    fn from(init: &ProcessInit) -> [usize; 7] {
         [
             u32::from_le_bytes(self.key.0[0..4].try_into().unwrap()) as _,
             u32::from_le_bytes(self.key.0[4..8].try_into().unwrap()) as _,


### PR DESCRIPTION
The guidelines on Rust `std` and `core` crates is to implement `From` instead of `Into` as implementing `From` you get the `Into` implementation too. The other way around doesn't.