### PR TITLE
Fix ReplyAndReceiveNext for hosted mode

### DIFF
--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -681,7 +681,7 @@ fn reply_and_receive_next(
                 #[cfg(baremetal)]
                 let src_virt = _server_addr.get() as _;
                 #[cfg(not(baremetal))]
-                let src_virt = arg1 as _; // TODO: Check this is correct on hosted mode
+                let src_virt = arg1 as _;
 
                 // Return the memory to the calling process
                 ss.return_memory(src_virt, pid, tid, client_addr.get() as _, len.get())?;
@@ -689,7 +689,10 @@ fn reply_and_receive_next(
                 MessageResponse {
                     pid,
                     tid,
-                    result: xous_kernel::Result::MemoryReturned(MemorySize::new(arg3), MemorySize::new(arg4)),
+                    result: xous_kernel::Result::MemoryReturned(
+                        MemorySize::new(arg3),
+                        MemorySize::new(arg4),
+                    ),
                 }
             }
             WaitingMessage::MovedMemory => {


### PR DESCRIPTION
With the introduction of `ReplyAndReceiveNext`, we now have a new way to return memory to a client.

Unfortunately, the underlying machinery wasn't updated to work with this new call, and as a result memory wasn't properly getting translated between processes.

Implement this so that memory now works.