### PR TITLE
RemoveClockEntry -> TryRemoveClockEntry

### DIFF
--- a/emulation/peripherals/BetrustedEcI2C.cs
+++ b/emulation/peripherals/BetrustedEcI2C.cs
@@ -171,7 +171,7 @@ namespace Antmicro.Renode.Peripherals.I2C.Betrusted
         private void FinishTransaction()
         {
             // this.Log(LogLevel.Error, "I2C: Removing clock entry for {0}",this.irqTimeoutCallback);
-            machine.ClockSource.RemoveClockEntry(FinishTransaction);
+            machine.ClockSource.TryRemoveClockEntry(FinishTransaction);
             irqTimeoutCallbackQueued = 0;
             if (shouldSendTxRxIrq)
             {

--- a/emulation/peripherals/BetrustedSocI2C.cs
+++ b/emulation/peripherals/BetrustedSocI2C.cs
@@ -162,7 +162,7 @@ namespace Antmicro.Renode.Peripherals.I2C.Betrusted
 
         private void FinishTransaction()
         {
-            machine.ClockSource.RemoveClockEntry(FinishTransaction);
+            machine.ClockSource.TryRemoveClockEntry(FinishTransaction);
             if (shouldSendTxRxIrq)
             {
                 shouldSendTxRxIrq = false;


### PR DESCRIPTION
fixes #262 

The change is needed to run with Renode 1.13.2. I didn't dig which exact version the change happened on the Renode side -- a quick search in the release notes showed nothing.