### PR TITLE
Add TryConnect call to xous-names

### DIFF
--- a/api/xous-api-names/src/api.rs
+++ b/api/xous-api-names/src/api.rs
@@ -52,6 +52,34 @@ pub enum Opcode {
     /// }
     /// ```
     BlockingConnect = 6,
+
+    /// Connect to a Server, returning the connection ID or an authentication request if
+    /// it exists, and returning ServerNotFound if it does not exist.
+    ///
+    /// # Message Types
+    ///
+    ///     * MutableLend
+    ///
+    /// # Arguments
+    ///
+    /// The memory being pointed to should be a &str, and the length of the string should
+    /// be specified in the `valid` field.
+    ///
+    /// # Return Values
+    ///
+    /// Memory is overwritten to contain a return value.  This return value can be defined
+    /// as the following enum:
+    ///
+    /// ```rust
+    /// #[repr(C)]
+    /// #[non_exhaustive]
+    /// enum ConnectResult {
+    ///     Success(xous::CID /* connection ID */, [u32; 4] /* Disconnection token */),
+    ///     Error(u32 /* error code */),
+    ///     Unhandled, /* Catchall for future Results */
+    /// }
+    /// ```
+    TryConnect = 7,
 }
 
 #[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]

--- a/services/xous-names/src/main.rs
+++ b/services/xous-names/src/main.rs
@@ -26,6 +26,9 @@ enum ConnectError {
 
     /// The message was not a mutable memory message
     InvalidMessageType = 4,
+
+    /// The server does not currently exist, and a blocking request was made
+    ServerNotFound = 5,
 }
 
 #[derive(PartialEq)]
@@ -464,7 +467,7 @@ fn main() -> ! {
                     xous::return_scalar(msg.sender, 0).unwrap();
                 }
             }),
-            Some(api::Opcode::BlockingConnect) => {
+            Some(api::Opcode::BlockingConnect) | Some(api::Opcode::TryConnect) => {
                 if !msg.body.is_blocking() {
                     continue;
                 }
@@ -479,9 +482,13 @@ fn main() -> ! {
                         respond_connect_success(msg, cid, disc)
                     }
                     Ok(ConnectSuccess::Wait) => {
-                        // Push waiting connections here, which will prevent it from getting
-                        // dropped and responded to.
-                        waiting_connections.push(msg);
+                        if msg.body.id() == api::Opcode::TryConnect as usize {
+                            respond_connect_error(msg, ConnectError::ServerNotFound);
+                        } else {
+                            // Push waiting connections here, which will prevent it from getting
+                            // dropped and responded to.
+                            waiting_connections.push(msg);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This patchset adds a nonblocking `TryConnect` API call to the name server. This will be used in places such as libstd where the panic routine will attempt to connect to the graphics server and will omit graphical panics if it is not available.