### PR TITLE
fix: make hosted mode work on macos again

### DIFF
--- a/services/graphics-server/src/main.rs
+++ b/services/graphics-server/src/main.rs
@@ -93,7 +93,7 @@ fn map_fonts() -> MemoryRange {
     fontregion
 }
 fn main () -> ! {
-    #[cfg(not(feature="ditherpunk"))]
+    #[cfg(any(not(feature = "ditherpunk"), target_os = "macos"))]
     wrapped_main();
 
     #[cfg(feature="ditherpunk")]


### PR DESCRIPTION
When ditherpunk flag is enabled, graphics-server cannot start. I suspect macOS doesn't tranfer thread-local variables when a new one is spawned, and this makes xous-names, logs crash.

This commit adds a compile setting that will bypass ditherpunk thread settings on macOS as well, allowing developers who happen to run this OS to develop and prototype for betrusted again.