### PR TITLE
Revert "Give servers their full quantum"

### DIFF
--- a/kernel/src/services.rs
+++ b/kernel/src/services.rs
@@ -749,30 +749,6 @@ impl SystemServices {
         }
     }
 
-    /// Set the "current thread" of a given process. It is designed
-    /// to set where the next thread will run in order to avoid starving threads
-    /// when messages are passed around.
-    /// For example, if there are three threads (1, 2, 3), then there is a case where
-    /// thread 1 sends a message to thread 3, which yields. In this case, thread 1 will be
-    /// picked to run next, completely skipping thread 2.
-    /// Use `set_last_thread()` when a process' quantum is up in order to tell the scheduler
-    /// which thread to use as a reference for picking the next runnable thread.
-    pub fn set_last_thread(&mut self, pid: PID, tid: TID) -> Result<(), xous_kernel::Error> {
-        let process = self.get_process_mut(pid)?;
-
-        match process.state {
-            ProcessState::Ready(runnable) if runnable & (1 << tid) != 0 => {
-                process.current_thread = tid;
-                Ok(())
-            }
-            ProcessState::Ready(_) | ProcessState::Sleeping => {
-                Err(xous_kernel::Error::ThreadNotAvailable)
-            }
-            ProcessState::Running(_) => panic!("thread was still running"),
-            _ => Err(xous_kernel::Error::ProcessNotFound),
-        }
-    }
-
     /// Mark the current process as "Ready to run".
     ///
     /// # Panics

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -7,7 +7,6 @@ use crate::irq::interrupt_claim;
 use crate::mem::{MemoryManager, PAGE_SIZE};
 use crate::server::{SenderID, WaitingMessage};
 use crate::services::SystemServices;
-use core::sync::atomic::{AtomicU8, AtomicUsize, Ordering::Relaxed};
 use xous_kernel::*;
 
 /* Quoth Xobs:
@@ -23,16 +22,6 @@ use xous_kernel::*;
 */
 /// This is the PID/TID of the last person that called SwitchTo
 static mut SWITCHTO_CALLER: Option<(PID, TID)> = None;
-
-/// When a process is switched to, take note of the original PID and TID.
-/// That way we know whether to give the process its full quantum when
-/// messages are Returned. If a process Returns messages while it's in its
-/// own quantum, then don't immediately transfer control to the Client.
-/// However, for processes that are running on Borrowed Quantum (i.e. when
-/// another process sent them a message and they're immediately responding,)
-/// return control to the Client.
-static ORIGINAL_PID: AtomicU8 = AtomicU8::new(2);
-static ORIGINAL_TID: AtomicUsize = AtomicUsize::new(2);
 
 #[derive(PartialEq)]
 enum ExecutionType {
@@ -213,22 +202,9 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
                         xous_kernel::Result::MessageEnvelope(envelope),
                     )
                     .expect("couldn't set result for server thread");
-                    let result = ss
-                        .activate_process_thread(tid, ppid, ptid, false)
+                    ss.activate_process_thread(tid, ppid, ptid, false)
                         .map(|_| Ok(xous_kernel::Result::ResumeProcess))
-                        .unwrap_or(Err(xous_kernel::Error::ProcessNotFound));
-
-                    // Keep track of which process owned the quantum. This ensures that the next
-                    // thread in sequence gets to run when this process is activated again.
-                    SystemServices::with_mut(|ss| {
-                        ss.set_last_thread(
-                            PID::new(ORIGINAL_PID.load(Relaxed)).unwrap(),
-                            ORIGINAL_TID.load(Relaxed),
-                        )
-                        .ok()
-                    });
-
-                    result
+                        .unwrap_or(Err(xous_kernel::Error::ProcessNotFound))
                 } else {
                     // Switch to the server, since it's in a state to be run.
                     klog!("Activating Server context and switching away from Client");
@@ -391,18 +367,7 @@ fn return_memory(
             ss.ready_thread(client_pid, client_tid)?;
         }
 
-        // Return to the server if any of the following are true:
-        //
-        // 1. We're running in hosted mode -- hosted mode runs all threads simultaneously anyway
-        // 2. We're in an interrupt -- interrupts cannot cross process boundaries
-        // 3. The client isn't runnable -- it may be being debugged
-        // 4. We're in the quantum assigned to the server -- this prevents pipeline blockages
-        if !cfg!(baremetal)
-            || in_irq
-            || !ss.runnable(client_pid, Some(client_tid))?
-            || (ORIGINAL_PID.load(Relaxed) == server_pid.get()
-                && ORIGINAL_TID.load(Relaxed) == client_tid)
-        {
+        if !cfg!(baremetal) || in_irq || !ss.runnable(client_pid, Some(client_tid))? {
             // In a hosted environment, `switch_to_thread()` doesn't continue
             // execution from the new thread. Instead it continues in the old
             // thread. Therefore, we need to instruct the client to resume, and
@@ -476,18 +441,7 @@ fn return_result(
             ss.ready_thread(client_pid, client_tid)?;
         }
 
-        // Return to the server if any of the following are true:
-        //
-        // 1. We're running in hosted mode -- hosted mode runs all threads simultaneously anyway
-        // 2. We're in an interrupt -- interrupts cannot cross process boundaries
-        // 3. The client isn't runnable -- it may be being debugged
-        // 4. We're in the quantum assigned to the server -- this prevents pipeline blockages
-        if !cfg!(baremetal)
-            || in_irq
-            || !ss.runnable(client_pid, Some(client_tid))?
-            || (ORIGINAL_PID.load(Relaxed) == server_pid.get()
-                && ORIGINAL_TID.load(Relaxed) == client_tid)
-        {
+        if !cfg!(baremetal) || in_irq || !ss.runnable(client_pid, Some(client_tid))? {
             // In a hosted environment, `switch_to_thread()` doesn't continue
             // execution from the new thread. Instead it continues in the old
             // thread. Therefore, we need to instruct the client to resume, and
@@ -514,7 +468,7 @@ fn return_result(
 fn reply_and_receive_next(
     server_pid: PID,
     server_tid: TID,
-    in_irq: bool,
+    _in_irq: bool,
     sender: MessageSender,
     arg0: usize,
     arg1: usize,
@@ -601,46 +555,35 @@ fn reply_and_receive_next(
                 return Err(xous_kernel::Error::DoubleFree);
             }
         };
-        let client_pid = response.pid;
-        let client_tid = response.tid;
-
-        if cfg!(baremetal) {
-            ss.ready_thread(client_pid, client_tid)?;
-        }
 
         // If there is a pending message, fetch it and schedule the thread to run
         if let Some(msg) = next_message {
-            if !cfg!(baremetal)
-                || in_irq
-                || !ss.runnable(client_pid, Some(client_tid))?
-                || (ORIGINAL_PID.load(Relaxed) == server_pid.get()
-                    && ORIGINAL_TID.load(Relaxed) == client_tid)
-            {
-                // Switch to the client and return the result
-                ss.set_thread_result(response.pid, response.tid, response.result)?;
-
-                // Return the new message envelope to the server
-                Ok(xous_kernel::Result::MessageEnvelope(msg))
-            } else {
-                if cfg!(baremetal) {
-                    ss.unschedule_thread(server_pid, server_tid)?;
-                    ss.ready_thread(server_pid, server_tid)?
-                }
-
+            if cfg!(baremetal) {
                 // When the server is resumed, it will receive this as a return value.
                 ss.set_thread_result(
                     server_pid,
                     server_tid,
                     xous_kernel::Result::MessageEnvelope(msg),
                 )?;
-
-                // Switch to the client
+                ss.ready_thread(response.pid, response.tid).unwrap();
+                ss.set_thread_result(response.pid, response.tid, response.result)?;
+                ss.activate_process_thread(server_tid, response.pid, response.tid, true)
+                    .map(|_| Ok(xous_kernel::Result::ResumeProcess))
+                    .unwrap_or(Err(xous_kernel::Error::ProcessNotFound))
+            } else {
+                // Switch to the client and return the result
                 ss.switch_to_thread(response.pid, Some(response.tid))?;
-                Ok(response.result)
+                ss.set_thread_result(response.pid, response.tid, response.result)?;
+
+                // Return the new message envelope to the server
+                Ok(xous_kernel::Result::MessageEnvelope(msg))
             }
         } else {
             // For baremetal targets, switch away from this process.
             if cfg!(baremetal) {
+                // Switch back to the client process.
+                ss.ready_thread(response.pid, response.tid)?;
+
                 // Set the thread result for the client
                 ss.set_thread_result(response.pid, response.tid, response.result)?;
 
@@ -925,10 +868,8 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
             //     "Activating process thread {} in pid {} coming from pid {} thread {}",
             //     new_context, new_pid, pid, tid
             // );
-            let new_tid = ss.activate_process_thread(tid, new_pid, new_tid, true)?;
-            ORIGINAL_PID.store(new_pid.get(), Relaxed);
-            ORIGINAL_TID.store(new_tid, Relaxed);
-            Ok(xous_kernel::Result::ResumeProcess)
+            ss.activate_process_thread(tid, new_pid, new_tid, true)
+                .map(|_ctx| xous_kernel::Result::ResumeProcess)
         }),
         SysCall::ClaimInterrupt(no, callback, arg) => {
             interrupt_claim(no, pid as definitions::PID, callback, arg)
@@ -941,16 +882,6 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
                     crate::arch::irq::set_isr_return_pair(parent_pid, parent_ctx)
                 }
             };
-
-            // Keep track of which process owned the quantum. This ensures that the next
-            // thread in sequence gets to run when this process is activated again.
-            SystemServices::with_mut(|ss| {
-                ss.set_last_thread(
-                    PID::new(ORIGINAL_PID.load(Relaxed)).unwrap(),
-                    ORIGINAL_TID.load(Relaxed),
-                )
-                .ok()
-            });
             Ok(xous_kernel::Result::ResumeProcess)
         }
         SysCall::ReceiveMessage(sid) => receive_message(pid, tid, sid, ExecutionType::Blocking),


### PR DESCRIPTION
Reverts betrusted-io/xous-core#314

Causes a regression, system only boots this far now:
```
  Betrusted/Precursor Bootloader v0.2.3
Using public key: b2927795649d15737c592b8cecbdc9d6aefe7d61278cb37575470c73c55ed0d0
Using public key: 1c9beae32aeac87507c18094387eff1c74614282affd8152d871352edf3f58bb
Signature check passed
Free stack: 0x00000b34


Jumping to loader...
Mapped UART @ 60001000
Process: map success!
Note: character injection via console UART is enabled.
Allocating IRQ...
Claimed IRQ 3
LOG: my PID is 3
LOG: Creating the reader thread
LOG: Xous Logging Server starting up...
LOG: Server listening on address SID([1937076088, 1735355437, 1919251245, 544367990])
LOG: my PID is 3
LOG: Counter tick: 0
INFO:xous_names: my PID is 4 (services\xous-names\src\main.rs:376)
```