### PR TITLE
add pddb edit (types pddb write <k> <v>)

### DIFF
--- a/services/gam/src/lib.rs
+++ b/services/gam/src/lib.rs
@@ -278,20 +278,19 @@ impl Gam {
         }
     }
 
-    pub fn type_keys(&self, s: &str) -> Result<bool, xous::Error> {
+    pub fn type_chars(&self, s: &str) -> Result<bool, xous::Error> {
         let mut view = s.chars().peekable();
 
         while view.peek().is_some() {
             let chunk: std::string::String = view.by_ref().take(4).collect();
-            let bytes = chunk.as_bytes();
             send_message(self.conn,
                 Message::new_scalar(Opcode::KeyboardEvent.to_usize().unwrap(),
-                 bytes[0] as usize,
-                 if bytes.len() > 1 {bytes[1]} else {0} as usize,
-                 if bytes.len() > 2 {bytes[2]} else {0} as usize,
-                 if bytes.len() > 3 {bytes[3]} else {0} as usize
+                 chunk.chars().nth(0).unwrap() as usize,
+                 if chunk.len() > 1 {chunk.chars().nth(1).unwrap()} else {'\u{0000}'} as usize,
+                 if chunk.len() > 2 {chunk.chars().nth(2).unwrap()} else {'\u{0000}'} as usize,
+                 if chunk.len() > 3 {chunk.chars().nth(3).unwrap()} else {'\u{0000}'} as usize
                 )
-            ).expect("Couldn't type keys");
+            ).expect("Couldn't type chars");
         }
 
         Ok(true)

--- a/services/gam/src/lib.rs
+++ b/services/gam/src/lib.rs
@@ -278,6 +278,25 @@ impl Gam {
         }
     }
 
+    pub fn type_keys(&self, s: &str) -> Result<bool, xous::Error> {
+        let mut view = s.chars().peekable();
+
+        while view.peek().is_some() {
+            let chunk: std::string::String = view.by_ref().take(4).collect();
+            let bytes = chunk.as_bytes();
+            send_message(self.conn,
+                Message::new_scalar(Opcode::KeyboardEvent.to_usize().unwrap(),
+                 bytes[0] as usize,
+                 if bytes.len() > 1 {bytes[1]} else {0} as usize,
+                 if bytes.len() > 2 {bytes[2]} else {0} as usize,
+                 if bytes.len() > 3 {bytes[3]} else {0} as usize
+                )
+            ).expect("Couldn't type keys");
+        }
+
+        Ok(true)
+    }
+
     pub fn claim_token(&self, name: &str) -> Result<Option<[u32; 4]>, xous::Error> {
         let tokenclaim = TokenClaim {
             token: None,

--- a/services/shellchat/src/cmds/pddb_cmd.rs
+++ b/services/shellchat/src/cmds/pddb_cmd.rs
@@ -180,7 +180,7 @@ impl<'a> ShellCmdApi<'a> for PddbCmd {
                                                 editcmd.push_str(" ");
                                                 editcmd.push_str(&s);
 
-                                                match _env.gam.type_keys(&editcmd) {
+                                                match _env.gam.type_chars(&editcmd) {
                                                     Ok(_) => {
                                                         write!(ret, "Edit the value and press enter:").unwrap()
                                                     }


### PR DESCRIPTION
This adds a new subcommand `edit` to shellchat's `pddb` command.  

Executing `pddb edit <key>` will make the Precursor type out the text `pddb write <key> <value>` into the typing area, allowing you to easily edit the value and then press enter to store the new value.

Screenshot example:
<img width="846" alt="Screen Shot 2023-01-14 at 3 13 58 PM" src="https://user-images.githubusercontent.com/1526749/212501161-20b162fa-d290-4576-9984-3c971c3688f1.png">
