### PR TITLE
A "copy" subcommand for shellchat pddb

### DIFF
--- a/services/shellchat/src/cmds/pddb_cmd.rs
+++ b/services/shellchat/src/cmds/pddb_cmd.rs
@@ -158,6 +158,21 @@ impl<'a> ShellCmdApi<'a> for PddbCmd {
                     }
                 }
                 "copy" => {
+                    if let Some(srcdescriptor) = tokens.next() {
+                        if let Some(dstdescriptor) = tokens.next() {
+                            write!(ret, "Will copy from {} to {}", srcdescriptor, dstdescriptor).ok();
+                            match std::fs::copy(srcdescriptor, dstdescriptor) {
+                                Ok(result) => {
+                                    write!(ret, "Copy from {} to {} succeeded", srcdescriptor, dstdescriptor).ok();
+                                }
+                                Err(e) => {
+                                    write!(ret, "Error copying from {} to {}: {:?}", srcdescriptor, dstdescriptor, e).ok();
+                                }
+                            }
+                        }
+                    }
+                }
+                "copy2" => {
                     if let Some(descriptor) = tokens.next() {
                         if let Some((dict, keyname)) = descriptor.split_once(':') {
                             match self.pddb.get(dict, keyname, None,

--- a/services/shellchat/src/cmds/pddb_cmd.rs
+++ b/services/shellchat/src/cmds/pddb_cmd.rs
@@ -54,9 +54,9 @@ impl<'a> ShellCmdApi<'a> for PddbCmd {
     fn process(&mut self, args: String::<1024>, _env: &mut CommonEnv) -> Result<Option<String::<1024>>, xous::Error> {
         let mut ret = String::<1024>::new();
         #[cfg(not(feature="pddbtest"))]
-        let helpstring = "pddb [basislist] [basiscreate] [basisunlock] [basislock] [basisdelete] [default]\n[dictlist] [keylist] [query] [dictdelete] [keydelete] [churn] [flush] [sync]";
+        let helpstring = "pddb [basislist] [basiscreate] [basisunlock] [basislock] [basisdelete] [default]\n[dictlist] [keylist] [write] [query] [copy] [dictdelete] [keydelete] [churn] [flush] [sync]";
         #[cfg(feature="pddbtest")]
-        let helpstring = "pddb [basislist] [basiscreate] [basisunlock] [basislock] [basisdelete] [default]\n[dictlist] [keylist] [query] [dictdelete] [keydelete] [churn] [flush] [sync]\n[test]";
+        let helpstring = "pddb [basislist] [basiscreate] [basisunlock] [basislock] [basisdelete] [default]\n[dictlist] [keylist] [write] [query] [copy] [dictdelete] [keydelete] [churn] [flush] [sync]\n[test]";
 
         let mut tokens = args.as_str().unwrap().split(' ');
         if let Some(sub_cmd) = tokens.next() {

--- a/services/shellchat/src/cmds/pddb_cmd.rs
+++ b/services/shellchat/src/cmds/pddb_cmd.rs
@@ -161,7 +161,7 @@ impl<'a> ShellCmdApi<'a> for PddbCmd {
                     if let Some(srcdescriptor) = tokens.next() {
                         if let Some(dstdescriptor) = tokens.next() {
                             match std::fs::copy(srcdescriptor, dstdescriptor) {
-                                Ok(result) => {
+                                Ok(_result) => {
                                     write!(ret, "Copy from {} to {} succeeded", srcdescriptor, dstdescriptor).ok();
                                 }
                                 Err(e) => {

--- a/services/shellchat/src/cmds/pddb_cmd.rs
+++ b/services/shellchat/src/cmds/pddb_cmd.rs
@@ -157,6 +157,67 @@ impl<'a> ShellCmdApi<'a> for PddbCmd {
                         write!(ret, "Missing query of form 'dict:key'").unwrap();
                     }
                 }
+                "copy" => {
+                    if let Some(descriptor) = tokens.next() {
+                        if let Some((dict, keyname)) = descriptor.split_once(':') {
+                            match self.pddb.get(dict, keyname, None,
+                                false, false, None, None::<fn()>) {
+                                Ok(mut key) => {
+                                    let mut readbuf = [0u8; 512]; // up to the first 512 chars of the key
+                                    match key.read(&mut readbuf) {
+                                        Ok(len) => {
+                                            match std::string::String::from_utf8(readbuf[..len].to_vec()) {
+                                                Ok(val) => {
+                                                    if let Some(descriptor) = tokens.next() {
+                                                        if let Some((dict, keyname)) = descriptor.split_once(':') {
+                                                            match self.pddb.get(dict, keyname, None,
+                                                                true, true, Some(256), None::<fn()>) {
+                                                                Ok(mut key) => {
+                                                                    if val.len() > 0 {
+                                                                        match key.write(&val.as_bytes()[..val.len()]) {
+                                                                            Ok(len) => {
+                                                                                self.pddb.sync().ok();
+                                                                                write!(ret, "Copied {} bytes to {}:{}", len, dict, keyname).ok();
+                                                                            }
+                                                                            Err(e) => {
+                                                                                write!(ret, "Error writing {}:{}: {:?}", dict, keyname, e).ok();
+                                                                            }
+                                                                        }
+                                                                    } else {
+                                                                        write!(ret, "Created an empty key {}:{}", dict, keyname).ok();
+                                                                    }
+                                                                }
+                                                                _ => write!(ret, "{}:{} not found or other error", dict, keyname).unwrap()
+                                                            }
+                                                        } else {
+                                                            write!(ret, "Query is of form 'dict:key'").unwrap();
+                                                        }
+                                                    } else {
+                                                        write!(ret, "Missing query of form 'dict:key'").unwrap();
+                                                    }
+                                                }
+                                                _ => {
+                                                    for &b in readbuf[..len].iter() {
+                                                        match write!(ret, "{:02x} ", b) {
+                                                            Ok(_) => (),
+                                                            Err(_) => break, // we can overflow our return buffer returning hex chars
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        _ => write!(ret, "Error encountered reading {}:{}", dict, keyname).unwrap()
+                                    }
+                                }
+                                _ => write!(ret, "{}:{} not found or other error", dict, keyname).unwrap()
+                            }
+                        } else {
+                            write!(ret, "Query is of form 'dict:key'").unwrap();
+                        }
+                    } else {
+                        write!(ret, "Missing query of form 'dict:key'").unwrap();
+                    }
+                }
                 "write" => {
                     if let Some(descriptor) = tokens.next() {
                         if let Some((dict, keyname)) = descriptor.split_once(':') {

--- a/services/shellchat/src/cmds/pddb_cmd.rs
+++ b/services/shellchat/src/cmds/pddb_cmd.rs
@@ -160,8 +160,8 @@ impl<'a> ShellCmdApi<'a> for PddbCmd {
                 "copy" => {
                     if let Some(srcdescriptor) = tokens.next() {
                         if let Some(dstdescriptor) = tokens.next() {
-                            if let Some((_srcdict, _srckeyname)) = srcdescriptor.split_once(':') {
-                                if let Some((_dstdict, _dstkeyname)) = dstdescriptor.split_once(':') {
+                            if let Some((_srcdict, _srckeyname)) = srcdescriptor.split_once(std::path::MAIN_SEPARATOR) {
+                                if let Some((_dstdict, _dstkeyname)) = dstdescriptor.split_once(std::path::MAIN_SEPARATOR) {
                                     match std::fs::copy(srcdescriptor, dstdescriptor) {
                                         Ok(_result) => {
                                             write!(ret, "Copy from {} to {} succeeded", srcdescriptor, dstdescriptor).ok();
@@ -171,10 +171,10 @@ impl<'a> ShellCmdApi<'a> for PddbCmd {
                                         }
                                     }
                                 } else {
-                                    write!(ret, "Destination {} is not of required form 'dict:key'", dstdescriptor).unwrap();
+                                    write!(ret, "Destination {} is not of required form 'dict{}key'", dstdescriptor, std::path::MAIN_SEPARATOR).unwrap();
                                 }
                             } else {
-                                write!(ret, "Source {} is not of required form 'dict:key'", srcdescriptor).unwrap();
+                                write!(ret, "Source {} is not of required form 'dict{}key'", srcdescriptor, std::path::MAIN_SEPARATOR).unwrap();
                             }
                         } else {
                             write!(ret, "Usage is copy 'dict:key' 'dict:key' (missing destination)").unwrap();

--- a/services/shellchat/src/cmds/pddb_cmd.rs
+++ b/services/shellchat/src/cmds/pddb_cmd.rs
@@ -160,15 +160,27 @@ impl<'a> ShellCmdApi<'a> for PddbCmd {
                 "copy" => {
                     if let Some(srcdescriptor) = tokens.next() {
                         if let Some(dstdescriptor) = tokens.next() {
-                            match std::fs::copy(srcdescriptor, dstdescriptor) {
-                                Ok(_result) => {
-                                    write!(ret, "Copy from {} to {} succeeded", srcdescriptor, dstdescriptor).ok();
+                            if let Some((_srcdict, _srckeyname)) = srcdescriptor.split_once(':') {
+                                if let Some((_dstdict, _dstkeyname)) = dstdescriptor.split_once(':') {
+                                    match std::fs::copy(srcdescriptor, dstdescriptor) {
+                                        Ok(_result) => {
+                                            write!(ret, "Copy from {} to {} succeeded", srcdescriptor, dstdescriptor).ok();
+                                        }
+                                        Err(e) => {
+                                            write!(ret, "Error copying from {} to {}: {:?}", srcdescriptor, dstdescriptor, e).ok();
+                                        }
+                                    }
+                                } else {
+                                    write!(ret, "Destination {} is not of required form 'dict:key'", dstdescriptor).unwrap();
                                 }
-                                Err(e) => {
-                                    write!(ret, "Error copying from {} to {}: {:?}", srcdescriptor, dstdescriptor, e).ok();
-                                }
+                            } else {
+                                write!(ret, "Source {} is not of required form 'dict:key'", srcdescriptor).unwrap();
                             }
+                        } else {
+                            write!(ret, "Usage is copy 'dict:key' 'dict:key' (missing destination)").unwrap();
                         }
+                    } else {
+                        write!(ret, "Usage is copy 'dict:key' 'dict:key' (missing source)").unwrap();
                     }
                 }
                 "write" => {


### PR DESCRIPTION
* Adds a "copy" subcommand to the shellchat pddb command.
* Lists "copy" (and "write") in the help for the pddb command.