### PR TITLE
WIP: Issue 287

### DIFF
--- a/apps/mtxcli/Cargo.toml
+++ b/apps/mtxcli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mtxcli"
-version = "0.1.0"
+version = "0.6.0"
 authors = ["bunnie <bunnie@kosagi.com>"]
 edition = "2018"
 description = "Matrix chat"

--- a/apps/mtxcli/locales/i18n.json
+++ b/apps/mtxcli/locales/i18n.json
@@ -20,6 +20,13 @@
         "ja": "シンプルなMTXCLIデモへようこそ",
         "zh": "简单的 mtxcli 演示活动"
     },
+    "mtxcli.heap.help": {
+        "en": "/heap",
+        "en-tts": "heap",
+        "fr": "/heap",
+        "ja": "/heap",
+        "zh": "/heap"
+    },
     "mtxcli.help.help": {
         "en": "/help [cmd]",
         "en-tts": "help [cmd]",

--- a/apps/mtxcli/src/cmds/heap.rs
+++ b/apps/mtxcli/src/cmds/heap.rs
@@ -1,0 +1,25 @@
+use crate::{ShellCmdApi,CommonEnv,heap_usage};
+use xous_ipc::String as XousString;
+use core::fmt::Write;
+
+#[derive(Debug)]
+pub struct Heap {
+}
+impl Heap {
+    pub fn new(_xns: &xous_names::XousNames) -> Self {
+        Heap {
+        }
+    }
+}
+
+impl<'a> ShellCmdApi<'a> for Heap {
+    cmd_api!(heap);
+
+    fn process(&mut self, _args: XousString::<1024>, _env: &mut CommonEnv) -> Result<Option<XousString::<1024>>, xous::Error> {
+        let mut ret = XousString::<1024>::new();
+        let heap = heap_usage();
+        write!(ret, "heap usage: {}", heap).unwrap();
+        log::info!("heap usage: {}", heap);
+        Ok(Some(ret))
+    }
+}

--- a/apps/mtxcli/src/cmds/help.rs
+++ b/apps/mtxcli/src/cmds/help.rs
@@ -30,6 +30,9 @@ impl<'a> ShellCmdApi<'a> for Help {
                 "get" => {
                     write!(ret, "{}", t!("mtxcli.get.help", xous::LANG)).unwrap();
                 }
+                "heap" => {
+                    write!(ret, "{}", t!("mtxcli.heap.help", xous::LANG)).unwrap();
+                }
                 "help" => {
                     write!(ret, "{}", t!("mtxcli.help.help", xous::LANG)).unwrap();
                 }
@@ -51,6 +54,7 @@ impl<'a> ShellCmdApi<'a> for Help {
                 "" => {
                     write!(ret, "{}\n", t!("mtxcli.help.overview", xous::LANG)).unwrap();
                     write!(ret, "{}\n", t!("mtxcli.get.help", xous::LANG)).unwrap();
+                    write!(ret, "{}\n", t!("mtxcli.heap.help", xous::LANG)).unwrap();
                     write!(ret, "{}\n", t!("mtxcli.help.help", xous::LANG)).unwrap();
                     write!(ret, "{}\n", t!("mtxcli.login.help", xous::LANG)).unwrap();
                     write!(ret, "{}\n", t!("mtxcli.logout.help", xous::LANG)).unwrap();

--- a/apps/mtxcli/src/cmds/migrations.rs
+++ b/apps/mtxcli/src/cmds/migrations.rs
@@ -1,0 +1,69 @@
+//! Migrations
+//!
+//! Runs migrations up to the current version
+
+use std::io::Error;
+use crate::cmds::{CommonEnv,VERSION_KEY};
+
+mod v0_9_11_0120;  use v0_9_11_0120::*;
+
+const DEFAULT_VERSION: &str = "0";
+
+pub trait MigrationApi<'a> {
+    // created with migration_api! macro
+    // returns my version
+    fn version(&self) -> &'static str;
+    // checks if the migration should be applied
+    fn applies(&self, version: &str) -> bool;
+    // run the migration
+    fn process(&self, common: &mut CommonEnv) -> Result<bool, Error>;
+}
+
+// the argument to this macro is the command verb
+#[macro_export]
+macro_rules! migration_api {
+    ($version:expr) => { // NOTE the expr will have literal quotes
+        fn version(&self) -> &'static str {
+            $version
+        }
+
+        fn applies(&self, version: &str) -> bool {
+            if version < self.version() {
+                true
+            } else {
+                false
+            }
+        }
+    };
+}
+
+/// Run migrations as needed
+pub fn run_migrations(common: &mut CommonEnv) {
+    let version = common.get_default(VERSION_KEY, DEFAULT_VERSION);
+    if version.ne(&common.version) {
+        log::info!("Running migrations from version {} to {}",
+                   version, common.version);
+        let mut migrations: Vec<Box<dyn MigrationApi>> = Vec::new();
+        migrations.push(Box::new(V0_9_11_0120::new()));
+        for migration in migrations.iter() {
+            if migration.applies(&version) {
+                match migration.process(common) {
+                    Ok(boolean) => {
+                        log::info!("migration competed: {}: {}",
+                                   migration.version(), boolean);
+                        if boolean {
+                            common.set(VERSION_KEY, migration.version())
+                                .expect("cannot set _version");
+                        }
+                    },
+                    Err(e) => {
+                        log::error!("error running migration: {}: {:?}",
+                                    migration.version(), e);
+                    }
+                }
+            }
+        }
+        common.set(VERSION_KEY, &common.version.clone())
+            .expect("cannot set _version");
+    }
+}

--- a/apps/mtxcli/src/cmds/migrations/v0_9_11_0120.rs
+++ b/apps/mtxcli/src/cmds/migrations/v0_9_11_0120.rs
@@ -1,0 +1,26 @@
+use std::io::Error;
+
+use crate::cmds::{CommonEnv,FILTER_KEY};
+use crate::cmds::migrations::MigrationApi;
+use crate::migration_api;
+
+#[derive(Debug)]
+pub struct V0_9_11_0120 {
+}
+impl V0_9_11_0120 {
+    pub fn new() -> Self {
+        V0_9_11_0120 {
+        }
+    }
+}
+
+impl<'a> MigrationApi<'a> for V0_9_11_0120 {
+    migration_api!("v0.9.11-0120");
+
+    fn process(&self, common: &mut CommonEnv) -> Result<bool, Error> {
+        log::info!("Running migration for: {}", self.version());
+        // we need to provoke the creation of a new/updated filter
+        common.unset(FILTER_KEY)?;
+        Ok(true)
+    }
+}


### PR DESCRIPTION

[screenlog.0.txt](https://github.com/betrusted-io/xous-core/files/10415951/screenlog.0.txt)
Here is a first pass at improving the memory usage of mtxcli.

Before you UPDATE SOFTWARE  please run `/get _filter` to find the number of your existing filter. You can set this old filter to reproduce the old memory consumption behavior.

Normally on startup a new migration will unset `_filter` -- causing it to get recreated with a more optimal filter.

DO NOT MERGE yet as there seems to be some issues testing on real hardware.