### PR TITLE
feat: user interaction-enabled slider

### DIFF
--- a/services/gam/src/modal.rs
+++ b/services/gam/src/modal.rs
@@ -116,6 +116,14 @@ impl TextEntryPayload {
 }
 
 #[derive(Debug, Copy, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct SliderPayload(pub u32);
+impl SliderPayload {
+    pub fn new(value: u32) -> Self {
+        SliderPayload(value)
+    }
+}
+
+#[derive(Debug, Copy, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct RadioButtonPayload(pub ItemName); // returns the name of the item corresponding to the radio button selection
 impl RadioButtonPayload {
     pub fn new(name: &str) -> Self {

--- a/services/gam/src/modal/slider.rs
+++ b/services/gam/src/modal/slider.rs
@@ -47,6 +47,11 @@ impl Slider {
             show_legend,
         }
     }
+
+    pub fn set_is_progressbar(&mut self, setting: bool) {
+        self.is_progressbar = setting;
+    } 
+
     pub fn set_is_password(&mut self, setting: bool) {
         // this will cause text to be inverted. Untrusted entities can try to set this,
         // but the GAM should defeat this for dialog boxes outside of the trusted boot
@@ -194,8 +199,11 @@ impl ActionApi for Slider {
                     gam.relinquish_focus().unwrap();
                     xous::yield_slice();
 
-                    send_message(self.action_conn,
-                        xous::Message::new_scalar(self.action_opcode as usize, self.action_payload as usize, 0, 0, 0)).expect("couldn't pass on action payload");
+                    let ret_payload = SliderPayload(self.action_payload);
+
+                    let buf = Buffer::into_buf(ret_payload).expect("couldn't convert message to payload");
+                    buf.send(self.action_conn, self.action_opcode).map(|_| ()).expect("couldn't send action message");
+
                     return None;
                 }
                 _ => {

--- a/services/modals/src/api.rs
+++ b/services/modals/src/api.rs
@@ -69,6 +69,8 @@ pub struct ManagedProgress {
     pub end_work: u32,
     /// current quanta of work. Used to int the bar, updates are just a scalar with the same value.
     pub current_work: u32,
+    /// can user interact with it?
+    pub user_interaction: bool,
 }
 
 /// This isn't a terribly useful notification -- it's basically read-only, no interactivity,
@@ -98,6 +100,8 @@ pub(crate) enum Opcode {
     Bip39 = 31, // ---- note op number
     Bip39Input = 32, // ----- note op number
     Bip39Return = 33, // ----- note op number
+    SliderReturn = 34,
+    Slider = 35,
     /// display an image
     #[cfg(feature = "ditherpunk")]
     Image = 3,


### PR DESCRIPTION
This commit adds `modals::Modals::slider()` with the same interface as `modals::Modals::start_progress()`, with the striking difference that
users can move the slider, and press the center keypad button to confirm the selection.

 Useful for objects like audio volume controls.