### PR TITLE
Fix rebuild logic on utralib

### DIFF
--- a/utralib/build.rs
+++ b/utralib/build.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
 use std::env;
 use std::fs::OpenOptions;
-use std::io::Write;
+use std::io::{Read, Write};
+use std::path::PathBuf;
 
 fn out_dir() -> PathBuf {
     PathBuf::from(env::var_os("OUT_DIR").unwrap())
@@ -70,50 +70,73 @@ fn main() {
 
     allow_single_target_feature!("precursor", "hosted", "renode");
 
-    #[cfg(feature="precursor")]
-    allow_single_gitrev_feature!("precursor-c809403", "precursor-c809403-perflib", "precursor-2753c12-dvt", "precursor-a0912d6");
+    #[cfg(feature = "precursor")]
+    allow_single_gitrev_feature!(
+        "precursor-c809403",
+        "precursor-c809403-perflib",
+        "precursor-2753c12-dvt",
+        "precursor-a0912d6"
+    );
 
     // ----- select an SVD file based on a specific revision -----
-    #[cfg(feature="precursor-c809403")]
+    #[cfg(feature = "precursor-c809403")]
     let svd_filename = "precursor/soc-c809403.svd";
-    #[cfg(feature="precursor-c809403")]
+    #[cfg(feature = "precursor-c809403")]
     let generated_filename = "src/generated/precursor_c809403.rs";
 
-    #[cfg(feature="precursor-a0912d6")]
+    #[cfg(feature = "precursor-a0912d6")]
     let svd_filename = "precursor/soc-a0912d6.svd";
-    #[cfg(feature="precursor-a0912d6")]
+    #[cfg(feature = "precursor-a0912d6")]
     let generated_filename = "src/generated/precursor_a0912d6.rs";
 
-    #[cfg(feature="precursor-c809403-perflib")]
+    #[cfg(feature = "precursor-c809403-perflib")]
     let svd_filename = "precursor/soc-perf-c809403.svd";
-    #[cfg(feature="precursor-c809403-perflib")]
+    #[cfg(feature = "precursor-c809403-perflib")]
     let generated_filename = "src/generated/precursor_perf_c809403.rs";
 
-    #[cfg(feature="renode")]
+    #[cfg(feature = "renode")]
     let svd_filename = "renode/renode.svd";
-    #[cfg(feature="renode")]
+    #[cfg(feature = "renode")]
     let generated_filename = "src/generated/renode.rs";
 
-    #[cfg(feature="precursor-2753c12-dvt")]
+    #[cfg(feature = "precursor-2753c12-dvt")]
     let svd_filename = "precursor/soc-dvt-2753c12.svd";
-    #[cfg(feature="precursor-2753c12-dvt")]
+    #[cfg(feature = "precursor-2753c12-dvt")]
     let generated_filename = "src/generated/precursor_dvt_2753c12.rs";
 
     // ----- control file generation and rebuild sequence -----
     // check and see if the configuration has changed since the last build. This should be
     // passed by the build system (e.g. xtask) if the feature is used.
-    #[cfg(not(feature="hosted"))]
+    #[cfg(not(feature = "hosted"))]
     {
-        let last_config = out_dir().join("../../LAST_CONFIG");
-        if last_config.exists() {
-            println!("cargo:rerun-if-changed={}", last_config.canonicalize().unwrap().display());
-        }
         let svd_file_path = std::path::Path::new(&svd_filename);
-        println!("cargo:rerun-if-changed={}", svd_file_path.canonicalize().unwrap().display());
+        println!(
+            "cargo:rerun-if-changed={}",
+            svd_file_path.canonicalize().unwrap().display()
+        );
 
+        // Regenerate the utra file in RAM.
         let src_file = std::fs::File::open(svd_filename).expect("couldn't open src file");
-        let mut dest_file = std::fs::File::create(generated_filename).expect("couldn't open dest file");
-        svd2utra::generate(src_file, &mut dest_file).unwrap();
+        let mut dest_vec = vec![];
+        svd2utra::generate(src_file, &mut dest_vec).unwrap();
+
+        // If the file exists, check to see if it is different from what we just generated.
+        // If not, skip writing the new file.
+        // If the file doesn't exist, or if it's different, write out a new utra file.
+        let should_write = if let Ok(mut existing_file) = std::fs::File::open(generated_filename) {
+            let mut existing_file_contents = vec![];
+            existing_file.read_to_end(&mut existing_file_contents).expect("couldn't read existing utra generated file");
+            existing_file_contents != dest_vec
+        } else {
+            true
+        };
+        if should_write {
+            let mut dest_file =
+                std::fs::File::create(generated_filename).expect("couldn't open dest file");
+            dest_file
+                .write_all(&dest_vec)
+                .expect("couldn't write contents to utra file");
+        }
 
         // ----- feedback SVD path to build framework -----
         // pass the computed SVD filename back to the build system, so that we can pass this
@@ -132,7 +155,7 @@ fn main() {
             .unwrap();
         write!(svd_file, "utralib/{}", svd_filename).unwrap();
     }
-    #[cfg(feature="hosted")]
+    #[cfg(feature = "hosted")]
     {
         let svd_path = out_dir().join("../../SVD_PATH");
         let mut svd_file = OpenOptions::new()

--- a/utralib/build.rs
+++ b/utralib/build.rs
@@ -107,6 +107,9 @@ fn main() {
     // ----- control file generation and rebuild sequence -----
     // check and see if the configuration has changed since the last build. This should be
     // passed by the build system (e.g. xtask) if the feature is used.
+    //
+    // Debug this using:
+    //  $env:CARGO_LOG="cargo::core::compiler::fingerprint=info"
     #[cfg(not(feature = "hosted"))]
     {
         let svd_file_path = std::path::Path::new(&svd_filename);

--- a/xtask/src/builder.rs
+++ b/xtask/src/builder.rs
@@ -433,35 +433,6 @@ impl Builder {
             return Err("Target unknown: please check your UTRA target".into());
         };
 
-        // LAST_CONFIG tracks the last SVD configuration. It's used by utralib to track if it
-        // should rebuild itself based on a change in SVD configs. Note that for some reason
-        // it takes two consecutive builds with the same SVD config before the build system
-        // figures out that it doesn't need to rebuild everything. After then, it behaves as expected.
-        let last_config = format!("target/{}/{}/build/LAST_CONFIG", TARGET_TRIPLE, self.stream.to_str());
-        std::fs::create_dir_all(format!("target/{}/{}/build/", TARGET_TRIPLE, self.stream.to_str())).unwrap();
-        let changed = match OpenOptions::new()
-            .read(true)
-            .open(&last_config) {
-            Ok(mut file) => {
-                let mut contents = String::new();
-                file.read_to_string(&mut contents).unwrap();
-                if contents != self.utra_target {
-                    true
-                } else {
-                    false
-                }
-            }
-            _ => true
-        };
-        if changed {
-            let mut file = OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(&last_config).unwrap();
-            write!(file, "{}", self.utra_target).unwrap();
-        }
-
         // ------ build the services & apps ------
         let mut app_names = Vec::<String>::new();
         for app in self.apps.iter() {


### PR DESCRIPTION
This patch relies on build flags in order to prevent spurious rebuilds in utralib. Since each build configuration is now gated behind a feature flag, we can rely on cargo's build management to manage when we need to rebuild things.

Each compilation unit ("crate") gets a fingerprint that's composed of a hash of a bunch of sources including selected feature flags. When changing feature flags, this hash changes, meaning cargo treats the outputs as two separate versions.

For example, selecting `--features renode`, my system builds `utralib-0b7f95b43aed6e06`.
When selecting `--features utralib/precursor-a0912d6`, my system builds `utralib-ef4877bbf43451a5`.

These two outputs exist independently and at the same time -- changing the feature flags will cause Cargo to use one or the other.

Because the feature flags determine which source files are compiled, modifying renode code will not cause a recompile of the precursor-a0912d6 version of the crate, because that is untouched.

This patchset causes utralib to depend on cargo for selecting which version of utralib to build.

This patchset has the following nice properties:

1. When you change the svd file, only that target is rebuilt. If you change `renode.svd`, then `precursor-a0912d6` will not need to rebuild.
2. Rebuilds may not need to happen when switching between `app-image` and `renode-image`
3. `utralib` only needs to be built once -- it will not have the double-rebuild issue that it previously had.

I've tested this with both positive and negative rebuild conditions, and it has always been successful.

Incidentally, this sort of thing can be made easier to debug if you run:

```
 $env:CARGO_LOG="cargo::core::compiler::fingerprint=info"
```