### PR TITLE
svd2utra: generate smaller compile tests for each peripheral

### DIFF
--- a/svd2utra/src/generate.rs
+++ b/svd2utra/src/generate.rs
@@ -900,16 +900,20 @@ fn print_tests<U: Write>(peripherals: &[Peripheral], out: &mut U) -> std::io::Re
     let test_header = r####"
 #[cfg(test)]
 mod tests {
-    #[test]
-    #[ignore]
-    fn compile_check() {
-        use super::*;
 "####
         .as_bytes();
     out.write_all(test_header)?;
+
     for peripheral in peripherals {
         let mod_name = peripheral.name.to_lowercase();
         let per_name = peripheral.name.to_lowercase() + "_csr";
+
+        write!(out, r####"
+    #[test]
+    #[ignore]
+    fn compile_check_{}() {{
+        use super::*;"####, per_name)?;
+
         writeln!(
             out,
             "        let mut {} = CSR::new(HW_{}_BASE as *mut u32);",
@@ -958,9 +962,11 @@ mod tests {
                 )?;
             }
         }
+
+        writeln!(out, "  }}")?;
     }
-    writeln!(out, "    }}")?;
     writeln!(out, "}}")?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Generating a one huge test for all of the peripherals is simple but if given big enough SVD file, this may even crash the `rustc` with a stack overflow message. Does crash for me.

Instead, generating multiple separate tests e.g. one per peripheral still works well but does not crash the compiler.