### PR TITLE
usb-device-xous: don't set device-wide class on mass-storage

### DIFF
--- a/services/usb-device-xous/src/main_hw.rs
+++ b/services/usb-device-xous/src/main_hw.rs
@@ -231,7 +231,6 @@ pub(crate) fn main_hw() -> ! {
         .manufacturer("Kosagi")
         .product("Precursor")
         .serial_number(&serial_number)
-        .device_class(usbd_mass_storage::USB_CLASS_MSC)
         .self_powered(false)
         .max_power(500)
         .build();


### PR DESCRIPTION
Setting it to zero (default if not set) makes mass-storage work under macOS.