### PR TITLE
feat: show boot process notifications for PDDB

### DIFF
--- a/services/gam/src/contexts.rs
+++ b/services/gam/src/contexts.rs
@@ -330,6 +330,7 @@ impl ContextManager {
         token: [u32; 4],
         clear: bool,
     ) -> Result<(), xous::Error> {
+        //log::set_max_level(log::LevelFilter::Trace);
         self.notify_app_switch(token).ok();
 
         let mut leaving_visibility: bool = false;
@@ -483,6 +484,7 @@ impl ContextManager {
                 self.redraw().expect("couldn't redraw the currently focused app");
             }
         }
+        //log::set_max_level(log::LevelFilter::Info);
         Ok(())
     }
     pub(crate) fn set_pred_api_token(&mut self, at: ApiToken) {

--- a/services/gam/src/layouts/modal.rs
+++ b/services/gam/src/layouts/modal.rs
@@ -8,7 +8,7 @@ use graphics_server::*;
 use crate::{LayoutApi, LayoutBehavior};
 
 use crate::contexts::MISC_CONTEXT_DEFAULT_TRUST;
-const TRUST_OFFSET: u8 = 1;
+const TRUST_OFFSET: u8 = 16;
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct ModalLayout {

--- a/services/graphics-server/src/api.rs
+++ b/services/graphics-server/src/api.rs
@@ -119,6 +119,9 @@ pub(crate) enum Opcode {
     /// SuspendResume callback
     SuspendResume,
 
+    /// draw the boot logo (for continuity as apps initialize)
+    DrawBootLogo,
+
     Quit,
 }
 

--- a/services/graphics-server/src/backend/betrusted.rs
+++ b/services/graphics-server/src/backend/betrusted.rs
@@ -68,7 +68,6 @@ impl XousDisplay {
         display
             .susres
             .push(RegOrField::Field(utra::memlcd::PRESCALER_PRESCALER), None);
-        display.sync_clear();
 
         /*
         use log::{error, info};
@@ -255,6 +254,7 @@ impl XousDisplay {
 
     /// "synchronous clear" -- must be called on init, so that the state of the LCD
     /// internal memory is consistent with the state of the frame buffer
+    /*
     fn sync_clear(&mut self) {
         let framebuffer = self.fb.as_mut_ptr() as *mut u32;
         for words in 0..FB_SIZE {
@@ -267,6 +267,7 @@ impl XousDisplay {
         self.update_all(); // because we force an all update here
         while self.busy() {}
     }
+    */
 
     fn busy(&self) -> bool {
         self.csr.rf(utra::memlcd::BUSY_BUSY) == 1

--- a/services/graphics-server/src/lib.rs
+++ b/services/graphics-server/src/lib.rs
@@ -108,6 +108,14 @@ impl Gfx {
         .map(|_| ())
     }
 
+    pub fn draw_boot_logo(&self) -> Result<(), xous::Error> {
+        send_message(
+            self.conn,
+            Message::new_scalar(Opcode::DrawBootLogo.to_usize().unwrap(), 0, 0, 0, 0),
+        )
+        .map(|_| ())
+    }
+
     pub fn screen_size(&self) -> Result<Point, xous::Error> {
         let response = send_message(
             self.conn,

--- a/services/graphics-server/src/main.rs
+++ b/services/graphics-server/src/main.rs
@@ -112,6 +112,7 @@ fn wrapped_main() -> ! {
     log::info!("my PID is {}", xous::process::id());
 
     let mut display = XousDisplay::new();
+    draw_boot_logo(&mut display); // bring this up as soon as possible
     let fontregion = map_fonts();
 
     // install the graphical panic handler. It won't catch really early panics, or panics in this crate,
@@ -138,8 +139,6 @@ fn wrapped_main() -> ! {
     let sid = xns
         .register_name(api::SERVER_NAME_GFX, Some(1))
         .expect("can't register server");
-
-    draw_boot_logo(&mut display);
 
     let screen_clip = Rectangle::new(Point::new(0, 0), display.screen_size());
 
@@ -456,6 +455,11 @@ fn wrapped_main() -> ! {
                 }),
                 Some(Opcode::DrawSleepScreen) => msg_scalar_unpack!(msg, _, _, _, _, {
                     display.blit_screen(&logo::LOGO_MAP);
+                    display.update();
+                    display.redraw();
+                }),
+                Some(Opcode::DrawBootLogo) => msg_scalar_unpack!(msg, _, _, _, _, {
+                    display.blit_screen(&poweron::LOGO_MAP);
                     display.update();
                     display.redraw();
                 }),

--- a/services/pddb/locales/i18n.json
+++ b/services/pddb/locales/i18n.json
@@ -13,6 +13,13 @@
         "ja": "パスワードを認証失敗でした。\n\nもう一度実行しください。",
         "zh": "密码错误。"
     },
+    "pddb.waitmount": {
+        "en": "Mounting PDDB, please wait...",
+        "en-tts": "Mounting PDDB, please wait...",
+        "fr": "Montage de PDDB, veuillez patienter...*MT*",
+        "ja": "PDDB をマウントしています。お待ちください...",
+        "zh": "正在挂载 PDDB，请稍候..."
+    },
     "pddb.basisname": {
         "en": "Basis Name:",
         "en-tts": "Enter name of Basis",

--- a/services/shellchat/locales/i18n.json
+++ b/services/shellchat/locales/i18n.json
@@ -12,5 +12,12 @@
         "fr": "",
         "ja": "",
         "zh": ""
+    },
+    "shellchat.bootwait": {
+        "en": "Please wait...",
+        "en-tts": "Please wait...",
+        "fr": "S'il vous plaît, attendez*MT*",
+        "ja": "お待ちください...",
+        "zh": "请稍等..."
     }
 }

--- a/services/shellchat/src/main.rs
+++ b/services/shellchat/src/main.rs
@@ -426,7 +426,11 @@ fn wrapped_main() -> ! {
         let main_conn = xous::connect(shch_sid).unwrap();
         move || {
             let tt = ticktimer_server::Ticktimer::new().unwrap();
-            tt.sleep_ms(500).ok(); // give some time for the system to finish booting
+            let xns = xous_names::XousNames::new().unwrap();
+            let gam = gam::Gam::new(&xns).unwrap();
+            while !gam.trusted_init_done().unwrap() {
+                tt.sleep_ms(50).ok();
+            }
             loop {
                 let (no_retry_failure, count) = pddb::Pddb::new().try_mount();
                 pddb_init_done.store(true, Ordering::SeqCst);

--- a/services/shellchat/src/main.rs
+++ b/services/shellchat/src/main.rs
@@ -32,12 +32,17 @@ Check for more detailed docs under Modules/cmds "Shell Chat" below
 use log::info;
 
 use core::fmt::Write;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use gam::UxRegistration;
 use graphics_server::{Gid, Point, Rectangle, TextBounds, TextView, DrawStyle, PixelColor};
 use graphics_server::api::GlyphStyle;
 use xous::MessageEnvelope;
 use xous_ipc::Buffer;
+
+use locales::t;
+use std::thread;
+use std::sync::Arc;
 
 #[doc = include_str!("../README.md")]
 mod cmds;
@@ -202,7 +207,7 @@ impl Repl{
     }
 
     /// update the loop, in response to various inputs
-    fn update(&mut self, was_callback: bool) -> Result<(), xous::Error> {
+    fn update(&mut self, was_callback: bool, init_done: bool) -> Result<(), xous::Error> {
         let debug1 = false;
         // if we had an input string, do something
         if let Some(local) = &self.input {
@@ -219,7 +224,7 @@ impl Repl{
 
         // redraw UI once upon accepting all input
         if !was_callback { // don't need to redraw on a callback, save some cycles
-            self.redraw().expect("can't redraw");
+            self.redraw(init_done).expect("can't redraw");
         }
 
         let mut dirty = true;
@@ -265,7 +270,7 @@ impl Repl{
         self.msg = None;
         // redraw UI now that we've responded
         if dirty {
-            self.redraw().expect("can't redraw");
+            self.redraw(init_done).expect("can't redraw");
         }
 
         if debug1 {
@@ -286,9 +291,27 @@ impl Repl{
             }
         )).expect("can't clear content area");
     }
-    fn redraw(&mut self) -> Result<(), xous::Error> {
+    fn redraw(&mut self, init_done: bool) -> Result<(), xous::Error> {
         log::trace!("going into redraw");
         self.clear_area();
+
+        if !init_done {
+            let mut init_tv = TextView::new(
+                self.content,
+                TextBounds::CenteredTop(
+                    Rectangle::new(
+                        Point::new(0, self.screensize.y / 3 - 64),
+                        Point::new(self.screensize.x, self.screensize.y / 3)
+                    )
+                )
+            );
+            init_tv.style = GlyphStyle::Bold;
+            init_tv.draw_border = false;
+            write!(init_tv.text, "{}", t!("shellchat.bootwait", xous::LANG)).ok();
+            self.gam.post_textview(&mut init_tv).expect("couldn't render wait text");
+            self.gam.redraw().expect("couldn't redraw screen");
+            return Ok(())
+        }
 
         // this defines the bottom border of the text bubbles as they stack up wards
         let mut bubble_baseline = self.screensize.y - self.margin.y;
@@ -393,8 +416,53 @@ fn wrapped_main() -> ! {
     let mut was_callback = false;
 
     let mut allow_redraw = true;
-    log::trace!("starting main loop");
+    let pddb_init_done = Arc::new(AtomicBool::new(false));
 
+    // spawn a thread to auto-mount the PDDB. It's important that this spawn happens after
+    // our GAM context has been registered (which happened in the `Repl::new()` call above)
+    repl.redraw(false).ok();
+    let _ = thread::spawn({
+        let pddb_init_done = pddb_init_done.clone();
+        let main_conn = xous::connect(shch_sid).unwrap();
+        move || {
+            let tt = ticktimer_server::Ticktimer::new().unwrap();
+            tt.sleep_ms(500).ok(); // give some time for the system to finish booting
+            loop {
+                let (no_retry_failure, count) = pddb::Pddb::new().try_mount();
+                pddb_init_done.store(true, Ordering::SeqCst);
+                if no_retry_failure {
+                    // this includes both successfully mounted, and user abort of mount attempt
+                    break;
+                } else {
+                    // this indicates system was guttered due to a retry failure
+                    let xns = xous_names::XousNames::new().unwrap();
+                    let susres = susres::Susres::new_without_hook(&xns).unwrap();
+                    let llio = llio::Llio::new(&xns);
+                    if ((llio.adc_vbus().unwrap() as u32) * 503) < 150_000 {
+                        // try to force suspend if possible, so that users who are just playing around with
+                        // the device don't run the battery down accidentally.
+                        susres.initiate_suspend().ok();
+                        tt.sleep_ms(1000).unwrap();
+                        let modals = modals::Modals::new(&xns).unwrap();
+                        modals.show_notification(
+                            &t!("login.fail", xous::LANG).replace("{fails}", &count.to_string()),
+                            None
+                        ).ok();
+                    } else {
+                        // otherwise force a reboot cycle to slow down guessers
+                        susres.reboot(true).expect("Couldn't reboot after too many failed password attempts");
+                        tt.sleep_ms(5000).unwrap();
+                    }
+                }
+            }
+            tt.sleep_ms(100).ok(); // this allows the shellchat context to foreground before calling the redraw
+            xous::send_message(main_conn,
+                xous::Message::new_scalar(ShellOpcode::Redraw.to_usize().unwrap(), 0, 0, 0, 0)
+            ).ok();
+        }
+    });
+
+    log::trace!("starting main loop");
     #[cfg(feature = "autobasis-ci")]
     {
         log::info!("starting autobasis CI launcher");
@@ -420,7 +488,7 @@ fn wrapped_main() -> ! {
             }
             Some(ShellOpcode::Redraw) => {
                 if allow_redraw {
-                    repl.redraw().expect("REPL couldn't redraw");
+                    repl.redraw(pddb_init_done.load(Ordering::SeqCst)).expect("REPL couldn't redraw");
                 }
             }
             Some(ShellOpcode::ChangeFocus) => xous::msg_scalar_unpack!(msg, new_state_code, _, _, _, {
@@ -446,7 +514,7 @@ fn wrapped_main() -> ! {
             }
         }
         if update_repl {
-            repl.update(was_callback).expect("REPL had problems updating");
+            repl.update(was_callback, pddb_init_done.load(Ordering::SeqCst)).expect("REPL had problems updating");
             update_repl = false;
         }
         log::trace!("reached bottom of main loop");

--- a/services/status/src/main.rs
+++ b/services/status/src/main.rs
@@ -633,41 +633,6 @@ fn wrapped_main() -> ! {
     #[cfg(any(feature="precursor", feature="renode"))]
     llio.clear_wakeup_alarm().unwrap(); // this is here to clear any wake-up alarms that were set by a prior coldboot command
 
-    // spawn a thread to auto-mount the PDDB
-    let _ = thread::spawn({
-        move || {
-            let tt = ticktimer_server::Ticktimer::new().unwrap();
-            tt.sleep_ms(2000).unwrap(); // a brief pause, to allow the other startup bits to finish running
-            loop {
-                let (no_retry_failure, count) = pddb::Pddb::new().try_mount();
-                if no_retry_failure {
-                    // this includes both successfully mounted, and user abort of mount attempt
-                    break;
-                } else {
-                    // this indicates system was guttered due to a retry failure
-                    let xns = xous_names::XousNames::new().unwrap();
-                    let susres = susres::Susres::new_without_hook(&xns).unwrap();
-                    let llio = llio::Llio::new(&xns);
-                    if ((llio.adc_vbus().unwrap() as u32) * 503) < 150_000 {
-                        // try to force suspend if possible, so that users who are just playing around with
-                        // the device don't run the battery down accidentally.
-                        susres.initiate_suspend().ok();
-                        tt.sleep_ms(1000).unwrap();
-                        let modals = modals::Modals::new(&xns).unwrap();
-                        modals.show_notification(
-                            &t!("login.fail", xous::LANG).replace("{fails}", &count.to_string()),
-                            None
-                        ).ok();
-                    } else {
-                        // otherwise force a reboot cycle to slow down guessers
-                        susres.reboot(true).expect("Couldn't reboot after too many failed password attempts");
-                        tt.sleep_ms(5000).unwrap();
-                    }
-                }
-            }
-        }
-    });
-
     pump_run.store(true, Ordering::Relaxed); // start status thread updating
     loop {
         let msg = xous::receive_message(status_sid).unwrap();


### PR DESCRIPTION
This commit shows two notifications:
 1. as soon as the device boots, a notification greets the user and tells them everything is fine, the device is booting
 2. as soon as the user enters (or doesn't) enter the password, a notification tell the user Xous is loading and mounting PDDB

I spent too much time on this but I believe it's a nice UX improvement.