### PR TITLE
Reply and receive next syscall

### DIFF
--- a/api/xous-api-ticktimer/src/api.rs
+++ b/api/xous-api-ticktimer/src/api.rs
@@ -1,4 +1,5 @@
 /// Do not modify the discriminants in this structure. They are used in `libstd` directly.
+#[repr(usize)]
 #[derive(num_derive::FromPrimitive, num_derive::ToPrimitive, Debug)]
 pub enum Opcode {
     /// Get the elapsed time in milliseconds
@@ -48,9 +49,12 @@ pub enum Opcode {
     /// *arg1*: An integer of some sort, such as the address of the Condvar
     /// *arg2*: The number of conditions to notify
     NotifyCondition = 9,
+
+    /// Invalid call -- an error occurred decoding the opcode
+    InvalidCall = u32::MAX as usize,
 }
 
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct VersionString {
-    pub version: xous_ipc::String::<512>,
+    pub version: xous_ipc::String<512>,
 }

--- a/kernel/src/debug/shell.rs
+++ b/kernel/src/debug/shell.rs
@@ -36,12 +36,12 @@ impl fmt::Write for Output {
                 self.character_count = 0;
             } else if self.character_count > 80 {
                 self.character_count = 0;
-                self.uart.putc(b'\n');
-                self.uart.putc(b'\r');
-                self.uart.putc(b' ');
-                self.uart.putc(b' ');
-                self.uart.putc(b' ');
-                self.uart.putc(b' ');
+                self.serial.putc(b'\n');
+                self.serial.putc(b'\r');
+                self.serial.putc(b' ');
+                self.serial.putc(b' ');
+                self.serial.putc(b' ');
+                self.serial.putc(b' ');
             } else {
                 self.character_count += 1;
             }

--- a/kernel/src/server.rs
+++ b/kernel/src/server.rs
@@ -589,7 +589,7 @@ impl Server {
 
         // Sanity check the specified address was correct, and matches what we
         // had cached.
-        if is_memory && cfg!(baremetal) {
+        if is_memory && cfg!(baremetal) && buf.is_some() {
             let buf = buf.expect("memory message expected but no buffer passed!");
             if server_addr != buf.as_ptr() as usize || len != buf.len() {
                 // klog!("Memory is attached but the returned buffer doesn't match (len: {} vs {}), buf addr: {:08x} vs {:08x}", len, buf.len(), server_addr, buf.as_ptr() as usize);

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -199,7 +199,7 @@ fn send_message(pid: PID, thread: TID, cid: CID, message: Message) -> SysCallRes
                     ss.set_thread_result(
                         server_pid,
                         server_tid,
-                        xous_kernel::Result::Message(envelope),
+                        xous_kernel::Result::MessageEnvelope(envelope),
                     )
                     .expect("couldn't set result for server thread");
                     ss.activate_process_thread(thread, ppid, ptid, false)
@@ -209,7 +209,7 @@ fn send_message(pid: PID, thread: TID, cid: CID, message: Message) -> SysCallRes
                     // Switch to the server, since it's in a state to be run.
                     klog!("Activating Server context and switching away from Client");
                     ss.activate_process_thread(thread, server_pid, server_tid, false)
-                        .map(|_| Ok(xous_kernel::Result::Message(envelope)))
+                        .map(|_| Ok(xous_kernel::Result::MessageEnvelope(envelope)))
                         .unwrap_or(Err(xous_kernel::Error::ProcessNotFound))
                 }
             } else if blocking && !cfg!(baremetal) {
@@ -219,7 +219,7 @@ fn send_message(pid: PID, thread: TID, cid: CID, message: Message) -> SysCallRes
                 ss.set_thread_result(
                     server_pid,
                     server_tid,
-                    xous_kernel::Result::Message(envelope),
+                    xous_kernel::Result::MessageEnvelope(envelope),
                 )
                 .map(|_| xous_kernel::Result::BlockedProcess)
             } else if cfg!(baremetal) {
@@ -228,7 +228,7 @@ fn send_message(pid: PID, thread: TID, cid: CID, message: Message) -> SysCallRes
                 ss.set_thread_result(
                     server_pid,
                     server_tid,
-                    xous_kernel::Result::Message(envelope),
+                    xous_kernel::Result::MessageEnvelope(envelope),
                 )
                 .map(|_| xous_kernel::Result::Ok)
             } else {
@@ -242,7 +242,7 @@ fn send_message(pid: PID, thread: TID, cid: CID, message: Message) -> SysCallRes
                 ss.set_thread_result(
                     server_pid,
                     server_tid,
-                    xous_kernel::Result::Message(envelope),
+                    xous_kernel::Result::MessageEnvelope(envelope),
                 )
                 .map(|_| xous_kernel::Result::Ok)
             };
@@ -639,7 +639,7 @@ fn receive_message(pid: PID, tid: TID, sid: SID, blocking: ExecutionType) -> Sys
         // If there is a pending message, return it immediately.
         if let Some(msg) = server.take_next_message(sidx) {
             klog!("waiting messages found -- returning {:x?}", msg);
-            return Ok(xous_kernel::Result::Message(msg));
+            return Ok(xous_kernel::Result::MessageEnvelope(msg));
         }
 
         if blocking == ExecutionType::NonBlocking {

--- a/services/test-spawn/spawn/src/main.rs
+++ b/services/test-spawn/spawn/src/main.rs
@@ -32,7 +32,7 @@ fn handle_panic(_arg: &core::panic::PanicInfo) -> ! {
 pub extern "C" fn init(server1: u32, server2: u32, server3: u32, server4: u32) -> ! {
     let server = xous::SID::from_u32(server1, server2, server3, server4);
     loop {
-        if let Ok(xous::Result::Message(envelope)) =
+        if let Ok(xous::Result::MessageEnvelope(envelope)) =
             xous::rsyscall(xous::SysCall::ReceiveMessage(server))
         {
             match envelope.id().into() {

--- a/xous-rs/src/arch/hosted/mod.rs
+++ b/xous-rs/src/arch/hosted/mod.rs
@@ -233,7 +233,7 @@ fn read_next_syscall_result(
 
         // If the client is passing us memory, read bytes from the data, then
         // remap the addresses to function in our address space.
-        if let Result::Message(msg) = &mut response {
+        if let Result::MessageEnvelope(msg) = &mut response {
             match &mut msg.body {
                 crate::Message::Move(ref mut memory_message)
                 | crate::Message::Borrow(ref mut memory_message)

--- a/xous-rs/src/arch/test/mod.rs
+++ b/xous-rs/src/arch/test/mod.rs
@@ -757,7 +757,7 @@ fn _xous_syscall_result(ret: &mut Result, thread_id: TID, server_connection: &Se
         });
 
         // If the client is passing us memory, remap the array to our own space.
-        if let Result::Message(msg) = &mut response {
+        if let Result::MessageEnvelope(msg) = &mut response {
             match &mut msg.body {
                 crate::Message::Move(ref mut memory_message)
                 | crate::Message::Borrow(ref mut memory_message)

--- a/xous-rs/src/definitions.rs
+++ b/xous-rs/src/definitions.rs
@@ -421,7 +421,7 @@ pub enum Result {
     NewServerID(SID, CID),
 
     // 9
-    Message(MessageEnvelope),
+    MessageEnvelope(MessageEnvelope),
 
     // 10
     ThreadID(TID),
@@ -488,7 +488,7 @@ impl Result {
                 [6, s.0 as _, s.1 as _, s.2 as _, s.3 as _, 0, 0, 0]
             }
             Result::ConnectionID(cid) => [7, *cid as usize, 0, 0, 0, 0, 0, 0],
-            Result::Message(me) => {
+            Result::MessageEnvelope(me) => {
                 let me_enc = me.to_usize();
                 [
                     9, me_enc[0], me_enc[1], me_enc[2], me_enc[3], me_enc[4], me_enc[5], me_enc[6],
@@ -589,7 +589,7 @@ impl Result {
                     )),
                     _ => return Result::Error(Error::InternalError),
                 };
-                Result::Message(MessageEnvelope {
+                Result::MessageEnvelope(MessageEnvelope {
                     sender: MessageSender::from_usize(sender),
                     body: message,
                 })

--- a/xous-rs/src/definitions/messages/envelope.rs
+++ b/xous-rs/src/definitions/messages/envelope.rs
@@ -10,21 +10,15 @@ pub struct Envelope {
 
 impl Envelope {
     pub fn to_usize(&self) -> [usize; 7] {
-        let ret = match &self.body {
-            Message::MutableBorrow(m) => (0, m.to_usize()),
-            Message::Borrow(m) => (1, m.to_usize()),
-            Message::Move(m) => (2, m.to_usize()),
-            Message::Scalar(m) => (3, m.to_usize()),
-            Message::BlockingScalar(m) => (4, m.to_usize()),
-        };
+        let body_usize = self.body.to_usize();
         [
             self.sender.to_usize(),
-            ret.0,
-            ret.1[0],
-            ret.1[1],
-            ret.1[2],
-            ret.1[3],
-            ret.1[4],
+            body_usize[0],
+            body_usize[1],
+            body_usize[2],
+            body_usize[3],
+            body_usize[4],
+            body_usize[5],
         ]
     }
 

--- a/xous-rs/src/definitions/messages/mod.rs
+++ b/xous-rs/src/definitions/messages/mod.rs
@@ -210,6 +210,10 @@ impl Message {
         }
     }
 
+    pub fn is_scalar(&self) -> bool {
+        !self.has_memory()
+    }
+
     pub fn memory(&self) -> Option<&MemoryRange> {
         self.memory_message().map(|msg| &msg.buf)
     }

--- a/xous-rs/src/definitions/messages/mod.rs
+++ b/xous-rs/src/definitions/messages/mod.rs
@@ -264,6 +264,19 @@ impl Message {
             Message::Scalar(s) | Message::BlockingScalar(s) => s.id = id,
         }
     }
+
+    pub fn to_usize(&self) -> [usize; 6] {
+        let ret = match &*self {
+            Message::MutableBorrow(m) => (0, m.to_usize()),
+            Message::Borrow(m) => (1, m.to_usize()),
+            Message::Move(m) => (2, m.to_usize()),
+            Message::Scalar(m) => (3, m.to_usize()),
+            Message::BlockingScalar(m) => (4, m.to_usize()),
+        };
+        [
+            ret.0, ret.1[0], ret.1[1], ret.1[2], ret.1[3], ret.1[4],
+        ]
+    }
 }
 
 impl TryFrom<(usize, usize, usize, usize, usize, usize)> for Message {

--- a/xous-rs/src/definitions/messages/mod.rs
+++ b/xous-rs/src/definitions/messages/mod.rs
@@ -92,7 +92,7 @@ impl MemoryMessage {
 }
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
 /// A simple scalar message.  This is similar to a `move` message.
 pub struct ScalarMessage {
     pub id: MessageId,
@@ -239,6 +239,15 @@ impl Message {
         }
     }
 
+    pub fn scalar_message_mut(&mut self) -> Option<&mut ScalarMessage> {
+        match self {
+            Message::MutableBorrow(_)
+            | Message::Borrow(_)
+            | Message::Move(_)
+            | Message::Scalar(_) => None,
+            Message::BlockingScalar(scalar) => Some(scalar),
+        }
+    }
     pub(crate) fn message_type(&self) -> usize {
         match *self {
             Message::MutableBorrow(_) => 1,

--- a/xous-rs/src/syscall.rs
+++ b/xous-rs/src/syscall.rs
@@ -324,11 +324,14 @@ pub enum SysCall {
     ///
     /// # Returns
     ///
-    /// * **Ok**: The Scalar / Send message was successfully sent, or the Borrow has finished
+    /// * **Ok**: The Scalar / Send message was successfully sent
     /// * **Scalar1**: The Server returned a `Scalar1` value
     /// * **Scalar2**: The Server returned a `Scalar2` value
     /// * **Scalar5**: The Server returned a `Scalar5` value
     /// * **BlockedProcess**: In Hosted mode, the target process is now blocked
+    /// * **Message**: For Scalar messages, this includes the args as returned
+    ///                 by the server. For MemoryMessages, this will include
+    ///                 the Opcode, Offset, and Valid fields.
     ///
     /// # Errors
     ///
@@ -511,6 +514,7 @@ pub enum SysCall {
         usize,         /* arg2 (BlockingScalar) or the memory length (MemoryMesage) */
         usize,         /* arg3 (BlockingScalar) or the memory offset (MemoryMesage) */
         usize,         /* arg4 (BlockingScalar) or the memory valid (MemoryMesage) */
+        usize,         /* for BlockingScalars, indicates how many args are valid */
     ),
 
     /// This syscall does not exist. It captures all possible


### PR DESCRIPTION
This adds syscall #41: `ReplyAndReceiveNext`.

This syscall will respond to a message and then pull the next message out of the queue. This should improve latency. This was tested on hosted mode and in Renode.

As a demonstration, I've converted `xous-ticktimer` to use the new API.

Note that as part of this, `xous::Result::Message` got renamed to `xous::Result::MessageEnvelope`. This shouldn't affect anything.