### PR TITLE
Issue 287: reduces mtxcli memory consumption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,6 +2254,7 @@ dependencies = [
  "log",
  "num-derive",
  "num-traits",
+ "pddb",
  "percent-encoding",
  "serde",
  "trng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "mtxcli"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "codec",
  "com",

--- a/apps/mtxcli/Cargo.toml
+++ b/apps/mtxcli/Cargo.toml
@@ -29,6 +29,8 @@ codec = {path = "../../services/codec"}
 percent-encoding = "2.2"
 serde = { version = "1.0", features = [ "derive" ] }
 ureq = { version = "2.5", features = ["json"] }
+# Xous APIs
+pddb = {path = "../../services/pddb" }
 
 [features]
 default = []

--- a/apps/mtxcli/Cargo.toml
+++ b/apps/mtxcli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mtxcli"
-version = "0.1.0"
+version = "0.6.0"
 authors = ["bunnie <bunnie@kosagi.com>"]
 edition = "2018"
 description = "Matrix chat"

--- a/apps/mtxcli/README.md
+++ b/apps/mtxcli/README.md
@@ -64,6 +64,10 @@ Xous please see the [locales README](https://github.com/betrusted-io/xous-core/b
 
 ## Troubleshooting
 
+Prequisites: it is essential that the PDDB is mounted and WiFi is
+connected before running mtxcli. You can verify these in Shellchat
+with `net ping 1.1.1.1`.
+
 If you see the message `WARNING: clock not set` that is likely because
 the Precursor real time clock needs to be set (e.g. if the battery
 has been completely discharged). Please go to the menu

--- a/apps/mtxcli/README.md
+++ b/apps/mtxcli/README.md
@@ -62,6 +62,19 @@ Xous please see the [locales README](https://github.com/betrusted-io/xous-core/b
 
 ![screenshot](xous-french.png)
 
+## Troubleshooting
+
+If you see the message `WARNING: clock not set` that is likely because
+the Precursor real time clock needs to be set (e.g. if the battery
+has been completely discharged). Please go to the menu
+**Preferences | Set Timezone** to set the time zone
+(and update the time via NTP).
+
+If you see the message `authentication failed` it might be because
+the `user` and `password` variables are not set properly.
+Alternatively it could be because TLS certificate validation
+has failed because the clock has not been set (see above).
+
 ## Acknowledgements
 
 This app is supported in part by a grant from the

--- a/apps/mtxcli/locales/i18n.json
+++ b/apps/mtxcli/locales/i18n.json
@@ -104,6 +104,13 @@
         "ja": "not connected *EN*",
         "zh": "not connected *EN*"
     },
+    "mtxcli.pddb.warning": {
+        "en": "WARNING: pddb not mounted",
+        "en-tts": "WARNING: pddb not mounted",
+        "fr": "AVERTISSEMENT: pddb pas monté",
+        "ja": "WARNING: pddb not mounted *EN*",
+        "zh": "WARNING: pddb not mounted *EN*"
+    },
     "mtxcli.please.set.password": {
         "en": "please /set password my-password",
         "en-tts": "please /set password my-password",
@@ -180,5 +187,12 @@
         "fr": "/unset clé",
         "ja": "/unset key *EN*",
         "zh": "/unset key *EN*"
+    },
+    "mtxcli.wifi.warning": {
+        "en": "WARNING: WiFi not connected",
+        "en-tts": "WARNING: WiFi not connected",
+        "fr": "AVERTISSEMENT: WiFi pas connecté",
+        "ja": "WARNING: WiFi not connected *EN*",
+        "zh": "WARNING: WiFi not connected *EN*"
     }
 }

--- a/apps/mtxcli/locales/i18n.json
+++ b/apps/mtxcli/locales/i18n.json
@@ -20,6 +20,13 @@
         "ja": "シンプルなMTXCLIデモへようこそ",
         "zh": "简单的 mtxcli 演示活动"
     },
+    "mtxcli.heap.help": {
+        "en": "/heap",
+        "en-tts": "heap",
+        "fr": "/heap",
+        "ja": "/heap",
+        "zh": "/heap"
+    },
     "mtxcli.help.help": {
         "en": "/help [cmd]",
         "en-tts": "help [cmd]",

--- a/apps/mtxcli/locales/i18n.json
+++ b/apps/mtxcli/locales/i18n.json
@@ -1,4 +1,11 @@
 {
+    "mtxcli.clock.warning": {
+        "en": "WARNING: clock not set",
+        "en-tts": "WARNING: clock not set",
+        "fr": "AVERTISSEMENT : horloge non réglée",
+        "ja": "WARNING: clock not set *EN*",
+        "zh": "WARNING: clock not set *EN*"
+    },
     "mtxcli.filter.failed": {
         "en": "error: could not create filter",
         "en-tts": "error: could not create filter",
@@ -83,6 +90,13 @@
         "ja": "/logout *EN*",
         "zh": "/logout *EN*"
     },
+    "mtxcli.migration.completed": {
+        "en": "migration completed",
+        "en-tts": "migration completed",
+        "fr": "migration terminée",
+        "ja": "migration completed *EN*",
+        "zh": "migration completed *EN*"
+    },
     "mtxcli.not.connected": {
         "en": "not connected",
         "en-tts": "not conntected",
@@ -124,6 +138,13 @@
         "fr": "erreur: impossible de trouver chambre",
         "ja": "error: could not find room_id *EN*",
         "zh": "error: could not find room_id *EN*"
+    },
+    "mtxcli.running.migrations": {
+        "en": "Running migrations from version",
+        "en-tts": "Running migrations from version",
+        "fr": "Exécution des migrations à partir de la version",
+        "ja": "Running migrations from version *EN*",
+        "zh": "Running migrations from version *EN*"
     },
     "mtxcli.send.failed": {
         "en": "failed to send!",

--- a/apps/mtxcli/src/cmds/get.rs
+++ b/apps/mtxcli/src/cmds/get.rs
@@ -7,7 +7,7 @@ use locales::t;
 pub struct Get {
 }
 impl Get {
-    pub fn new(_xns: &xous_names::XousNames) -> Self {
+    pub fn new() -> Self {
         Get {
         }
     }

--- a/apps/mtxcli/src/cmds/heap.rs
+++ b/apps/mtxcli/src/cmds/heap.rs
@@ -1,0 +1,25 @@
+use crate::{ShellCmdApi,CommonEnv,heap_usage};
+use xous_ipc::String as XousString;
+use core::fmt::Write;
+
+#[derive(Debug)]
+pub struct Heap {
+}
+impl Heap {
+    pub fn new(_xns: &xous_names::XousNames) -> Self {
+        Heap {
+        }
+    }
+}
+
+impl<'a> ShellCmdApi<'a> for Heap {
+    cmd_api!(heap);
+
+    fn process(&mut self, _args: XousString::<1024>, _env: &mut CommonEnv) -> Result<Option<XousString::<1024>>, xous::Error> {
+        let mut ret = XousString::<1024>::new();
+        let heap = heap_usage();
+        write!(ret, "heap usage: {}", heap).unwrap();
+        log::info!("heap usage: {}", heap);
+        Ok(Some(ret))
+    }
+}

--- a/apps/mtxcli/src/cmds/heap.rs
+++ b/apps/mtxcli/src/cmds/heap.rs
@@ -6,7 +6,7 @@ use core::fmt::Write;
 pub struct Heap {
 }
 impl Heap {
-    pub fn new(_xns: &xous_names::XousNames) -> Self {
+    pub fn new() -> Self {
         Heap {
         }
     }

--- a/apps/mtxcli/src/cmds/help.rs
+++ b/apps/mtxcli/src/cmds/help.rs
@@ -1,5 +1,5 @@
 use crate::{ShellCmdApi,CommonEnv,
-            cmds::CLOCK_NOT_SET_ID};
+            cmds::{CLOCK_NOT_SET_ID,PDDB_NOT_MOUNTED_ID,WIFI_NOT_CONNECTED_ID}};
 use xous::{MessageEnvelope, Message,StringBuffer};
 use xous_ipc::String as XousString;
 use core::fmt::Write;
@@ -78,13 +78,24 @@ impl<'a> ShellCmdApi<'a> for Help {
         match &msg.body {
             Message::Scalar(xous::ScalarMessage{id: _, arg1: _, arg2: _,
                                                 arg3: _, arg4: async_msg_id}) => {
-                if *async_msg_id == CLOCK_NOT_SET_ID {
-                    let mut ret = XousString::<1024>::new();
-                    let warning = t!("mtxcli.clock.warning", xous::LANG);
-                    write!(ret, "{}", warning).unwrap();
-                    log::warn!("{}", warning);
-                    return Ok(Some(ret));
-                }
+                let mut ret = XousString::<1024>::new();
+                let warning = match *async_msg_id {
+                    CLOCK_NOT_SET_ID => {
+                        t!("mtxcli.clock.warning", xous::LANG)
+                    },
+                    PDDB_NOT_MOUNTED_ID => {
+                        t!("mtxcli.pddb.warning", xous::LANG)
+                    },
+                    WIFI_NOT_CONNECTED_ID => {
+                        t!("mtxcli.wifi.warning", xous::LANG)
+                    },
+                    _ => {
+                       "unknown async_msg_id"
+                    },
+                };
+                write!(ret, "{}", warning).unwrap();
+                log::warn!("{}", warning);
+                return Ok(Some(ret));
             },
             Message::Move(mm) => {
                 let str_buf = unsafe { StringBuffer::from_memory_message(mm) };

--- a/apps/mtxcli/src/cmds/help.rs
+++ b/apps/mtxcli/src/cmds/help.rs
@@ -30,6 +30,9 @@ impl<'a> ShellCmdApi<'a> for Help {
                 "get" => {
                     write!(ret, "{}", t!("mtxcli.get.help", xous::LANG)).unwrap();
                 }
+                "heap" => {
+                    write!(ret, "{}", t!("mtxcli.heap.help", xous::LANG)).unwrap();
+                }
                 "help" => {
                     write!(ret, "{}", t!("mtxcli.help.help", xous::LANG)).unwrap();
                 }
@@ -51,6 +54,7 @@ impl<'a> ShellCmdApi<'a> for Help {
                 "" => {
                     write!(ret, "{}\n", t!("mtxcli.help.overview", xous::LANG)).unwrap();
                     write!(ret, "{}\n", t!("mtxcli.get.help", xous::LANG)).unwrap();
+                    write!(ret, "{}\n", t!("mtxcli.heap.help", xous::LANG)).unwrap();
                     write!(ret, "{}\n", t!("mtxcli.help.help", xous::LANG)).unwrap();
                     write!(ret, "{}\n", t!("mtxcli.login.help", xous::LANG)).unwrap();
                     write!(ret, "{}\n", t!("mtxcli.logout.help", xous::LANG)).unwrap();

--- a/apps/mtxcli/src/cmds/login.rs
+++ b/apps/mtxcli/src/cmds/login.rs
@@ -5,7 +5,7 @@ use xous_ipc::String as XousString;
 pub struct Login {
 }
 impl Login {
-    pub fn new(_xns: &xous_names::XousNames) -> Self {
+    pub fn new() -> Self {
         Login {
         }
     }

--- a/apps/mtxcli/src/cmds/logout.rs
+++ b/apps/mtxcli/src/cmds/logout.rs
@@ -5,7 +5,7 @@ use xous_ipc::String as XousString;
 pub struct Logout {
 }
 impl Logout {
-    pub fn new(_xns: &xous_names::XousNames) -> Self {
+    pub fn new() -> Self {
         Logout {
         }
     }

--- a/apps/mtxcli/src/cmds/migrations.rs
+++ b/apps/mtxcli/src/cmds/migrations.rs
@@ -1,0 +1,69 @@
+//! Migrations
+//!
+//! Runs migrations up to the current version
+
+use std::io::Error;
+use crate::cmds::{CommonEnv,VERSION_KEY};
+
+mod v0_9_11_0120;  use v0_9_11_0120::*;
+
+const DEFAULT_VERSION: &str = "0";
+
+pub trait MigrationApi<'a> {
+    // created with migration_api! macro
+    // returns my version
+    fn version(&self) -> &'static str;
+    // checks if the migration should be applied
+    fn applies(&self, version: &str) -> bool;
+    // run the migration
+    fn process(&self, common: &mut CommonEnv) -> Result<bool, Error>;
+}
+
+// the argument to this macro is the command verb
+#[macro_export]
+macro_rules! migration_api {
+    ($version:expr) => { // NOTE the expr will have literal quotes
+        fn version(&self) -> &'static str {
+            $version
+        }
+
+        fn applies(&self, version: &str) -> bool {
+            if version < self.version() {
+                true
+            } else {
+                false
+            }
+        }
+    };
+}
+
+/// Run migrations as needed
+pub fn run_migrations(common: &mut CommonEnv) {
+    let version = common.get_default(VERSION_KEY, DEFAULT_VERSION);
+    if version.ne(&common.version) {
+        log::info!("Running migrations from version {} to {}",
+                   version, common.version);
+        let mut migrations: Vec<Box<dyn MigrationApi>> = Vec::new();
+        migrations.push(Box::new(V0_9_11_0120::new()));
+        for migration in migrations.iter() {
+            if migration.applies(&version) {
+                match migration.process(common) {
+                    Ok(boolean) => {
+                        log::info!("migration competed: {}: {}",
+                                   migration.version(), boolean);
+                        if boolean {
+                            common.set(VERSION_KEY, migration.version())
+                                .expect("cannot set _version");
+                        }
+                    },
+                    Err(e) => {
+                        log::error!("error running migration: {}: {:?}",
+                                    migration.version(), e);
+                    }
+                }
+            }
+        }
+        common.set(VERSION_KEY, &common.version.clone())
+            .expect("cannot set _version");
+    }
+}

--- a/apps/mtxcli/src/cmds/migrations/v0_9_11_0120.rs
+++ b/apps/mtxcli/src/cmds/migrations/v0_9_11_0120.rs
@@ -1,0 +1,26 @@
+use std::io::Error;
+
+use crate::cmds::{CommonEnv,FILTER_KEY};
+use crate::cmds::migrations::MigrationApi;
+use crate::migration_api;
+
+#[derive(Debug)]
+pub struct V0_9_11_0120 {
+}
+impl V0_9_11_0120 {
+    pub fn new() -> Self {
+        V0_9_11_0120 {
+        }
+    }
+}
+
+impl<'a> MigrationApi<'a> for V0_9_11_0120 {
+    migration_api!("v0.9.11-0120");
+
+    fn process(&self, common: &mut CommonEnv) -> Result<bool, Error> {
+        log::info!("Running migration for: {}", self.version());
+        // we need to provoke the creation of a new/updated filter
+        common.unset(FILTER_KEY)?;
+        Ok(true)
+    }
+}

--- a/apps/mtxcli/src/cmds/set.rs
+++ b/apps/mtxcli/src/cmds/set.rs
@@ -7,7 +7,7 @@ use locales::t;
 pub struct Set {
 }
 impl Set {
-    pub fn new(_xns: &xous_names::XousNames) -> Self {
+    pub fn new() -> Self {
         Set {
         }
     }

--- a/apps/mtxcli/src/cmds/set.rs
+++ b/apps/mtxcli/src/cmds/set.rs
@@ -30,21 +30,30 @@ impl<'a> ShellCmdApi<'a> for Set {
                         match value {
                             "" => {
                                 write!(ret, "{}", t!("mtxcli.set.help", xous::LANG)).unwrap();
-                           }
+                            }
                             _ => {
                                 match env.set(key, value) {
                                     Ok(()) => {
                                         write!(ret, "set {}", key).unwrap();
                                     },
                                     Err(e) => {
-                                        // write!(ret, "error setting key {}: {:?}", key, e).unwrap();
                                         log::error!("error setting key {}: {:?}", key, e);
                                     }
                                 }
                             }
                         }
                     } else {
-                        write!(ret, "{}", t!("mtxcli.set.help", xous::LANG)).unwrap();
+                        // Instead of an error -- set to the empty string
+                        // write!(ret, "{}", t!("mtxcli.set.help", xous::LANG)).unwrap();
+                        // write!(ret, "{}", t!("mtxcli.set.help", xous::LANG)).unwrap();
+                        match env.set(key, "") {
+                            Ok(()) => {
+                                write!(ret, "set {} EMPTY", key).unwrap();
+                            },
+                            Err(e) => {
+                                log::error!("error setting key {}: {:?}", key, e);
+                            }
+                        }
                     }
                 }
             }

--- a/apps/mtxcli/src/cmds/status.rs
+++ b/apps/mtxcli/src/cmds/status.rs
@@ -6,7 +6,7 @@ use locales::t;
 pub struct Status {
 }
 impl Status {
-    pub fn new(_xns: &xous_names::XousNames) -> Self {
+    pub fn new() -> Self {
         Status {
         }
     }

--- a/apps/mtxcli/src/cmds/unset.rs
+++ b/apps/mtxcli/src/cmds/unset.rs
@@ -7,7 +7,7 @@ use locales::t;
 pub struct Unset {
 }
 impl Unset {
-    pub fn new(_xns: &xous_names::XousNames) -> Self {
+    pub fn new() -> Self {
         Unset {
         }
     }

--- a/apps/mtxcli/src/mtxcli.rs
+++ b/apps/mtxcli/src/mtxcli.rs
@@ -14,7 +14,6 @@ struct History {
     pub is_input: bool,
 }
 
-#[allow(dead_code)]
 pub(crate) struct Mtxcli {
     // optional structures that indicate new input to the Mtxcli loop per iteration
     // an input string
@@ -38,9 +37,6 @@ pub(crate) struct Mtxcli {
 
     // command environment
     env: CmdEnv,
-
-    // our security token for making changes to our record on the GAM
-    token: [u32; 4],
 }
 impl Mtxcli{
     pub(crate) fn new(xns: &xous_names::XousNames, sid: xous::SID) -> Self {
@@ -60,10 +56,12 @@ impl Mtxcli{
 
         let content = gam.request_content_canvas(token.unwrap()).expect("couldn't get content canvas");
         let screensize = gam.get_canvas_bounds(content).expect("couldn't get dimensions of content canvas");
+        let history: Vec::<History> = vec![History{text: String::from(t!("mtxcli.greeting", xous::LANG)), is_input: false}];
+        let env = CmdEnv::new();
         Mtxcli {
             input: None,
             msg: None,
-            history: vec![History{text: String::from(t!("mtxcli.greeting", xous::LANG)), is_input: false}],
+            history,
             history_len: 10,
             content,
             gam,
@@ -73,8 +71,7 @@ impl Mtxcli{
             bubble_margin: Point::new(4, 4),
             bubble_radius: 4,
             bubble_space: 4,
-            env: CmdEnv::new(xns),
-            token: token.unwrap(),
+            env,
         }
     }
 


### PR DESCRIPTION
_NOTE: Before you UPDATE SOFTWARE_ please run `/get _filter` to find the number of your existing filter. You can set this old filter in case you would like to reproduce the old memory consumption behavior.

Normally on startup a new migration will unset _filter -- causing it to get recreated with a more optimal filter.

Updates the mtxcli README with a troubleshooting section that includes:
```
Prequisites: it is essential that the PDDB is mounted and WiFi is
connected before running mtxcli. You can verify these in Shellchat
with `net ping 1.1.1.1`.
```

Introduces "read only" variables (e.g. __version).

Adds /heap command to mtxcli

Adds migrations framework

* Migration for v0.9.11-0120: update the filter
    
Delays mtxcli initialization until first user input, because we know:

*  RTC Timer is stable
* PDDB is mounted (verified at initialization time)
* _NOTE:_ the WiFi check is not yet implemented
* User actually using mtxcli

Adds send_async_msg & scalar_async_msg -- a basis for automatically updating chatroom
    
Allows a variable to be set to the EMPTY string by not setting a value `/set myvar`
    
