### PR TITLE
Use CARGO_CFG_TARGET_OS in build scripts.

### DIFF
--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -10,9 +10,8 @@ use std::path::PathBuf;
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let target = env::var("TARGET").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let name = env::var("CARGO_PKG_NAME").unwrap();
-
-    let target_os = target.split('-').nth(2).unwrap_or("none");
 
     // If we're not running on a desktop-class operating system, emit the "baremetal"
     // config setting. This will enable software to do tasks such as

--- a/services/gam/build.rs
+++ b/services/gam/build.rs
@@ -2,9 +2,7 @@
 use std::env;
 
 fn main() {
-    let target = env::var("TARGET").unwrap();
-
-    let target_os = target.split('-').nth(2).unwrap_or("none");
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
     // If we're not running on a desktop-class operating system, emit the "baremetal"
     // config setting. This will enable software to do tasks such as

--- a/services/kernel-test/build.rs
+++ b/services/kernel-test/build.rs
@@ -2,9 +2,7 @@
 use std::env;
 
 fn main() {
-    let target = env::var("TARGET").unwrap();
-
-    let target_os = target.split('-').nth(2).unwrap_or("none");
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
     // If we're not running on a desktop-class operating system, emit the "baremetal"
     // config setting. This will enable software to do tasks such as

--- a/xous-rs/build.rs
+++ b/xous-rs/build.rs
@@ -1,3 +1,4 @@
+use core::panic;
 // NOTE: Adapted from cortex-m/build.rs
 use std::env;
 use std::fs;
@@ -6,9 +7,8 @@ use std::path::PathBuf;
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let target = env::var("TARGET").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let name = env::var("CARGO_PKG_NAME").unwrap();
-
-    let target_os = target.split('-').nth(2).unwrap_or("none");
 
     // If we're not running on a desktop-class operating system, emit the "baremetal"
     // config setting. This will enable software to do tasks such as


### PR DESCRIPTION
This allows for a more reliable detection of target_os configuration in build scripts. The target is inconsistent between some architectures, notably armv7a is `armv7a-none-eabi` skipping the `unknown` (the vendor, I guess) part. This happen with some of the unrelated Cortex-M targets present, and others may also be.

Signed-off-by: Jean-Pierre De Jesus DIAZ <me@jeandudey.tech>