### PR TITLE
xous-rs: remove unused features.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
  "cipher 0.4.3",
  "hex-literal",
  "log",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
 ]
 
@@ -65,7 +65,7 @@ version = "0.1.0"
 dependencies = [
  "hex-literal",
  "log",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
 ]
 
@@ -175,11 +175,11 @@ dependencies = [
  "num-derive",
  "num-traits",
  "trng",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -532,12 +532,12 @@ dependencies = [
  "rkyv",
  "trng",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -553,12 +553,12 @@ dependencies = [
  "trng",
  "typenum",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-semver",
 ]
 
@@ -611,7 +611,7 @@ dependencies = [
  "graphics-server",
  "log",
  "rkyv",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-names",
 ]
 
@@ -1046,11 +1046,11 @@ dependencies = [
  "rkyv",
  "trng",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1168,12 +1168,12 @@ dependencies = [
  "num-traits",
  "rkyv",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1285,7 +1285,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
@@ -1503,12 +1503,12 @@ dependencies = [
  "trng",
  "tts-frontend",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1545,9 +1545,9 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
  "wasm-bindgen-test",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-names",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1567,12 +1567,12 @@ dependencies = [
  "num-traits",
  "rkyv",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1657,10 +1657,10 @@ dependencies = [
  "num-derive",
  "num-traits",
  "tts-frontend",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1794,11 +1794,11 @@ dependencies = [
  "rkyv",
  "tts-frontend",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1810,9 +1810,9 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rkyv",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-names",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1825,11 +1825,11 @@ dependencies = [
  "num-traits",
  "rkyv",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1844,11 +1844,11 @@ dependencies = [
  "rkyv",
  "tts-frontend",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1928,12 +1928,12 @@ dependencies = [
  "num-traits",
  "rkyv",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1948,7 +1948,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-ticktimer",
 ]
@@ -1964,12 +1964,12 @@ dependencies = [
  "rkyv",
  "spinor",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2020,7 +2020,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-ticktimer",
@@ -2038,12 +2038,12 @@ dependencies = [
  "num-traits",
  "rkyv",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-semver",
 ]
 
@@ -2203,11 +2203,11 @@ dependencies = [
  "trng",
  "tts-frontend",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2227,11 +2227,11 @@ dependencies = [
  "num-derive",
  "num-traits",
  "trng",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2267,12 +2267,12 @@ dependencies = [
  "smoltcp",
  "trng",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-semver",
 ]
 
@@ -2540,12 +2540,12 @@ dependencies = [
  "trng",
  "tts-frontend",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize",
  "zeroize_derive",
 ]
@@ -2573,7 +2573,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3015,11 +3015,11 @@ dependencies = [
  "num-derive",
  "num-traits",
  "trng",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3058,9 +3058,9 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-names",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3140,12 +3140,12 @@ dependencies = [
  "tts-frontend",
  "usb-device-xous",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-semver",
  "zeroize",
 ]
@@ -3409,12 +3409,12 @@ dependencies = [
  "rkyv",
  "trng",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3492,12 +3492,12 @@ dependencies = [
  "utralib",
  "webpki-roots",
  "x25519-dalek",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3548,7 +3548,7 @@ dependencies = [
 name = "spawn"
 version = "0.1.0"
 dependencies = [
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3591,12 +3591,12 @@ dependencies = [
  "rkyv",
  "trng",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3655,12 +3655,12 @@ dependencies = [
  "trng",
  "usb-device-xous",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-semver",
 ]
 
@@ -3764,7 +3764,7 @@ dependencies = [
 name = "test-spawn"
 version = "0.1.0"
 dependencies = [
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3961,12 +3961,12 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rkyv",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3979,11 +3979,11 @@ dependencies = [
  "num-traits",
  "rkyv",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-tts-backend",
 ]
 
@@ -4130,12 +4130,12 @@ dependencies = [
  "usbd-human-interface-device 0.2.1",
  "utralib",
  "vcell",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-semver",
 ]
 
@@ -4155,7 +4155,7 @@ dependencies = [
  "usbd-human-interface-device 0.1.1",
  "utralib",
  "vcell",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
@@ -4259,12 +4259,12 @@ dependencies = [
  "usb-device-xous",
  "usbd-human-interface-device 0.2.1",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4708,7 +4708,7 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xous"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "compiler_builtins",
  "lazy_static",
@@ -4717,99 +4717,99 @@ dependencies = [
 
 [[package]]
 name = "xous"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f40f1c4402c15cb135b5f1f129099754666a08bd52829a12e663ecc5ff049d"
+checksum = "34dd83c15fa9deb0794d237524036a2bde6d38dfb7448776806f6155dada70fa"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "xous-api-log"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f433ca96e492e25391626ccfdf21de41e9d864e3b730b2125bad5e8edb3f39a"
+checksum = "03998d05db3f42b39c6e5a57020b51252ebc5df0b5f79e7dc70bb1aebcb8822b"
 dependencies = [
  "log",
  "num-derive",
  "num-traits",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "xous-api-names"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163ca61abe6e5c8d20a95e65de5032c17070004fb2d26f6aeb549fc4a7a8f108"
+checksum = "a0c40dc218ca8c00a13bb51af7d46a82f05ee7dc2215cb3cfbc5137a71cd1b0b"
 dependencies = [
  "log",
  "num-derive",
  "num-traits",
  "rkyv",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "xous-api-susres"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed71ead61d663556c7aea758c23c2ba51c22eec888c1164ef8ec3af97aca03"
+checksum = "fae47daa61284c97732a18763b93e2c35ec69d786edc8d7b137c3740cb6f844d"
 dependencies = [
  "log",
  "num-derive",
  "num-traits",
  "rkyv",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "xous-api-ticktimer"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d89c805480db79434ca8f748e2a3d9684ae9bfa07a2123420c4fa7342ec89d"
+checksum = "8994c510248cd4db0b6e5429cc63f1a7d7f5c5031862e9e090e63771c01d6dac"
 dependencies = [
  "log",
  "num-derive",
  "num-traits",
  "rkyv",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-semver",
 ]
 
 [[package]]
 name = "xous-ipc"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "bitflags",
  "rkyv",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "xous-ipc"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2b937414b4b92ba8deaa8b280fc986cccdf00edc5a5381463ce93066cb8749"
+checksum = "2d426772ff8a968289038e17f53e4b2d2bf7bfb2ef60897a74543976d7d4d060"
 dependencies = [
  "bitflags",
  "rkyv",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "xous-kernel"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "bitflags",
  "crossbeam-channel",
@@ -4819,36 +4819,36 @@ dependencies = [
  "rand_chacha 0.3.1",
  "stats_alloc",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-riscv",
 ]
 
 [[package]]
 name = "xous-log"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "log",
  "num-derive",
  "num-traits",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "xous-names"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "log",
  "num-derive",
  "num-traits",
  "rkyv",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4869,6 +4869,22 @@ checksum = "6ed3278bb4e7be4895c1c597434e5269f7357ffb800ebc644f0398bb008a15ad"
 
 [[package]]
 name = "xous-susres"
+version = "0.1.15"
+dependencies = [
+ "log",
+ "num-derive",
+ "num-traits",
+ "rkyv",
+ "utralib",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-api-log",
+ "xous-api-names",
+ "xous-api-susres",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "xous-ticktimer"
 version = "0.1.14"
 dependencies = [
  "log",
@@ -4876,28 +4892,12 @@ dependencies = [
  "num-traits",
  "rkyv",
  "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "xous-api-log",
- "xous-api-names",
- "xous-api-susres",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "xous-ticktimer"
-version = "0.1.13"
-dependencies = [
- "log",
- "num-derive",
- "num-traits",
- "rkyv",
- "utralib",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
  "xous-api-susres",
  "xous-api-ticktimer",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-semver",
 ]
 
@@ -4911,9 +4911,9 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rkyv",
- "xous 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-names",
- "xous-ipc 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-ipc 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/api/xous-api-log/Cargo.toml
+++ b/api/xous-api-log/Cargo.toml
@@ -3,15 +3,15 @@ authors = ["Sean Cross <sean@xobs.io>"]
 description = "Log server API"
 edition = "2018"
 name = "xous-api-log"
-version = "0.1.13"
+version = "0.1.14"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/betrusted-io/xous-core/"
 homepage = "https://betrusted.io/xous-book/"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-xous-ipc = "0.9.19"
+xous = "0.9.20"
+xous-ipc = "0.9.20"
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}

--- a/api/xous-api-names/Cargo.toml
+++ b/api/xous-api-names/Cargo.toml
@@ -3,16 +3,16 @@ authors = ["bunnie <bunnie@kosagi.com>"]
 description = "Xous microkernel OS inter-process name resolution server"
 edition = "2018"
 name = "xous-api-names"
-version = "0.9.14"
+version = "0.9.15"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/betrusted-io/xous-core/"
 homepage = "https://betrusted.io/"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-log-server = {package = "xous-api-log", version = "0.1.13"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
+log-server = {package = "xous-api-log", version = "0.1.14"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
 log = "0.4.14"

--- a/api/xous-api-susres/Cargo.toml
+++ b/api/xous-api-susres/Cargo.toml
@@ -22,9 +22,9 @@ rkyv = {version = "0.4.3", default-features = false, features = ["const_generics
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 sus_reboot = [] # when selected, suspend triggers an immediate reboot instead of suspend. For testing only.
 debugprint = []
 default = []

--- a/api/xous-api-susres/Cargo.toml
+++ b/api/xous-api-susres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xous-api-susres"
-version = "0.9.12"
+version = "0.9.13"
 authors = ["bunnie <bunnie@kosagi.com>"]
 edition = "2018"
 description = "Manager of suspend/resume operations"
@@ -10,10 +10,10 @@ homepage = "https://betrusted.io/xous-book/"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}

--- a/api/xous-api-ticktimer/Cargo.toml
+++ b/api/xous-api-ticktimer/Cargo.toml
@@ -3,18 +3,18 @@ authors = ["bunnie <bunnie@kosagi.com>", "Sean Cross <sean@xobs.io>"]
 description = "Provide high-resolution, non-rollover system time"
 edition = "2018"
 name = "xous-api-ticktimer"
-version = "0.9.12"
+version = "0.9.13"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/betrusted-io/xous-core/"
 homepage = "https://betrusted.io/xous-book/"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-log-server = {package = "xous-api-log", version = "0.1.13"}
-susres = {package = "xous-api-susres", version = "0.9.12"}
-xous-names = {package = "xous-api-names", version = "0.9.14"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+log-server = {package = "xous-api-log", version = "0.1.14"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
+xous-names = {package = "xous-api-names", version = "0.9.15"}
 log = "0.4.14"
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
 num-derive = {version = "0.3.3", default-features = false}

--- a/apps/ball/Cargo.toml
+++ b/apps/ball/Cargo.toml
@@ -10,11 +10,11 @@ description = "Ball demo app"
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 gam = {path = "../../services/gam" }
 trng = {path = "../../services/trng"}
 modals = {path = "../../services/modals"}

--- a/apps/hello/Cargo.toml
+++ b/apps/hello/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 gam = {path = "../../services/gam" }
 graphics-server = {path = "../../services/graphics-server" }
 locales = {path = "../../locales"}

--- a/apps/mtxcli/Cargo.toml
+++ b/apps/mtxcli/Cargo.toml
@@ -10,11 +10,11 @@ description = "Matrix chat"
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 gam = {path = "../../services/gam" }
 graphics-server = {path = "../../services/graphics-server" }
 trng = {path = "../../services/trng"}

--- a/apps/repl/Cargo.toml
+++ b/apps/repl/Cargo.toml
@@ -10,11 +10,11 @@ description = "REPL demo app"
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 gam = {path = "../../services/gam" }
 graphics-server = {path = "../../services/graphics-server" }
 trng = {path = "../../services/trng"}

--- a/apps/vault/Cargo.toml
+++ b/apps/vault/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2018"
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
+xous = "0.9.20"
+xous-ipc = "0.9.20"
 rkyv = {version = "0.4.3", features = ["const_generics"], default-features = false}
-log-server = { package = "xous-api-log", version = "0.1.13" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+log-server = { package = "xous-api-log", version = "0.1.14" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 gam = {path = "../../services/gam" }
 graphics-server = {path = "../../services/graphics-server" }
 locales = {path = "../../locales"}
@@ -21,7 +21,7 @@ usbd-human-interface-device = "0.2.1"
 pddb = {path = "../../services/pddb" }
 modals = {path = "../../services/modals" }
 trng = {path="../../services/trng"}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 ime-plugin-api = {path = "../../services/ime-plugin-api"}
 content-plugin-api = {path = "../../services/content-plugin-api"} # all content canvas providers must provide this API
 ctap-crypto = {path = "libraries/crypto"}
@@ -31,7 +31,7 @@ byteorder = { version = "1.4.3", default-features = false }
 arrayref = "0.3.6"
 subtle = { version = "2.2.3", default-features = false, features = ["nightly"] }
 rand_core = "0.6.3"
-ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.12"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.13"}
 
 # ux formatting
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }

--- a/apps/vault/libraries/crypto/Cargo.toml
+++ b/apps/vault/libraries/crypto/Cargo.toml
@@ -14,7 +14,7 @@ cbor = { path = "../cbor" }
 arrayref = "0.3.6"
 subtle = { version = "2.2.3", default-features = false}
 trng = {path = "../../../../services/trng"}
-xous-names = {package = "xous-api-names", version = "0.9.14"}
+xous-names = {package = "xous-api-names", version = "0.9.15"}
 rand_core = "0.6.3"
 p256 = {version = "0.10.1", default-features = false, features = ["ecdsa", "ecdh", "std"]}
 cbc = "0.1.2"

--- a/imports/getrandom/Cargo.toml
+++ b/imports/getrandom/Cargo.toml
@@ -30,9 +30,9 @@ js-sys = { version = "0.3", optional = true }
 wasm-bindgen-test = "0.3.18"
 
 [target.'cfg(target_os = "xous")'.dependencies]
-xous-names = {package = "xous-api-names", version = "0.9.14"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
 
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -28,7 +28,7 @@ riscv = { version = "0.5.6", package = "xous-riscv" } # source is in "../imports
 [features]
 precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous-kernel/renode"]
+renode = ["utralib/renode"]
 
 debug-print = []
 gdb-stub = []

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -26,9 +26,10 @@ xous-kernel = { package = "xous", version = "0.9.19", features = [
 riscv = { version = "0.5.6", package = "xous-riscv" } # source is in "../imports/riscv-0.5.6"
 
 [features]
-precursor = ["utralib/precursor", "xous-kernel/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
 renode = ["utralib/renode", "xous-kernel/renode"]
+
 debug-print = []
 gdb-stub = []
 print-panics = []

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -4,20 +4,20 @@ description = "Core kernel for Xous, including task switching and memory managem
 license = "MIT OR Apache-2.0"
 edition = "2018"
 name = "xous-kernel"
-version = "0.9.12"
+version = "0.9.13"
 resolver = "2"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
 bitflags = "1.2.1"
 stats_alloc = { version = "0.1.8", optional = true }
-xous-kernel = { package = "xous", version = "0.9.19", features = [
+xous-kernel = { package = "xous", version = "0.9.20", features = [
     "forget-memory-messages",
 ] }
 utralib = { version = "0.1.7", optional = true, default_features = false }
 
 [target.'cfg(any(windows,unix))'.dev-dependencies]
-xous-kernel = { package = "xous", version = "0.9.19", features = [
+xous-kernel = { package = "xous", version = "0.9.20", features = [
     "forget-memory-messages",
     "processes-as-threads",
 ] }

--- a/services/aes-test/Cargo.toml
+++ b/services/aes-test/Cargo.toml
@@ -8,9 +8,9 @@ version = "0.1.0"
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
 log = "0.4.14"
-log-server = {package = "xous-api-log", version = "0.1.13"}
+log-server = {package = "xous-api-log", version = "0.1.14"}
 hex-literal = "0.3.1"
-xous = "0.9.19"
+xous = "0.9.20"
 
 [features]
 default = []

--- a/services/aes/Cargo.toml
+++ b/services/aes/Cargo.toml
@@ -7,8 +7,8 @@ description = "AES library for Xous"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
 log = "0.4.14"
 hex-literal = "0.3.1"
 cipher = "0.4.2"

--- a/services/codec/Cargo.toml
+++ b/services/codec/Cargo.toml
@@ -7,16 +7,16 @@ description = "Audio CODEC server"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 llio = {path = "../llio"}
 trng = {path = "../trng"}
 
-xous-ipc = "0.9.19"
+xous-ipc = "0.9.20"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}

--- a/services/codec/Cargo.toml
+++ b/services/codec/Cargo.toml
@@ -24,7 +24,7 @@ rkyv = {version = "0.4.3", default-features = false, features = ["const_generics
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 default = []

--- a/services/com/Cargo.toml
+++ b/services/com/Cargo.toml
@@ -30,9 +30,9 @@ utralib = {version = "0.1.7", optional = true, default-features = false }
 [target.'cfg(any(windows,unix))'.dependencies]
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = []
 default = [] # "debugprint"
 fccagent = []

--- a/services/com/Cargo.toml
+++ b/services/com/Cargo.toml
@@ -9,13 +9,13 @@ version = "0.1.0"
 [dependencies]
 com_rs-ref = {path = "../../imports/com_rs-ref"}
 log = "0.4.14"
-log-server = {package = "xous-api-log", version = "0.1.13"}
-ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.12"}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+log-server = {package = "xous-api-log", version = "0.1.14"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.13"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 typenum = "1.12"
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
 trng = {path = "../trng"}
 llio = {path = "../llio"}
 

--- a/services/content-plugin-api/Cargo.toml
+++ b/services/content-plugin-api/Cargo.toml
@@ -7,9 +7,9 @@ description = "Content Canvas Plugin Common APIs"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
+xous = "0.9.20"
 rkyv = { version = "0.4.3", default_features = false }
 graphics-server = { path="../graphics-server"} # this is used by the IMEF portion of the API
-xous-names = {package = "xous-api-names", version = "0.9.14"} # used by the IMEF for registering listeners
+xous-names = {package = "xous-api-names", version = "0.9.15"} # used by the IMEF for registering listeners
 log = "0.4.14"
 

--- a/services/dns/Cargo.toml
+++ b/services/dns/Cargo.toml
@@ -7,15 +7,15 @@ description = "Xous DNS resolver"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
 net = {path = "../net"}
-xous-ipc = "0.9.19"
+xous-ipc = "0.9.20"
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
 trng = {path = "../trng"}
 

--- a/services/dns/Cargo.toml
+++ b/services/dns/Cargo.toml
@@ -22,7 +22,7 @@ trng = {path = "../trng"}
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 default = []

--- a/services/engine-25519/Cargo.toml
+++ b/services/engine-25519/Cargo.toml
@@ -7,16 +7,16 @@ description = "Curve25519 Engine"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 llio =  {path = "../llio"} # temporary for testing some power stuff
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
-xous-ipc = "0.9.19"
+xous-ipc = "0.9.20"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}

--- a/services/engine-25519/Cargo.toml
+++ b/services/engine-25519/Cargo.toml
@@ -28,7 +28,7 @@ default-features = false
 features = []
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 default = []

--- a/services/engine-sha512/Cargo.toml
+++ b/services/engine-sha512/Cargo.toml
@@ -7,15 +7,15 @@ description = "Sha512 hardware accelerator engine"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 trng = { path = "../trng" }
 
-xous-ipc = "0.9.19"
+xous-ipc = "0.9.20"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}

--- a/services/engine-sha512/Cargo.toml
+++ b/services/engine-sha512/Cargo.toml
@@ -28,8 +28,8 @@ opaque-debug = "0.3.0" # prevents internal hash state leakage from debug structu
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 event_wait = [] # in theory, event_wait should be more efficient, but the OS overhead is greater than the computation.
 default = []

--- a/services/ffi-test/Cargo.toml
+++ b/services/ffi-test/Cargo.toml
@@ -7,14 +7,14 @@ description = "FFI test integration"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 ffi-sys = {path = "sys"}
 keyboard = {path = "../keyboard"}
 

--- a/services/ffi-test/Cargo.toml
+++ b/services/ffi-test/Cargo.toml
@@ -21,7 +21,7 @@ keyboard = {path = "../keyboard"}
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 default = []

--- a/services/gam/Cargo.toml
+++ b/services/gam/Cargo.toml
@@ -14,18 +14,18 @@ ime-plugin-api = {path = "../ime-plugin-api"}
 ime-plugin-shell = {path = "../ime-plugin-shell"}
 keyboard = {path = "../keyboard"}
 log = "0.4.14"
-log-server = {package = "xous-api-log", version = "0.1.13"}
-ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.12"}
+log-server = {package = "xous-api-log", version = "0.1.14"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.13"}
 trng = {path = "../trng"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
 
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
 
-susres = {package = "xous-api-susres", version = "0.9.12"} # used for the sleep now menu item
+susres = {package = "xous-api-susres", version = "0.9.13"} # used for the sleep now menu item
 
 enum_dispatch = "0.3.7" # used for trait-based dispatch off of multiple layout objects.
 locales = {path = "../../locales"}

--- a/services/gam/Cargo.toml
+++ b/services/gam/Cargo.toml
@@ -44,9 +44,9 @@ digest = "0.9.0"
 utralib = {version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = []
 tts = []
 # default = ["debugprint"] # "debugprint"

--- a/services/graphics-server/Cargo.toml
+++ b/services/graphics-server/Cargo.toml
@@ -26,9 +26,9 @@ utralib = {version = "0.1.7", optional = true, default-features = false }
 minifb = "0.23.0"
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = []
 braille = []
 gfx-testing = []

--- a/services/graphics-server/Cargo.toml
+++ b/services/graphics-server/Cargo.toml
@@ -9,13 +9,13 @@ version = "0.1.0"
 [dependencies]
 keyboard = {path = "../keyboard"}
 log = "0.4.14"
-log-server = {package = "xous-api-log", version = "0.1.13"}
-xous = "0.9.19"
-susres = {package = "xous-api-susres", version = "0.9.12"}
-ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.12"}
+log-server = {package = "xous-api-log", version = "0.1.14"}
+xous = "0.9.20"
+susres = {package = "xous-api-susres", version = "0.9.13"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.13"}
 
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}

--- a/services/ime-frontend/Cargo.toml
+++ b/services/ime-frontend/Cargo.toml
@@ -28,9 +28,9 @@ tts-frontend = {path="../tts"}
 utralib = {version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 tts = []
 debugprint = []
 default = [] # "debugprint"

--- a/services/ime-frontend/Cargo.toml
+++ b/services/ime-frontend/Cargo.toml
@@ -12,12 +12,12 @@ graphics-server = {path = "../graphics-server"}
 ime-plugin-api = {path = "../ime-plugin-api"}
 keyboard = {path = "../keyboard"}
 log = "0.4.14"
-log-server = {package = "xous-api-log", version = "0.1.13"}
-ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.12"}
-xous = "0.9.19"
+log-server = {package = "xous-api-log", version = "0.1.14"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.13"}
+xous = "0.9.20"
 locales = {path = "../../locales"}
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
 
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}

--- a/services/ime-plugin-api/Cargo.toml
+++ b/services/ime-plugin-api/Cargo.toml
@@ -9,9 +9,9 @@ version = "0.1.0"
 [dependencies]
 graphics-server = {path = "../graphics-server"}# this is used by the IMEF portion of the API
 log = "0.4.14"
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}# used by the IMEF for registering listeners
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}# used by the IMEF for registering listeners
 
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}

--- a/services/ime-plugin-shell/Cargo.toml
+++ b/services/ime-plugin-shell/Cargo.toml
@@ -22,8 +22,8 @@ rkyv = {version = "0.4.3", default-features = false, features = ["const_generics
 utralib = {version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = []
 default = [] # "debugprint"

--- a/services/ime-plugin-shell/Cargo.toml
+++ b/services/ime-plugin-shell/Cargo.toml
@@ -9,11 +9,11 @@ version = "0.1.0"
 [dependencies]
 ime-plugin-api = {path = "../ime-plugin-api"}
 log = "0.4.14"
-log-server = {package = "xous-api-log", version = "0.1.13"}
-ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.12"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}
+log-server = {package = "xous-api-log", version = "0.1.14"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.13"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
 
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}

--- a/services/ime-plugin-tts/Cargo.toml
+++ b/services/ime-plugin-tts/Cargo.toml
@@ -25,8 +25,8 @@ locales = {path = "../../locales"}
 utralib = {version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = []
 default = [] # "debugprint"

--- a/services/ime-plugin-tts/Cargo.toml
+++ b/services/ime-plugin-tts/Cargo.toml
@@ -9,11 +9,11 @@ version = "0.1.0"
 [dependencies]
 ime-plugin-api = {path = "../ime-plugin-api"}
 log = "0.4.14"
-log-server = {package = "xous-api-log", version = "0.1.13"}
-ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.12"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}
+log-server = {package = "xous-api-log", version = "0.1.14"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.13"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
 
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}

--- a/services/jtag/Cargo.toml
+++ b/services/jtag/Cargo.toml
@@ -7,16 +7,16 @@ description = "JTAG port server"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 
-xous-ipc = "0.9.19"
+xous-ipc = "0.9.20"
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
 
 utralib = { version = "0.1.7", optional = true, default-features = false }

--- a/services/jtag/Cargo.toml
+++ b/services/jtag/Cargo.toml
@@ -22,8 +22,8 @@ rkyv = {version = "0.4.3", default-features = false, features = ["const_generics
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 hazardous-debug = []
 default = ["hazardous-debug"]

--- a/services/kernel-test/Cargo.toml
+++ b/services/kernel-test/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.14"
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 default = []

--- a/services/kernel-test/Cargo.toml
+++ b/services/kernel-test/Cargo.toml
@@ -7,9 +7,9 @@ description = "Program to test various aspects of the kernel"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
 log = "0.4.14"
 
 utralib = { version = "0.1.7", optional = true, default-features = false }

--- a/services/keyboard/Cargo.toml
+++ b/services/keyboard/Cargo.toml
@@ -8,13 +8,13 @@ version = "0.1.0"
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
 log = {version = "0.4", features = ["max_level_trace", "release_max_level_trace"]}
-log-server = {package = "xous-api-log", version = "0.1.13"}
-ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.12"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}
+log-server = {package = "xous-api-log", version = "0.1.14"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.13"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
 llio = {path = "../llio"}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 spinor = {path = "../spinor"}
 
 num-derive = {version = "0.3.3", default-features = false}

--- a/services/keyboard/Cargo.toml
+++ b/services/keyboard/Cargo.toml
@@ -24,9 +24,9 @@ rkyv = {version = "0.4.3", default-features = false, features = ["const_generics
 utralib = {version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = []
 debuginject = [] # used only if you want key injection via the UART
 rawserial = []

--- a/services/libstd-test/Cargo.toml
+++ b/services/libstd-test/Cargo.toml
@@ -7,10 +7,10 @@ description = "libstd test stub"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}

--- a/services/libstd-test/Cargo.toml
+++ b/services/libstd-test/Cargo.toml
@@ -21,7 +21,7 @@ com = {path = "../com"}
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 default = []

--- a/services/llio/Cargo.toml
+++ b/services/llio/Cargo.toml
@@ -34,9 +34,9 @@ chrono = "0.4.19"
 "chrono" = "0.4.19"
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = []
 wfi_off = [] # useful for serial port debugging, forces power on so the UART characters can finish printing
 tts = []

--- a/services/llio/Cargo.toml
+++ b/services/llio/Cargo.toml
@@ -8,12 +8,12 @@ version = "0.1.0"
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
 log = "0.4.14"
-log-server = {package = "xous-api-log", version = "0.1.13"}
-ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.12"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+log-server = {package = "xous-api-log", version = "0.1.14"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.13"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 
 # RTC dependencies
 bitflags = "1.2.1"

--- a/services/log-test-client/Cargo.toml
+++ b/services/log-test-client/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
+xous = "0.9.20"
 
 [features]
 default = []

--- a/services/modals/Cargo.toml
+++ b/services/modals/Cargo.toml
@@ -7,14 +7,14 @@ description = "Ux modals server"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-xous-ipc = "0.9.19"
+xous-ipc = "0.9.20"
 rkyv = {version = "0.4.3", features = ["const_generics"], default-features = false}
 gam = {path="../gam"}
 trng = {path="../trng"}

--- a/services/modals/Cargo.toml
+++ b/services/modals/Cargo.toml
@@ -25,9 +25,9 @@ bit_field = "0.9.0"
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 tts = []
 ditherpunk = []
 default = []

--- a/services/net/Cargo.toml
+++ b/services/net/Cargo.toml
@@ -7,15 +7,15 @@ description = "Network middleware"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 #rkyv = "0.7.18"
 rkyv = {version = "0.4.3", features = ["const_generics"], default-features = false}
 llio = {path = "../llio"}

--- a/services/net/Cargo.toml
+++ b/services/net/Cargo.toml
@@ -50,8 +50,8 @@ features = [
 ]
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 renode-minimal = []
 default = []

--- a/services/pddb/Cargo.toml
+++ b/services/pddb/Cargo.toml
@@ -8,15 +8,15 @@ description = "Plausibly Deniable Database"
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
 bitflags = {version = "1"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 rkyv = {version = "0.4.3", features = ["const_generics"], default-features = false}
 trng = {path = "../trng"}
 spinor = {path = "../spinor"}

--- a/services/pddb/Cargo.toml
+++ b/services/pddb/Cargo.toml
@@ -57,9 +57,9 @@ rand_chacha = "0.3.1"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"], optional = true }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 # when selected, physical disk addresses are set to 64 bits, otherwise, they are 32 bits.
 # 32 bit addressing is recommended for Precursor, as its disk is only 128MiB and it has limited RAM for bookkeeping.
 u64_pa = []

--- a/services/root-keys/Cargo.toml
+++ b/services/root-keys/Cargo.toml
@@ -7,12 +7,12 @@ description = "Xous root keys server"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 trng = {path= "../trng"}
 spinor = {path="../spinor"}
 llio = {path="../llio"}
@@ -20,7 +20,7 @@ com = {path="../com"}
 xous-semver = "0.1.2"
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
-xous-ipc = "0.9.19"
+xous-ipc = "0.9.20"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}

--- a/services/root-keys/Cargo.toml
+++ b/services/root-keys/Cargo.toml
@@ -75,9 +75,9 @@ default-features = false
 features = ["u32_backend", "rand"]
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 policy-menu = [] # provisions for users to set their password retention policies (on the block for deprecation) (note: to re-enable you need to add "rootkeys menu" to the tokens.rs in the GAM)
 hazardous-debug = []  # this feature enables the printing of secret materials for debug purposes
 tts = []

--- a/services/shellchat/Cargo.toml
+++ b/services/shellchat/Cargo.toml
@@ -16,13 +16,13 @@ ime-plugin-shell = {path = "../ime-plugin-shell"}
 ime-plugin-tts = {path = "../ime-plugin-tts"}
 llio = {path = "../llio"}
 log = "0.4.14"
-log-server = {package = "xous-api-log", version = "0.1.13"}
-ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.12"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}
+log-server = {package = "xous-api-log", version = "0.1.14"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.13"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
 keyboard = {path = "../keyboard"}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 codec = {path = "../codec"}
 #engine-sha512 = {path="../engine-sha512"}
 sha2 = {path="../engine-sha512"}

--- a/services/shellchat/Cargo.toml
+++ b/services/shellchat/Cargo.toml
@@ -106,9 +106,9 @@ default-features = false
 features = ["u32_backend", "rand"]
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = []
 spinortest = [] # for spinor testing. contra-indicated with PDDB, as it steals memory from the PDDB.
 benchmarks = [] # adds the benchmark routines. Left off normally to free up code and memory space.

--- a/services/skeleton/Cargo.toml
+++ b/services/skeleton/Cargo.toml
@@ -19,7 +19,7 @@ susres = {package = "xous-api-susres", version = "0.9.12"}
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 default = []

--- a/services/skeleton/Cargo.toml
+++ b/services/skeleton/Cargo.toml
@@ -7,14 +7,14 @@ description = "Audio CODEC server"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 
 utralib = { version = "0.1.7", optional = true, default-features = false }
 

--- a/services/spinor/Cargo.toml
+++ b/services/spinor/Cargo.toml
@@ -7,18 +7,18 @@ description = "SPINOR ROM operations server"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 trng = { path = "../trng" }
 com = { path = "../com" }
 llio = { path = "../llio" }
 
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
-xous-ipc = "0.9.19"
+xous-ipc = "0.9.20"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
 

--- a/services/spinor/Cargo.toml
+++ b/services/spinor/Cargo.toml
@@ -29,9 +29,9 @@ lazy_static = "1.4.0"
 rand = "0.7.3"
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 extra_flush = []
 default = ["extra_flush"]
 

--- a/services/status/Cargo.toml
+++ b/services/status/Cargo.toml
@@ -48,9 +48,9 @@ utralib = {version = "0.1.7", optional = true, default-features = false }
 chrono = "0.4.19"
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = []
 braille = [] # used for braille mode, so console isn't overwhelmed with status
 tts = []

--- a/services/status/Cargo.toml
+++ b/services/status/Cargo.toml
@@ -10,17 +10,17 @@ version = "0.1.0"
 com = {path = "../com"}
 content-plugin-api = {path = "../content-plugin-api"}
 log = "0.4.14"
-log-server = {package = "xous-api-log", version = "0.1.13"}
-ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.12"}
+log-server = {package = "xous-api-log", version = "0.1.14"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.13"}
 trng = {path = "../trng"}
 llio = {path = "../llio"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
 graphics-server = {path = "../graphics-server"}
 gam = {path = "../gam"}
 locales = {path = "../../locales"}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 root-keys = {path = "../root-keys"}
 modals = {path = "../modals"}
 pddb = {path = "../pddb"}

--- a/services/test-spawn/Cargo.toml
+++ b/services/test-spawn/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-xous = "0.9.19"
+xous = "0.9.20"

--- a/services/test-spawn/spawn/Cargo.toml
+++ b/services/test-spawn/spawn/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-xous = "0.9.19"
+xous = "0.9.20"

--- a/services/trng/Cargo.toml
+++ b/services/trng/Cargo.toml
@@ -25,9 +25,9 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = []
 avalanchetest = []
 ringosctest = []

--- a/services/trng/Cargo.toml
+++ b/services/trng/Cargo.toml
@@ -7,16 +7,16 @@ description = "TRNG server"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
-xous-ipc = "0.9.19"
+xous-ipc = "0.9.20"
 
 utralib = { version = "0.1.7", optional = true, default-features = false }
 

--- a/services/tts/Cargo.toml
+++ b/services/tts/Cargo.toml
@@ -23,8 +23,8 @@ codec = {path = "../codec"}
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 tts = []
 default = []

--- a/services/tts/Cargo.toml
+++ b/services/tts/Cargo.toml
@@ -7,11 +7,11 @@ description = "Text to speech integration server"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}

--- a/services/usb-device-xous/Cargo.toml
+++ b/services/usb-device-xous/Cargo.toml
@@ -7,17 +7,17 @@ description = "Xous USB device drivers"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 llio = {path="../llio"}
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 modals = {path = "../modals"}
 keyboard = {path = "../keyboard"}
 bitfield = "0.13.2"

--- a/services/usb-device-xous/Cargo.toml
+++ b/services/usb-device-xous/Cargo.toml
@@ -40,8 +40,8 @@ rand = "0.7.3"
 rand_chacha = "0.3.1"
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 mjolnir = [] # the big hammer for debugging Spinal USB issues. A raw memory dump of config and descriptor space. Use with care.
 default = []

--- a/services/usb-test/Cargo.toml
+++ b/services/usb-test/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.7.3"
 rand_chacha = "0.3.1"
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 default = []

--- a/services/usb-test/Cargo.toml
+++ b/services/usb-test/Cargo.toml
@@ -7,14 +7,14 @@ description = "USB test & development stub"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
-log-server = { package = "xous-api-log", version = "0.1.13" }
-ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.12" }
-xous-names = { package = "xous-api-names", version = "0.9.14" }
+xous = "0.9.20"
+log-server = { package = "xous-api-log", version = "0.1.14" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.13" }
+xous-names = { package = "xous-api-names", version = "0.9.15" }
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 keyboard = {path = "../keyboard"}
 bitfield = "0.13.2"
 vcell = "0.1.3"

--- a/services/xous-log/Cargo.toml
+++ b/services/xous-log/Cargo.toml
@@ -3,16 +3,16 @@ authors = ["Sean Cross <sean@xobs.io>"]
 description = "Log output program"
 edition = "2018"
 name = "xous-log"
-version = "0.1.10"
+version = "0.1.11"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/betrusted-io/xous-core/"
 homepage = "https://betrusted.io/xous-book/"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous-api-log = {package = "xous-api-log", version = "0.1.13"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
+xous-api-log = {package = "xous-api-log", version = "0.1.14"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
 log = "0.4.14"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}

--- a/services/xous-log/Cargo.toml
+++ b/services/xous-log/Cargo.toml
@@ -20,9 +20,9 @@ num-traits = {version = "0.2.14", default-features = false}
 utralib = {version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = [] # adding this allocates the UART for debugging the logger
 logging = [] # adding this allocates the hardware UART for console interactions
 #default = []

--- a/services/xous-names/Cargo.toml
+++ b/services/xous-names/Cargo.toml
@@ -3,17 +3,17 @@ authors = ["bunnie <bunnie@kosagi.com>"]
 description = "Xous microkernel OS inter-process name resolution server"
 edition = "2018"
 name = "xous-names"
-version = "0.9.18"
+version = "0.9.19"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/betrusted-io/xous-core/"
 homepage = "https://betrusted.io/"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous-api-names = "0.9.14"
-log-server = {package = "xous-api-log", version = "0.1.13"}
-xous = "0.9.19"
-xous-ipc = "0.9.19"
+xous-api-names = "0.9.15"
+log-server = {package = "xous-api-log", version = "0.1.14"}
+xous = "0.9.20"
+xous-ipc = "0.9.20"
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}
 log = "0.4.14"

--- a/services/xous-names/Cargo.toml
+++ b/services/xous-names/Cargo.toml
@@ -24,8 +24,8 @@ utralib = {version = "0.1.7", optional = true, default-features = false }
 [target.'cfg(any(windows,unix))'.dependencies]
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 debugprint = []
 default = [] # "debugprint"

--- a/services/xous-susres/Cargo.toml
+++ b/services/xous-susres/Cargo.toml
@@ -25,9 +25,9 @@ rkyv = {version = "0.4.3", default-features = false, features = ["const_generics
 utralib = { version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 sus_reboot = [] # when selected, suspend triggers an immediate reboot instead of suspend. For testing only.
 debugprint = []
 default = []

--- a/services/xous-susres/Cargo.toml
+++ b/services/xous-susres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xous-susres"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["bunnie <bunnie@kosagi.com>"]
 edition = "2018"
 description = "Manager of suspend/resume operations implementation"
@@ -10,11 +10,11 @@ homepage = "https://betrusted.io/xous-book/"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous-api-susres = "0.9.12"
-xous-names = { package = "xous-api-names", version = "0.9.14" }
-log-server = { package = "xous-api-log", version = "0.1.13" }
-xous = "0.9.19"
-xous-ipc = "0.9.19"
+xous-api-susres = "0.9.13"
+xous-names = { package = "xous-api-names", version = "0.9.15" }
+log-server = { package = "xous-api-log", version = "0.1.14" }
+xous = "0.9.20"
+xous-ipc = "0.9.20"
 log = "0.4.14"
 
 num-derive = {version = "0.3.3", default-features = false}

--- a/services/xous-ticktimer/Cargo.toml
+++ b/services/xous-ticktimer/Cargo.toml
@@ -3,19 +3,19 @@ authors = ["bunnie <bunnie@kosagi.com>"]
 description = "Provide high-resolution, non-rollover system time"
 edition = "2018"
 name = "xous-ticktimer"
-version = "0.1.13"
+version = "0.1.14"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/betrusted-io/xous-core/"
 homepage = "https://betrusted.io/xous-book/"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous-api-ticktimer = "0.9.12"
-xous = "0.9.19"
-xous-ipc = "0.9.19"
-xous-names = {package = "xous-api-names", version = "0.9.14"}
-log-server = {package = "xous-api-log", version = "0.1.13"}
-susres = {package = "xous-api-susres", version = "0.9.12"}
+xous-api-ticktimer = "0.9.13"
+xous = "0.9.20"
+xous-ipc = "0.9.20"
+xous-names = {package = "xous-api-names", version = "0.9.15"}
+log-server = {package = "xous-api-log", version = "0.1.14"}
+susres = {package = "xous-api-susres", version = "0.9.13"}
 log = "0.4.14"
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
 num-derive = {version = "0.3.3", default-features = false}

--- a/services/xous-ticktimer/Cargo.toml
+++ b/services/xous-ticktimer/Cargo.toml
@@ -24,9 +24,9 @@ xous-semver = "0.1.2"
 utralib = {version = "0.1.7", optional = true, default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor", "susres/precursor"]
+precursor = ["utralib/precursor", "susres/precursor"]
 hosted = ["utralib/hosted", "susres/hosted"]
-renode = ["utralib/renode", "xous/renode", "susres/renode"]
+renode = ["utralib/renode", "susres/renode"]
 debug-print = []
 watchdog = []
 timestamp = []

--- a/tools/perflib/Cargo.toml
+++ b/tools/perflib/Cargo.toml
@@ -12,7 +12,7 @@ log = "0.4.14"
 utralib = { version = "0.1.7", default-features = false }
 
 [features]
-precursor = ["utralib/precursor", "xous/precursor"]
+precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
-renode = ["utralib/renode", "xous/renode"]
+renode = ["utralib/renode"]
 default = []

--- a/tools/perflib/Cargo.toml
+++ b/tools/perflib/Cargo.toml
@@ -7,7 +7,7 @@ description = "Performance counter tooling"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
+xous = "0.9.20"
 log = "0.4.14"
 utralib = { version = "0.1.7", default-features = false }
 

--- a/xous-ipc/Cargo.toml
+++ b/xous-ipc/Cargo.toml
@@ -4,12 +4,12 @@ description = "System call interface for Xous"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "xous-ipc"
-version = "0.9.19"
+version = "0.9.20"
 repository = "https://github.com/betrusted-io/xous-core/"
 homepage = "https://betrusted.io/"
 
 # Dependency versions enforced by Cargo.lock.
 [dependencies]
-xous = "0.9.19"
+xous = "0.9.20"
 bitflags = {version = "1"}
 rkyv = {version = "0.4.3", features = ["const_generics"], default-features = false}

--- a/xous-rs/Cargo.toml
+++ b/xous-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xous"
-version = "0.9.19"
+version = "0.9.20"
 authors = ["Sean Cross <sean@xobs.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/xous-rs/Cargo.toml
+++ b/xous-rs/Cargo.toml
@@ -16,11 +16,6 @@ compiler_builtins = { version = '0.1.0', optional = true }
 v2p = []
 default = []
 
-# various targets as features
-precursor = []
-hosted = []
-renode = []
-
 # alternative language targets. Only one may be specified at a time
 lang-ja = []
 lang-zh = []

--- a/xous-rs/build.rs
+++ b/xous-rs/build.rs
@@ -6,18 +6,7 @@ use std::path::PathBuf;
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let target = env::var("TARGET").unwrap();
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let name = env::var("CARGO_PKG_NAME").unwrap();
-
-    // If we're not running on a desktop-class operating system, emit the "baremetal"
-    // config setting. This will enable software to do tasks such as
-    // managing memory.
-    if target_os == "none" {
-        println!("Target {} is bare metal", target);
-        println!("cargo:rustc-cfg=baremetal");
-    } else {
-        println!("Target {} is NOT bare metal", target);
-    }
 
     if target.starts_with("riscv") {
         fs::copy(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -117,12 +117,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // packages located on crates.io. For testing non-local build configs that are less
     // concerned about software supply chain and more focused on developer convenience.
     let base_pkgs_remote = [
-        "xous-log@0.1.10",         // "well known" service: debug logging
-        "xous-names@0.9.18",      // "well known" service: manage inter-server connection lookup
-        "xous-susres@0.1.14",     // ticktimer registers with susres to coordinate time continuity across sleeps
-        "xous-ticktimer@0.1.13",   // "well known" service: thread scheduling
+        "xous-log@0.1.11",         // "well known" service: debug logging
+        "xous-names@0.9.19",      // "well known" service: manage inter-server connection lookup
+        "xous-susres@0.1.15",     // ticktimer registers with susres to coordinate time continuity across sleeps
+        "xous-ticktimer@0.1.14",   // "well known" service: thread scheduling
     ].to_vec();
-    let xous_kernel_remote = "xous-kernel@0.9.12";
+    let xous_kernel_remote = "xous-kernel@0.9.13";
 
     // ---- extract position independent args ----
     let lkey = get_flag("--lkey")?;

--- a/xtask/src/verifier.rs
+++ b/xtask/src/verifier.rs
@@ -10,20 +10,20 @@ use crate::DynError;
 pub fn check_project_consistency() -> Result<(), DynError> {
     let check_pkgs = [
         // this set updates with kernel API changes
-        "xous@0.9.19",
-        "xous-kernel@0.9.12",
-        "xous-ipc@0.9.19",
-        "xous-api-log@0.1.13",
-        "xous-api-names@0.9.14",
-        "xous-api-susres@0.9.12",
-        "xous-api-ticktimer@0.9.12",
-        "xous-log@0.1.10",
-        "xous-names@0.9.18",
-        "xous-susres@0.1.14",
-        "xous-ticktimer@0.1.13",
+        "xous@0.9.20",
+        "xous-kernel@0.9.13",
+        "xous-ipc@0.9.20",
+        "xous-api-log@0.1.14",
+        "xous-api-names@0.9.15",
+        "xous-api-susres@0.9.13",
+        "xous-api-ticktimer@0.9.13",
+        "xous-log@0.1.11",
+        "xous-names@0.9.19",
+        "xous-susres@0.1.15",
+        "xous-ticktimer@0.1.14",
         // this set is only updated if the utralib changes
-        "utralib@0.1.7",
-        "svd2utra@0.1.5",
+        "utralib@0.1.8",
+        "svd2utra@0.1.6",
     ];
     for pkg in check_pkgs {
         verify(pkg.into())?;

--- a/xtask/src/verifier.rs
+++ b/xtask/src/verifier.rs
@@ -22,8 +22,8 @@ pub fn check_project_consistency() -> Result<(), DynError> {
         "xous-susres@0.1.15",
         "xous-ticktimer@0.1.14",
         // this set is only updated if the utralib changes
-        "utralib@0.1.8",
-        "svd2utra@0.1.6",
+        "utralib@0.1.7",
+        "svd2utra@0.1.5",
     ];
     for pkg in check_pkgs {
         verify(pkg.into())?;


### PR DESCRIPTION
Following #252 made this to reduce some feature selection code.

Mainly to make `xous-rs` only have architecture specific code and not device specific, so that crates can depend on it without specifying features.

Also removed the `target_os` detection code as it's not used.