### PR TITLE
Verious svd2utra generator bugfixes

### DIFF
--- a/svd2utra/src/generate.rs
+++ b/svd2utra/src/generate.rs
@@ -837,7 +837,7 @@ pub mod utra {
                 out,
                 "            {} = {},",
                 register.name.to_case(Case::UpperCamel),
-                register.offset / 4
+                register.offset
             )?;
         }
         writeln!(out, "        }}")?;

--- a/svd2utra/src/generate.rs
+++ b/svd2utra/src/generate.rs
@@ -123,7 +123,7 @@ fn generate_field<T: BufRead>(reader: &mut Reader<T>) -> Result<Field, ParseErro
                     .unescape_and_decode(reader)
                     .map_err(|_| ParseError::NonUTF8)?;
                 match tag_name.as_str() {
-                    "name" => name = Some(extract_contents(reader)?),
+                    "name" if name.is_none() => name = Some(extract_contents(reader)?),
                     "lsb" => lsb = Some(parse_usize(extract_contents(reader)?.as_bytes())?),
                     "msb" => msb = Some(parse_usize(extract_contents(reader)?.as_bytes())?),
                     _ => (),


### PR DESCRIPTION
While implementing utralib generation for one of our chip SVD files I faced some issues with incomplete support of SVD spec but also just bugs. Here are the fixes.

@bunnie pls check if it doesn't break Precursor target code generation.