### PR TITLE
WIP: XIP loader support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,9 +4924,9 @@ dependencies = [
 
 [[package]]
 name = "xmas-elf"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74de9a366f6ab8c405fa6b371d9ac24943921fa14b3d64afcb202065c405f11"
+checksum = "f820cc767d65b32eef9d7ce7201448f28501c59edc55d47b71375fea579fc2df"
 dependencies = [
  "zero",
 ]

--- a/kernel/src/services.rs
+++ b/kernel/src/services.rs
@@ -330,7 +330,7 @@ impl SystemServices {
         let init_offsets = {
             let mut init_count = 1;
             for arg in args.iter() {
-                if arg.name == u32::from_le_bytes(*b"IniE") {
+                if arg.name == u32::from_le_bytes(*b"IniE") || arg.name == u32::from_le_bytes(*b"IniF") {
                     init_count += 1;
                 }
             }

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -37,7 +37,14 @@ const FLG_A: usize = 0x40;
 const FLG_D: usize = 0x80;
 const STACK_PAGE_COUNT: usize = 8;
 
-const VDBG: bool = false; // verbose debug
+const MINIELF_FLG_W: u8 = 1;
+#[allow(dead_code)]
+const MINIELF_FLG_NC: u8 = 2;
+#[allow(dead_code)]
+const MINIELF_FLG_X: u8 = 4;
+
+const VDBG: bool = true; // verbose debug
+const VVDBG: bool = false; // very verbose debug
 
 mod debug;
 
@@ -187,7 +194,7 @@ impl MiniElfSection {
 
 /// Describes a Mini ELF file, suitable for loading into RAM
 pub struct MiniElf {
-    /// Physical source address of this program in RAM (i.e. SPI flash).
+    /// Offset of the source data relative to the start of the image file
     pub load_offset: u32,
 
     /// Virtual address of the entrypoint
@@ -215,12 +222,20 @@ impl MiniElf {
     /// Load the process into its own memory space.
     /// The process will have been already loaded in stage 1.  This simply assigns
     /// memory maps as necessary.
-    pub fn load(&self, allocator: &mut BootConfig, load_offset: usize, pid: XousPid) -> usize {
+    pub fn load(&self, allocator: &mut BootConfig, load_offset: usize, pid: XousPid, xip: bool) -> usize {
         println!("Mapping PID {} starting at offset {:08x}", pid, load_offset);
         let mut allocated_bytes = 0;
 
         let mut current_page_addr: usize = 0;
         let mut previous_addr: usize = 0;
+        let mut last_mapped_xip = 0;
+        let image_phys_base = allocator.base_addr as usize + self.load_offset as usize;
+        // It is a requirement that the image generator lay out the artifacts on disk such that
+        // the page offsets line up for XIP sections. This assert confirms this necessary pre-condition.
+        if xip {
+            assert!((image_phys_base & (PAGE_SIZE - 1)) == self.sections[0].virt as usize & (PAGE_SIZE - 1), "Image generator did not align load offsets to page offsets!");
+        }
+        println!("flash_map_offset: {:x} / base_addr {:x} load_offset {:x}", image_phys_base as usize, allocator.base_addr as usize, self.load_offset as usize);
 
         // The load offset is the end of this process.  Shift it down by one page
         // so we get the start of the first page.
@@ -266,6 +281,9 @@ impl MiniElf {
             }
         }
 
+        // this works to set the initial offset, but from here we have to track it by
+        // adding the length of each section as we see it
+        let mut section_start_phys_offset = 0;
         // Example: Page starts at 0xf0c0 and is 8192 bytes long.
         // 1. Copy 3094 bytes to page 1
         // 2. Copy 4096 bytes to page 2
@@ -282,78 +300,132 @@ impl MiniElf {
         for section in self.sections {
             if VDBG {println!("    Section @ {:08x}", section.virt as usize);}
             let flag_defaults = FLG_U
-                | FLG_R
-                | FLG_X
-                | FLG_VALID
-                | if section.flags() & 1 == 1 { FLG_W } else { 0 }
-                | if section.flags() & 4 == 4 { FLG_X } else { 0 };
+            | FLG_R
+            | FLG_X
+            | FLG_VALID
+            | if section.flags() & 1 == 1 { FLG_W } else { 0 }
+            | if section.flags() & 4 == 4 { FLG_X } else { 0 };
 
+            let copy_to_ram = ((section.flags() as u8) & MINIELF_FLG_W) != 0;
             if (section.virt as usize) < previous_addr {
                 panic!("init section addresses are not strictly increasing");
             }
 
-            let mut this_page = section.virt as usize & !(PAGE_SIZE - 1);
-            let mut bytes_to_copy = section.len();
+            if copy_to_ram || !xip {
+                let mut this_page = section.virt as usize & !(PAGE_SIZE - 1);
+                let mut bytes_to_copy = section.len();
 
-            // If this is not a new page, ensure the uninitialized values from between
-            // this section and the previous one are all zeroed out.
-            if this_page != current_page_addr || previous_addr == current_page_addr {
-                if VDBG {println!("1       {:08x} -> {:08x}", top as usize, this_page);}
-                allocator.map_page(satp, top as usize, this_page, flag_defaults);
-                allocator.change_owner(pid as XousPid, top as usize);
-                allocated_bytes += PAGE_SIZE;
-                top -= PAGE_SIZE;
-                this_page += PAGE_SIZE;
+                // If this is not a new page, ensure the uninitialized values from between
+                // this section and the previous one are all zeroed out.
+                if this_page != current_page_addr || previous_addr == current_page_addr {
+                    if VDBG {println!("1       {:08x} -> {:08x}", top as usize, this_page);}
+                    allocator.map_page(satp, top as usize, this_page, flag_defaults);
+                    allocator.change_owner(pid as XousPid, top as usize);
+                    allocated_bytes += PAGE_SIZE;
+                    top -= PAGE_SIZE;
+                    this_page += PAGE_SIZE;
 
-                // Part 1: Copy the first chunk over.
-                let mut first_chunk_size = PAGE_SIZE - (section.virt as usize & (PAGE_SIZE - 1));
-                if first_chunk_size > section.len() {
-                    first_chunk_size = section.len();
-                }
-                bytes_to_copy -= first_chunk_size;
-            } else {
-                if VDBG {println!(
-                    "This page is {:08x}, and last page was {:08x}",
-                    this_page, current_page_addr
-                );}
-                // This is a continuation of the previous section, and as a result
-                // the memory will have been copied already. Avoid copying this data
-                // to a new page.
-                let first_chunk_size = PAGE_SIZE - (section.virt as usize & (PAGE_SIZE - 1));
-                if VDBG {println!("First chunk size: {}", first_chunk_size);}
-                if bytes_to_copy < first_chunk_size {
-                    bytes_to_copy = 0;
-                    if VDBG {println!("Clamping to 0 bytes");}
-                } else {
+                    // Part 1: Copy the first chunk over.
+                    let mut first_chunk_size = PAGE_SIZE - (section.virt as usize & (PAGE_SIZE - 1));
+                    if first_chunk_size > section.len() {
+                        first_chunk_size = section.len();
+                    }
                     bytes_to_copy -= first_chunk_size;
+                } else {
                     if VDBG {println!(
-                        "Clamping to {} bytes by cutting off {} bytes",
-                        bytes_to_copy, first_chunk_size
+                        "This page is {:08x}, and last page was {:08x}",
+                        this_page, current_page_addr
                     );}
+                    // This is a continuation of the previous section, and as a result
+                    // the memory will have been copied already. Avoid copying this data
+                    // to a new page.
+                    let first_chunk_size = PAGE_SIZE - (section.virt as usize & (PAGE_SIZE - 1));
+                    if VDBG {println!("First chunk size: {}", first_chunk_size);}
+                    if bytes_to_copy < first_chunk_size {
+                        bytes_to_copy = 0;
+                        if VDBG {println!("Clamping to 0 bytes");}
+                    } else {
+                        bytes_to_copy -= first_chunk_size;
+                        if VDBG {println!(
+                            "Clamping to {} bytes by cutting off {} bytes",
+                            bytes_to_copy, first_chunk_size
+                        );}
+                    }
+                    this_page += PAGE_SIZE;
                 }
-                this_page += PAGE_SIZE;
-            }
 
-            // Part 2: Copy any full pages.
-            while bytes_to_copy >= PAGE_SIZE {
-                if VDBG {println!("2       {:08x} -> {:08x}", top as usize, this_page);}
-                allocator.map_page(satp, top as usize, this_page, flag_defaults);
-                allocator.change_owner(pid as XousPid, top as usize);
-                allocated_bytes += PAGE_SIZE;
-                top -= PAGE_SIZE;
-                this_page += PAGE_SIZE;
-                bytes_to_copy -= PAGE_SIZE;
-            }
+                // Part 2: Copy any full pages.
+                while bytes_to_copy >= PAGE_SIZE {
+                    if VDBG {println!("2       {:08x} -> {:08x}", top as usize, this_page);}
+                    allocator.map_page(satp, top as usize, this_page, flag_defaults);
+                    allocator.change_owner(pid as XousPid, top as usize);
+                    allocated_bytes += PAGE_SIZE;
+                    top -= PAGE_SIZE;
+                    this_page += PAGE_SIZE;
+                    bytes_to_copy -= PAGE_SIZE;
+                }
 
-            // Part 3: Copy the final residual partial page
-            if bytes_to_copy > 0 {
-                let this_page = (section.virt as usize + section.len()) & !(PAGE_SIZE - 1);
-                if VDBG {println!("3       {:08x} -> {:08x}", top as usize, this_page);}
-                allocator.map_page(satp, top as usize, this_page, flag_defaults);
-                allocator.change_owner(pid as XousPid, top as usize);
-                allocated_bytes += PAGE_SIZE;
-                top -= PAGE_SIZE;
+                // Part 3: Copy the final residual partial page
+                if bytes_to_copy > 0 {
+                    let this_page = (section.virt as usize + section.len()) & !(PAGE_SIZE - 1);
+                    if VDBG {println!("3       {:08x} -> {:08x}", top as usize, this_page);}
+                    allocator.map_page(satp, top as usize, this_page, flag_defaults);
+                    allocator.change_owner(pid as XousPid, top as usize);
+                    allocated_bytes += PAGE_SIZE;
+                    top -= PAGE_SIZE;
+                }
+            } else {
+                // --- calculate how many pages need mapping ---
+                let mut bytes_to_map = section.len();
+                assert!(bytes_to_map > 0, "no data to map");
+                let mut pages_to_map = 1;
+                let start_page = section.virt as usize & !(PAGE_SIZE - 1);
+
+                let unaligned_start_len = (start_page + PAGE_SIZE) - section.virt as usize;
+                if unaligned_start_len >= bytes_to_map {
+                     // we're done: the page is already mapped and it holds all the data we intend to map
+                } else {
+                    // remaining data from the first aligned page to end of mapped region
+                    bytes_to_map -= unaligned_start_len;
+                    // convert this to pages_to_map
+                    pages_to_map += bytes_to_map / PAGE_SIZE;
+                    if (bytes_to_map % PAGE_SIZE) != 0 {
+                        // unaligned end page adds one more mapped page
+                        pages_to_map += 1;
+                    }
+                }
+
+                // --- calculate starting offset of section from image base ---
+                let mut section_map_phys_offset = section_start_phys_offset;
+
+                // --- avoid double-mapping the previous section's end ---
+                // check if last_mapped_xip has already been mapped so we don't double-map overlapping pages
+                // assume: sections are always increasing in size
+                let mut virt_page = start_page;
+                if last_mapped_xip == start_page {
+                    if VDBG {println!("Skipping a page to avoid double-mapping: pa {:x} -> va {:x}",
+                        (image_phys_base + section_start_phys_offset) & !(PAGE_SIZE - 1), virt_page);}
+                    virt_page += PAGE_SIZE;
+                    section_map_phys_offset += PAGE_SIZE;
+                    pages_to_map -= 1;
+                }
+                if VDBG {
+                    println!("section is 0x{:x} bytes long; mapping {} pages", section.len(), pages_to_map);
+                }
+
+                // --- map FLASH pages to virtual memory ---
+                while pages_to_map > 0 {
+                    let map_phys_addr = (image_phys_base + section_map_phys_offset) & !(PAGE_SIZE - 1);
+                    allocator.map_page(satp, map_phys_addr, virt_page, flag_defaults);
+                    last_mapped_xip = virt_page;
+                    allocator.change_owner(pid as XousPid, top as usize);
+
+                    section_map_phys_offset += PAGE_SIZE;
+                    virt_page += PAGE_SIZE;
+                    pages_to_map -= 1;
+                }
             }
+            section_start_phys_offset += section.len(); // the length of the section on disk
 
             previous_addr = section.virt as usize + section.len();
             current_page_addr = previous_addr & !(PAGE_SIZE - 1);
@@ -363,7 +435,7 @@ impl MiniElf {
         process.entrypoint = self.entry_point as usize;
         process.sp = stack_addr;
         process.satp = 0x8000_0000 | ((pid as usize) << 22) | (satp_address >> 12);
-
+        println!("load allocated 0x{:x} bytes", allocated_bytes);
         allocated_bytes
     }
 }
@@ -629,7 +701,7 @@ pub fn read_initial_config(cfg: &mut BootConfig) {
                 "invalid XKrn size"
             );
             kernel_seen = true;
-        } else if tag.name == u32::from_le_bytes(*b"IniE") {
+        } else if tag.name == u32::from_le_bytes(*b"IniE") || tag.name == u32::from_le_bytes(*b"IniF") {
             assert!(tag.size >= 4, "invalid Init size");
             init_seen = true;
             cfg.init_process_count += 1;
@@ -671,6 +743,8 @@ fn copy_processes(cfg: &mut BootConfig) {
             // Example: Page starts at oxf0c0 and is 128 bytes long
             // 1. Copy 128 bytes to page 1
             println!("\n\nIniE {} has {} sections", _pid, inie.sections.len());
+            println!("Initial top: {:x}, extra_pages: {:x}, init_size: {:x}, base_addr: {:x}",
+                cfg.get_top() as *mut u8 as u32, cfg.extra_pages, cfg.init_size, cfg.base_addr as u32);
             for section in inie.sections.iter() {
                 if (section.virt as usize) < previous_addr {
                     panic!("init section addresses are not strictly increasing (new virt: {:08x}, last virt: {:08x})", section.virt, previous_addr);
@@ -783,7 +857,11 @@ fn copy_processes(cfg: &mut BootConfig) {
 
                 previous_addr = section.virt as usize + section.len();
                 page_addr = previous_addr & !(PAGE_SIZE - 1);
-                if VDBG {println!("Looping to the next section");}
+                if VDBG {
+                    println!("Looping to the next section");
+                    println!("top: {:x}, extra_pages: {:x}, init_size: {:x}, base_addr: {:x}", cfg.get_top() as *mut u8 as u32, cfg.extra_pages, cfg.init_size, cfg.base_addr as u32);
+                    println!("previous_addr: {:x}, page_addr: {:x}", previous_addr, page_addr);
+                }
             }
 
             println!("Done with sections");
@@ -807,6 +885,7 @@ fn copy_processes(cfg: &mut BootConfig) {
             let load_size_rounded = (prog.text_size as usize + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
             cfg.extra_pages += load_size_rounded / PAGE_SIZE;
             let top = cfg.get_top();
+            println!("\n\nKernel top: {:x}, extra_pages: {:x}", top as u32, cfg.extra_pages);
             unsafe {
                 // Copy the program to the target address, rounding it off to the load size.
                 let src_addr = cfg
@@ -867,6 +946,165 @@ fn copy_processes(cfg: &mut BootConfig) {
                     top.add(load_size_rounded as usize / mem::size_of::<usize>()),
                 )
             };
+        } else if tag.name == u32::from_le_bytes(*b"IniF") {
+            _pid += 1;
+            let mut page_addr: usize = 0;
+            let mut previous_addr: usize = 0;
+            let mut previous_ram_zero_addr: usize = 0;
+            let mut top = core::ptr::null_mut::<u8>();
+
+            let inif = MiniElf::new(&tag);
+            let mut src_addr = unsafe {
+                cfg.base_addr
+                    .add(inif.load_offset as usize / mem::size_of::<usize>())
+            } as *const u8;
+            // let mut accumulated_len = 0;
+
+            println!("\n\nIniF {} has {} sections", _pid, inif.sections.len());
+            println!("Initial top: {:x}, extra_pages: {:x}, init_size: {:x}, base_addr: {:x}", cfg.get_top() as *mut u8 as u32, cfg.extra_pages, cfg.init_size, cfg.base_addr as u32);
+            for section in inif.sections.iter() {
+                let flags = section.flags() as u8;
+                // any section that requires "write" must be copied to RAM
+                // note that ELF helpfully adds a 4096-byte gap between non-write pages and write-pages
+                // allowing us to just trundle through the pages and not have to deal with partially
+                // writeable pages.
+                let copy_to_ram = flags & MINIELF_FLG_W != 0;
+                if (section.virt as usize) < previous_addr {
+                    panic!("init section addresses are not strictly increasing (new virt: {:08x}, last virt: {:08x})", section.virt, previous_addr);
+                }
+                if copy_to_ram {
+                    let this_page = section.virt as usize & !(PAGE_SIZE - 1);
+                    let mut bytes_to_copy = section.len();
+
+                    if VDBG {println!(
+                        "Section is {} bytes long, loaded to {:08x}",
+                        bytes_to_copy, section.virt
+                    );}
+                    // If this is not a new page, ensure the uninitialized values from between
+                    // this section and the previous one are all zeroed out.
+                    if this_page != page_addr || previous_addr == page_addr {
+                        if VDBG {println!("New page @ {:08x}", this_page);}
+                        if previous_ram_zero_addr != 0 && previous_ram_zero_addr != page_addr && cfg.extra_pages > 0 {
+                            if VDBG {println!(
+                                "Zeroing-out remainder of previous page: {:08x} (mapped to physical address {:08x})",
+                                previous_ram_zero_addr, top as usize,
+                            );}
+                            unsafe {
+                                bzero(
+                                    top.add(previous_ram_zero_addr as usize & (PAGE_SIZE - 1)),
+                                    top.add(PAGE_SIZE as usize),
+                                )
+                            };
+                        }
+
+                        // Allocate a new page.
+                        cfg.extra_pages += 1;
+                        top = cfg.get_top() as *mut u8;
+
+                        // Zero out the page, if necessary.
+                        unsafe { bzero(top, top.add(section.virt as usize & (PAGE_SIZE - 1))) };
+                    } else {
+                        if VDBG {println!("Reusing existing page @ {:08x}", this_page);}
+                    }
+
+                    // Part 1: Copy the first chunk over.
+                    let mut first_chunk_size = PAGE_SIZE - (section.virt as usize & (PAGE_SIZE - 1));
+                    if first_chunk_size > section.len() {
+                        first_chunk_size = section.len();
+                    }
+                    let first_chunk_offset = section.virt as usize & (PAGE_SIZE - 1);
+                    if VDBG {println!(
+                        "Section chunk is {} bytes, {} from {:08x}:{:08x} -> {:08x}:{:08x} (virt: {:08x})",
+                        first_chunk_size,
+                        if section.no_copy() { "zeroing" } else { "copying" },
+                        src_addr as usize,
+                        unsafe { src_addr.add(first_chunk_size) as usize },
+                        unsafe { top.add(first_chunk_offset) as usize },
+                        unsafe { top.add(first_chunk_size + first_chunk_offset)
+                            as usize },
+                        this_page + first_chunk_offset,
+                    );}
+                    // Perform the copy, if NOCOPY is not set
+                    if !section.no_copy() {
+                        unsafe {
+                            memcpy(top.add(first_chunk_offset), src_addr, first_chunk_size);
+                            src_addr = src_addr.add(first_chunk_size);
+                        }
+                    } else {
+                        unsafe {
+                            bzero(
+                                top.add(first_chunk_offset),
+                                top.add(first_chunk_offset + first_chunk_size),
+                            );
+                        }
+                    }
+                    bytes_to_copy -= first_chunk_size;
+
+                    // Part 2: Copy any full pages.
+                    while bytes_to_copy >= PAGE_SIZE {
+                        cfg.extra_pages += 1;
+                        top = cfg.get_top() as *mut u8;
+                        // println!(
+                        //     "Copying next page from {:08x} {:08x} ({} bytes to go...)",
+                        //     src_addr as usize, top as usize, bytes_to_copy
+                        // );
+                        if !section.no_copy() {
+                            unsafe {
+                                memcpy(top, src_addr, PAGE_SIZE);
+                                src_addr = src_addr.add(PAGE_SIZE);
+                            }
+                        } else {
+                            unsafe { bzero(top, top.add(PAGE_SIZE)) };
+                        }
+                        bytes_to_copy -= PAGE_SIZE;
+                    }
+
+                    // Part 3: Copy the final residual partial page
+                    if bytes_to_copy > 0 {
+                        if VDBG {println!(
+                            "Copying final section -- {} bytes @ {:08x}",
+                            bytes_to_copy,
+                            section.virt + (section.len() as u32) - (bytes_to_copy as u32)
+                        );}
+                        cfg.extra_pages += 1;
+                        top = cfg.get_top() as *mut u8;
+                        if !section.no_copy() {
+                            unsafe {
+                                memcpy(top, src_addr, bytes_to_copy);
+                                src_addr = src_addr.add(bytes_to_copy);
+                            }
+                        } else {
+                            unsafe { bzero(top, top.add(bytes_to_copy)) };
+                        }
+                    }
+                    previous_ram_zero_addr = section.virt as usize + section.len();
+                } else {
+                    top = cfg.get_top() as *mut u8;
+                    src_addr = unsafe {src_addr.add(section.len())};
+                }
+
+                previous_addr = section.virt as usize + section.len();
+                page_addr = previous_addr & !(PAGE_SIZE - 1);
+                if VDBG {
+                    println!("Looping to the next section");
+                    println!("top: {:x}, extra_pages: {:x}, init_size: {:x}, base_addr: {:x}", cfg.get_top() as *mut u8 as u32, cfg.extra_pages, cfg.init_size, cfg.base_addr as u32);
+                    println!("previous_addr: {:x}, page_addr: {:x}", previous_addr, page_addr);
+                }
+            }
+
+            println!("Done with sections");
+            if previous_addr as usize & (PAGE_SIZE - 1) != 0 {
+                println!("Zeroing out remaining data");
+                // Zero-out the trailing bytes
+                unsafe {
+                    bzero(
+                        top.add(previous_addr as usize & (PAGE_SIZE - 1)),
+                        top.add(PAGE_SIZE as usize),
+                    )
+                };
+            } else {
+                println!("Skipping zero step -- we ended on a page boundary");
+            }
         }
     }
 }
@@ -944,6 +1182,7 @@ impl BootConfig {
     ///
     /// * If you try to map a page twice
     pub fn map_page(&mut self, root: &mut PageTable, phys: usize, virt: usize, flags: usize) {
+        if VDBG {println!("    map pa {:x} -> va {:x} (satp {:x})", phys, virt, root as *mut PageTable as u32);}
         match WORD_SIZE {
             4 => self.map_page_32(root, phys, virt, flags),
             8 => panic!("map_page doesn't work on 64-bit devices"),
@@ -973,8 +1212,8 @@ impl BootConfig {
         // Allocate a new level 1 pagetable entry if one doesn't exist.
         if l1_pt[vpn1] & FLG_VALID == 0 {
             let na = self.alloc() as usize;
-            println!("The Level 1 page table is invalid ({:08x}) @ {:08x} -- allocating a new one @ {:08x}",
-                unsafe { l1_pt.as_ptr().add(vpn1) } as usize, l1_pt[vpn1], na);
+            if VDBG {println!("The Level 1 page table is invalid ({:08x}) @ {:08x} -- allocating a new one @ {:08x}",
+                unsafe { l1_pt.as_ptr().add(vpn1) } as usize, l1_pt[vpn1], na);}
             // Mark this entry as a leaf node (WRX as 0), and indicate
             // it is a valid page by setting "V".
             l1_pt[vpn1] = ((na >> 12) << 10) | FLG_VALID;
@@ -1001,11 +1240,11 @@ impl BootConfig {
         // If we had to allocate a level 1 pagetable entry, ensure that it's
         // mapped into our address space, owned by PID 1.
         if let Some(addr) = new_addr {
-            println!(
+            if VDBG {println!(
                 ">>> Mapping new address {:08x} -> {:08x}",
                 addr.get(),
                 PAGE_TABLE_OFFSET + vpn1 * PAGE_SIZE
-            );
+            );}
             self.map_page(
                 root,
                 addr.get(),
@@ -1013,7 +1252,7 @@ impl BootConfig {
                 FLG_R | FLG_W | FLG_VALID,
             );
             self.change_owner(1 as XousPid, addr.get());
-            println!("<<< Done mapping new address");
+            if VDBG {println!("<<< Done mapping new address");}
         }
     }
 }
@@ -1271,16 +1510,6 @@ fn boot_sequence(args: KernelArguments, _signature: u32) -> ! {
         resume_csr.wfo(utra::susres::INTERRUPT_INTERRUPT, 1);
     }
 
-    println!("Font maps located as follows:");
-    println!("  Hanzi @ {:08x}", fonts::zh::ZH_GLYPHS.as_ptr() as u32);
-    println!("  Emoji @ {:08x}", fonts::emoji::EMOJI_GLYPHS.as_ptr() as u32);
-    println!(
-        "  Regular @ {:08x}",
-        fonts::regular::REGULAR_GLYPHS.as_ptr() as u32
-    );
-    println!("  Small @ {:08x}", fonts::small::SMALL_GLYPHS.as_ptr() as u32);
-    println!("  Bold @ {:08x}", fonts::bold::BOLD_GLYPHS.as_ptr() as u32);
-
     if !clean {
         // The MMU should be set up now, and memory pages assigned to their
         // respective processes.
@@ -1314,9 +1543,11 @@ fn boot_sequence(args: KernelArguments, _signature: u32) -> ! {
             (*backup_args)[6] = if cfg.debug {1} else {0};
             #[cfg(feature="debug-print")]
             {
-                println!("Backup kernel args:");
-                for i in 0..7 {
-                    println!("0x{:08x}", (*backup_args)[i]);
+                if VDBG {
+                    println!("Backup kernel args:");
+                    for i in 0..7 {
+                        println!("0x{:08x}", (*backup_args)[i]);
+                    }
                 }
             }
         }
@@ -1491,7 +1722,7 @@ pub fn phase_2(cfg: &mut BootConfig) {
 
     // This is the offset in RAM where programs are loaded from.
     let mut process_offset = cfg.sram_start as usize + cfg.sram_size - cfg.init_size;
-    println!("Procesess start out @ {:08x}", process_offset);
+    println!("\n\nPhase2: Processess start out @ {:08x}", process_offset);
 
     // Go through all Init processes and the kernel, setting up their
     // page tables and mapping memory to them.
@@ -1499,11 +1730,20 @@ pub fn phase_2(cfg: &mut BootConfig) {
     for tag in args.iter() {
         if tag.name == u32::from_le_bytes(*b"IniE") {
             let inie = MiniElf::new(&tag);
-            println!("Mapping program into memory");
-            process_offset -= inie.load(cfg, process_offset, pid);
+            println!("\n\nCopying IniE program into memory");
+            let allocated = inie.load(cfg, process_offset, pid, false);
+            println!("IniE Allocated {:x}", allocated);
+            process_offset -= allocated;
+            pid += 1;
+        } else if tag.name == u32::from_le_bytes(*b"IniF") {
+            let inif = MiniElf::new(&tag);
+            println!("\n\nMapping IniF program into memory");
+            let allocated = inif.load(cfg, process_offset, pid, true);
+            println!("IniF Allocated {:x}", allocated);
+            process_offset -= allocated;
             pid += 1;
         } else if tag.name == u32::from_le_bytes(*b"XKrn") {
-            println!("Mapping kernel into memory");
+            println!("\n\nCopying kernel into memory");
             let xkrn = unsafe { &*(tag.data.as_ptr() as *const ProgramDescription) };
             let load_size_rounded = ((xkrn.text_size as usize + PAGE_SIZE - 1) & !(PAGE_SIZE - 1))
                 + (((xkrn.data_size + xkrn.bss_size) as usize + PAGE_SIZE - 1) & !(PAGE_SIZE - 1));
@@ -1541,7 +1781,7 @@ pub fn phase_2(cfg: &mut BootConfig) {
         unsafe { (l1_pt_addr as *mut usize).add(1023).write(krn_pg1023_ptr) };
     }
 
-    if VDBG {
+    if VVDBG {
         println!("PID1 pagetables:");
         debug::print_pagetable(cfg.processes[0].satp);
         println!();

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = "0.7.1"
 log = "0.4.14"
 pem = "0.8.3"
 svd2utra = "0.1.11"
-xmas-elf = "0.7.0"
+xmas-elf = "0.9.0"
 xous-semver = "0.1.2"
 
 [[bin]]

--- a/tools/src/bin/create-image.rs
+++ b/tools/src/bin/create-image.rs
@@ -276,7 +276,8 @@ fn main() {
             );
             pid += 1;
             let init = read_minielf(init_path).expect("couldn't parse init file");
-            args.add(IniF::new(init.entry_point, init.sections, init.program));
+            args.add(IniF::new(init.entry_point, init.sections, init.program, init.alignment_offset));
+            args.set_alignment_offset(init.alignment_offset);
         }
     }
 

--- a/tools/src/bin/create-image.rs
+++ b/tools/src/bin/create-image.rs
@@ -9,6 +9,7 @@ use std::fs::File;
 use tools::elf::{read_minielf, read_program};
 use tools::tags::bflg::Bflg;
 use tools::tags::inie::IniE;
+use tools::tags::inif::IniF;
 use tools::tags::memory::{MemoryRegion, MemoryRegions};
 use tools::tags::pnam::ProcessNames;
 use tools::tags::xkrn::XousKernel;
@@ -86,6 +87,15 @@ fn main() {
                 .multiple(true)
                 .number_of_values(1)
                 .help("Initial program to load"),
+        )
+        .arg(
+            Arg::with_name("inif")
+                .short("f")
+                .long("inif")
+                .takes_value(true)
+                .multiple(true)
+                .number_of_values(1)
+                .help("Initial program to load from FLASH"),
         )
         .arg(
             Arg::with_name("csv")
@@ -235,8 +245,8 @@ fn main() {
     .expect("unable to read kernel");
 
     process_names.set(1, "kernel");
+    let mut pid = 2;
     if let Some(init_paths) = matches.values_of("init") {
-        let mut pid = 2;
         for init_path in init_paths {
             let program_name = std::path::Path::new(init_path);
             process_names.set(
@@ -250,6 +260,23 @@ fn main() {
             pid += 1;
             let init = read_minielf(init_path).expect("couldn't parse init file");
             args.add(IniE::new(init.entry_point, init.sections, init.program));
+        }
+    }
+
+    if let Some(init_paths) = matches.values_of("inif") {
+        for init_path in init_paths {
+            let program_name = std::path::Path::new(init_path);
+            process_names.set(
+                pid,
+                program_name
+                    .file_stem()
+                    .expect("program had no name")
+                    .to_str()
+                    .expect("program name is not valid utf-8"),
+            );
+            pid += 1;
+            let init = read_minielf(init_path).expect("couldn't parse init file");
+            args.add(IniF::new(init.entry_point, init.sections, init.program));
         }
     }
 

--- a/tools/src/bin/create-image.rs
+++ b/tools/src/bin/create-image.rs
@@ -277,7 +277,6 @@ fn main() {
             pid += 1;
             let init = read_minielf(init_path).expect("couldn't parse init file");
             args.add(IniF::new(init.entry_point, init.sections, init.program, init.alignment_offset));
-            args.set_alignment_offset(init.alignment_offset);
         }
     }
 

--- a/tools/src/tags/inie.rs
+++ b/tools/src/tags/inie.rs
@@ -62,7 +62,7 @@ impl XousArgument for IniE {
         self.load_offset = offset as u32;
 
         assert!(offset % crate::tags::PAGE_SIZE == 0, "IniE load offset is not aligned");
-        self.data = crate::tags::align_data_up(&self.data);
+        self.data = crate::tags::align_data_up(&self.data, 0);
         self.data.len()
     }
 

--- a/tools/src/tags/inif.rs
+++ b/tools/src/tags/inif.rs
@@ -74,6 +74,10 @@ impl XousArgument for IniF {
         &self.data
     }
 
+    fn alignment_offset(&self) -> usize {
+        self.alignment_offset
+    }
+
     fn serialize(&self, output: &mut dyn io::Write) -> io::Result<usize> {
         let mut written = 0;
         written += output.write(&self.load_offset.to_le_bytes())?;

--- a/tools/src/tags/mod.rs
+++ b/tools/src/tags/mod.rs
@@ -7,19 +7,23 @@ pub mod inif;
 
 pub (crate) const PAGE_SIZE: usize = 4096;
 
-pub fn align_size_up(offset: usize) -> usize {
-    if offset % PAGE_SIZE == 0 {
+pub fn align_size_up(offset: usize, alignment_offset: usize) -> usize {
+    if offset % PAGE_SIZE == alignment_offset {
         offset
     } else {
-        (offset + PAGE_SIZE) & !(PAGE_SIZE - 1)
+        if offset % PAGE_SIZE < alignment_offset {
+            offset + (alignment_offset - offset % PAGE_SIZE)
+        } else {
+            (offset & !(PAGE_SIZE - 1)) + PAGE_SIZE + alignment_offset
+        }
     }
 }
 
-pub fn align_data_up(data: &Vec<u8>) -> Vec::<u8> {
-    if data.len() % PAGE_SIZE == 0 {
+pub fn align_data_up(data: &Vec<u8>, alignment_offset: usize) -> Vec::<u8> {
+    if data.len() % PAGE_SIZE == alignment_offset {
         data.to_vec()
     } else {
-        let padding = align_size_up(data.len()) - data.len();
+        let padding = align_size_up(data.len(), alignment_offset) - data.len();
         let pad = vec![0u8; padding];
         (&[&data[..], &pad[..]]).concat().to_vec()
     }

--- a/tools/src/tags/mod.rs
+++ b/tools/src/tags/mod.rs
@@ -3,3 +3,24 @@ pub mod inie;
 pub mod memory;
 pub mod pnam;
 pub mod xkrn;
+pub mod inif;
+
+pub (crate) const PAGE_SIZE: usize = 4096;
+
+pub fn align_size_up(offset: usize) -> usize {
+    if offset % PAGE_SIZE == 0 {
+        offset
+    } else {
+        (offset + PAGE_SIZE) & !(PAGE_SIZE - 1)
+    }
+}
+
+pub fn align_data_up(data: &Vec<u8>) -> Vec::<u8> {
+    if data.len() % PAGE_SIZE == 0 {
+        data.to_vec()
+    } else {
+        let padding = align_size_up(data.len()) - data.len();
+        let pad = vec![0u8; padding];
+        (&[&data[..], &pad[..]]).concat().to_vec()
+    }
+}

--- a/tools/src/tags/xkrn.rs
+++ b/tools/src/tags/xkrn.rs
@@ -79,7 +79,7 @@ impl XousArgument for XousKernel {
         "kernel text section is invalid: 0x{:08x} < 0xff000000 -- was it linked with a linker script?", self.text_offset);
 
         assert!(offset % crate::tags::PAGE_SIZE == 0, "XKrn load offset is not aligned");
-        self.program = crate::tags::align_data_up(&self.program);
+        self.program = crate::tags::align_data_up(&self.program, 0);
 
         self.program.len()
     }

--- a/tools/src/tags/xkrn.rs
+++ b/tools/src/tags/xkrn.rs
@@ -77,6 +77,10 @@ impl XousArgument for XousKernel {
         self.load_offset = offset as u32;
         assert!(self.text_offset > 0xff00_0000,
         "kernel text section is invalid: 0x{:08x} < 0xff000000 -- was it linked with a linker script?", self.text_offset);
+
+        assert!(offset % crate::tags::PAGE_SIZE == 0, "XKrn load offset is not aligned");
+        self.program = crate::tags::align_data_up(&self.program);
+
         self.program.len()
     }
 

--- a/xtask/src/builder.rs
+++ b/xtask/src/builder.rs
@@ -268,8 +268,10 @@ impl Builder {
 
     /// Add just one app
     #[allow(dead_code)]
-    pub fn add_app<'a>(&'a mut self, app_spec: &str) -> &'a mut Builder {
-        self.apps.push(app_spec.into());
+    pub fn add_app<'a>(&'a mut self, app_spec: &str, xip: bool) -> &'a mut Builder {
+        let mut spec: CrateSpec = app_spec.into();
+        spec.set_xip(xip);
+        self.apps.push(spec);
         self
     }
     /// Add a list of apps

--- a/xtask/src/builder.rs
+++ b/xtask/src/builder.rs
@@ -446,7 +446,8 @@ impl Builder {
             let mut found = false;
             for app in self.apps.iter() {
                 if let Some(n) = &app.name() {
-                    if Path::new(service).file_name().unwrap_or_default().to_str().unwrap_or_default() == n {
+                    if Path::new(service).file_name().unwrap_or_default().to_str().unwrap_or_default() ==
+                        Path::new(n).file_name().unwrap_or_default().to_str().unwrap_or_default() {
                         if app.is_xip() {
                             inif.push(service.to_string());
                         } else {
@@ -462,7 +463,8 @@ impl Builder {
             }
             for serv in self.services.iter() {
                 if let Some(n) = &serv.name() {
-                    if Path::new(service).file_name().unwrap_or_default().to_str().unwrap_or_default() == n {
+                    if Path::new(service).file_name().unwrap_or_default().to_str().unwrap_or_default() ==
+                        Path::new(n).file_name().unwrap_or_default().to_str().unwrap_or_default() {
                         if serv.is_xip() {
                             inif.push(service.to_string());
                         } else {

--- a/xtask/src/builder.rs
+++ b/xtask/src/builder.rs
@@ -22,25 +22,55 @@ impl BuildStream {
     }
 }
 
+#[derive(Debug)]
 pub enum CrateSpec {
     /// name of the crate
-    Local(String),
+    Local(String, bool),
     /// crates.io: (name of crate, version)
-    CratesIo(String, String),
+    CratesIo(String, String, bool),
     /// a prebuilt package: (name of executable, URL for download)
-    Prebuilt(String, String),
+    Prebuilt(String, String, bool),
     /// a prebuilt binary, done using command line tools
-    BinaryFile(String),
+    BinaryFile(String, bool),
     /// an empty entry
     None,
+}
+impl CrateSpec {
+    pub fn is_xip(&self) -> bool {
+        match self {
+            CrateSpec::Local(_s, xip) => *xip,
+            CrateSpec::CratesIo(_n, _v, xip) => *xip,
+            CrateSpec::Prebuilt(_n, _u, xip) => *xip,
+            CrateSpec::BinaryFile(_path, xip) => *xip,
+            _ => false
+        }
+    }
+    pub fn set_xip(&mut self, xip: bool) {
+        *self = match self {
+            CrateSpec::Local(s, _xip) => CrateSpec::Local(s.to_string(), xip),
+            CrateSpec::CratesIo(n, v, _xip) => CrateSpec::CratesIo(n.to_string(), v.to_string(), xip),
+            CrateSpec::Prebuilt(n, u, _xip) => CrateSpec::Prebuilt(n.to_string(), u.to_string(), xip),
+            CrateSpec::BinaryFile(path, _xip) => CrateSpec::BinaryFile(path.to_string(), xip),
+            CrateSpec::None => CrateSpec::None,
+        }
+    }
+    pub fn name(&self) -> Option<String> {
+        match self {
+            CrateSpec::Local(s, _xip) => Some(s.to_string()),
+            CrateSpec::CratesIo(n, _v, _xip) => Some(n.to_string()),
+            CrateSpec::Prebuilt(n, _u, _xip) => Some(n.to_string()),
+            CrateSpec::BinaryFile(path, _xip) => Some(path.to_string()),
+            _ => None,
+        }
+    }
 }
 impl Clone for CrateSpec {
     fn clone(&self) -> CrateSpec {
         match self {
-            CrateSpec::Local(s) => CrateSpec::Local(s.to_string()),
-            CrateSpec::CratesIo(n, v) => CrateSpec::CratesIo(n.to_string(), v.to_string()),
-            CrateSpec::Prebuilt(n, u) => CrateSpec::Prebuilt(n.to_string(), u.to_string()),
-            CrateSpec::BinaryFile(path) => CrateSpec::BinaryFile(path.to_string()),
+            CrateSpec::Local(s, xip) => CrateSpec::Local(s.to_string(), *xip),
+            CrateSpec::CratesIo(n, v, xip) => CrateSpec::CratesIo(n.to_string(), v.to_string(), *xip),
+            CrateSpec::Prebuilt(n, u, xip) => CrateSpec::Prebuilt(n.to_string(), u.to_string(), *xip),
+            CrateSpec::BinaryFile(path, xip) => CrateSpec::BinaryFile(path.to_string(), *xip),
             CrateSpec::None => CrateSpec::None,
         }
     }
@@ -52,7 +82,8 @@ impl From<&str> for CrateSpec {
             let (name, version) = spec.split_once('@').expect("couldn't parse crate specifier");
             CrateSpec::CratesIo(
                 name.to_string(),
-                version.to_string()
+                version.to_string(),
+                false
             )
         // prebuilt crates are specified as "name#url"
         // i.e. "espeak-embedded#https://ci.betrusted.io/job/espeak-embedded/lastSuccessfulBuild/artifact/target/riscv32imac-unknown-xous-elf/release/"
@@ -60,16 +91,17 @@ impl From<&str> for CrateSpec {
             let (name, url) = spec.split_once('#').expect("couldn't parse crate specifier");
             CrateSpec::Prebuilt(
                 name.to_string(),
-                url.to_string()
+                url.to_string(),
+                false
             )
         // local files are specified as paths, which, at a minimum include one directory separator "/" or "\"
         // i.e. "./local_file"
         // Note that this is after a test for the '#' character, so that disambiguates URL slashes
         // It does mean that files with a '#' character in them are mistaken for URL coded paths, and '@' as remote crates.
         } else if spec.contains('/') || spec.contains('\\') {
-            CrateSpec::BinaryFile(spec.to_string())
+            CrateSpec::BinaryFile(spec.to_string(), false)
         } else {
-            CrateSpec::Local(spec.to_string())
+            CrateSpec::Local(spec.to_string(), false)
         }
     }
 }
@@ -103,11 +135,11 @@ pub(crate) struct Builder {
 impl Builder {
     pub fn new() -> Builder {
         Builder {
-            loader: CrateSpec::Local("loader".to_string()),
+            loader: CrateSpec::Local("loader".to_string(), false),
             loader_features: Vec::new(),
             loader_key: "devkey/dev.key".into(),
             loader_disable_defaults: false,
-            kernel: CrateSpec::Local("xous-kernel".to_string()),
+            kernel: CrateSpec::Local("xous-kernel".to_string(), false),
             kernel_features: Vec::new(),
             kernel_key: "devkey/dev.key".into(),
             kernel_disable_defaults: false,
@@ -189,8 +221,8 @@ impl Builder {
         self.stream = BuildStream::Release;
         self.run_svd2repl = true;
         self.utra_target = "renode".to_string();
-        self.loader = CrateSpec::Local("loader".to_string());
-        self.kernel = CrateSpec::Local("xous-kernel".to_string());
+        self.loader = CrateSpec::Local("loader".to_string(), false);
+        self.kernel = CrateSpec::Local("xous-kernel".to_string(), false);
         self
     }
     /// Configure for precursor targets. This is the default, but it's good practice
@@ -201,8 +233,8 @@ impl Builder {
         self.stream = BuildStream::Release;
         self.utra_target = format!("precursor-{}", soc_version).to_string();
         self.run_svd2repl = false;
-        self.loader = CrateSpec::Local("loader".to_string());
-        self.kernel = CrateSpec::Local("xous-kernel".to_string());
+        self.loader = CrateSpec::Local("loader".to_string(), false);
+        self.kernel = CrateSpec::Local("xous-kernel".to_string(), false);
         self
     }
 
@@ -220,9 +252,10 @@ impl Builder {
     }
 
     /// Add just one service
-    #[allow(dead_code)]
-    pub fn add_service<'a>(&'a mut self, service_spec: &str) -> &'a mut Builder {
-        self.services.push(service_spec.into());
+    pub fn add_service<'a>(&'a mut self, service_spec: &str, xip: bool) -> &'a mut Builder {
+        let mut spec: CrateSpec = service_spec.into();
+        spec.set_xip(xip);
+        self.services.push(spec);
         self
     }
     /// Add a list of services
@@ -339,8 +372,8 @@ impl Builder {
         let mut remote_pkgs = Vec::<(&str, &str)>::new();
         for pkg in packages.iter() {
             match pkg {
-                CrateSpec::Local(name) => local_pkgs.push(&name),
-                CrateSpec::CratesIo(name, version) => remote_pkgs.push((&name, &version)),
+                CrateSpec::Local(name, _xip) => local_pkgs.push(&name),
+                CrateSpec::CratesIo(name, version, _xip) => remote_pkgs.push((&name, &version)),
                 _ => {},
             }
         }
@@ -404,6 +437,50 @@ impl Builder {
         Ok(artifacts)
     }
 
+    pub fn split_xip(&self, services: Vec<String>) -> (Vec<String>, Vec<String>) {
+        let mut inie = Vec::<String>::new();
+        let mut inif = Vec::<String>::new();
+        for service in services.iter() {
+            let mut found = false;
+            for app in self.apps.iter() {
+                if let Some(n) = &app.name() {
+                    if Path::new(service).file_name().unwrap_or_default().to_str().unwrap_or_default() == n {
+                        if app.is_xip() {
+                            inif.push(service.to_string());
+                        } else {
+                            inie.push(service.to_string());
+                        }
+                        found = true;
+                        continue;
+                    }
+                }
+            }
+            if found {
+                continue;
+            }
+            for serv in self.services.iter() {
+                if let Some(n) = &serv.name() {
+                    if Path::new(service).file_name().unwrap_or_default().to_str().unwrap_or_default() == n {
+                        if serv.is_xip() {
+                            inif.push(service.to_string());
+                        } else {
+                            inie.push(service.to_string());
+                        }
+                        found = true;
+                        continue;
+                    }
+                }
+            }
+            if found {
+                continue;
+            }
+            // the service wasn't found in any of the other lists, mark it as non-xip
+            inie.push(service.to_string());
+        }
+        assert!(inie.len() + inif.len() == services.len());
+        (inie, inif)
+    }
+
     /// Consume the builder and execute the configured build task. This handles dispatching all configurations,
     /// including renode, hosted, and hardware targets.
     pub fn build(mut self) -> Result<(), DynError> {
@@ -441,8 +518,8 @@ impl Builder {
         let mut app_names = Vec::<String>::new();
         for app in self.apps.iter() {
             match app {
-                CrateSpec::Local(name) => app_names.push(name.into()),
-                CrateSpec::CratesIo(name, _version) => app_names.push(name.into()),
+                CrateSpec::Local(name, _xip) => app_names.push(name.into()),
+                CrateSpec::CratesIo(name, _version, _xip) => app_names.push(name.into()),
                 _ => {}
             }
         }
@@ -460,7 +537,7 @@ impl Builder {
             // throw a warning if prebuilts are specified for hosted mode
             for item in [&self.services[..], &self.apps[..]].concat() {
                 match item {
-                    CrateSpec::Prebuilt(name, _) => println!("Warning! Pre-built binaries not supported for hosted mode ({})", name),
+                    CrateSpec::Prebuilt(name, _, _xip) => println!("Warning! Pre-built binaries not supported for hosted mode ({})", name),
                     _ => {},
                 }
             }
@@ -503,7 +580,7 @@ impl Builder {
             } else {
                 // confirm the kernel can build before quitting
                 let _ = self.builder(
-                    &vec![CrateSpec::Local("xous-kernel".into())],
+                    &vec![CrateSpec::Local("xous-kernel".into(), false)],
                     &self.kernel_features,
                     &target,
                     self.stream,
@@ -584,9 +661,11 @@ impl Builder {
             services_path.append(&mut self.enumerate_binary_files()?);
 
             // --------- package up and sign a binary image ----------
+            let (inie, inif) = self.split_xip(services_path);
             let output_bundle = self.create_image(
                 &kernel_path[0],
-                &services_path,
+                &inie,
+                &inif,
                 MemorySpec::SvdFile(svd_path)
             )?;
             println!();
@@ -679,6 +758,7 @@ impl Builder {
         &self,
         kernel: &String,
         init: &[String],
+        inif: &[String],
         memory_spec: MemorySpec,
     ) -> Result<PathBuf, DynError> {
         let stream = self.stream.to_str();
@@ -696,6 +776,11 @@ impl Builder {
 
         for i in init {
             args.push("--init");
+            args.push(i);
+        }
+
+        for i in inif {
+            args.push("--inif");
             args.push(i);
         }
 
@@ -721,7 +806,7 @@ impl Builder {
         let mut paths = Vec::<String>::new();
         for item in [&self.services[..], &self.apps[..]].concat() {
             match item {
-                CrateSpec::Prebuilt(name, url) => {
+                CrateSpec::Prebuilt(name, url, _xip) => {
                     let exec_name = format!("target/{}/{}/{}", TARGET_TRIPLE, self.stream.to_str(), name);
                     println!("Fetching {} executable from build server...", name);
                     let mut exec_file = OpenOptions::new()
@@ -752,7 +837,7 @@ impl Builder {
         let mut paths = Vec::<String>::new();
         for item in [&self.services[..], &self.apps[..]].concat() {
             match item {
-                CrateSpec::BinaryFile(path) => {
+                CrateSpec::BinaryFile(path, _xip) => {
                     paths.push(path);
                 }
                 _ => {}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -284,7 +284,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             for app in get_cratespecs() {
-                builder.add_app(&app, false);
+                builder.add_app(&app, true);
             }
         }
         Some("perf-image") => {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -193,10 +193,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                    .add_services(&get_cratespecs());
             builder.add_loader_feature("renode-bypass")
                    .add_loader_feature("renode-minimal");
-            builder.add_service("net")
-                .add_service("com")
-                .add_service("llio")
-                .add_service("dns");
+            builder.add_service("net", false)
+                .add_service("com", false)
+                .add_service("llio", false)
+                .add_service("dns", false);
         }
         Some("renode-aes-test") => {
             builder.target_renode()
@@ -207,7 +207,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             builder.target_renode()
                    .add_services(&gfx_base_pkgs.into_iter().map(String::from).collect())
                    .add_services(&get_cratespecs());
-            builder.add_service("ffi-test");
+            builder.add_service("ffi-test", false);
             builder.add_loader_feature("renode-bypass");
         }
         Some("renode-remote") => {
@@ -316,7 +316,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             builder.add_services(&pkgs.into_iter().map(String::from).collect())
                 .add_apps(&get_cratespecs())
-                .add_service("espeak-embedded#https://ci.betrusted.io/job/espeak-embedded/lastSuccessfulBuild/artifact/target/riscv32imac-unknown-xous-elf/release/espeak-embedded")
+                .add_service("espeak-embedded#https://ci.betrusted.io/job/espeak-embedded/lastSuccessfulBuild/artifact/target/riscv32imac-unknown-xous-elf/release/espeak-embedded", false)
                 .override_locale("en-tts")
                 .add_feature("tts")
                 .add_feature("braille");
@@ -331,7 +331,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                    .add_services(&base_pkgs.into_iter().map(String::from).collect())
                    .add_services(&get_cratespecs());
             //builder.add_service("usb-test");
-            builder.add_service("usb-device-xous");
+            builder.add_service("usb-device-xous", false);
         }
         Some("pddb-dev") => {
             builder.target_precursor(PRECURSOR_SOC_VERSION)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -272,6 +272,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                    .add_feature("mass-storage") // add this in by default to help with testing
                    .add_apps(&get_cratespecs());
         }
+        Some("app-image-xip") => {
+            builder.target_precursor(PRECURSOR_SOC_VERSION)
+                   //.add_services(&user_pkgs.into_iter().map(String::from).collect())
+                   .add_feature("mass-storage"); // add this in by default to help with testing
+            for service in user_pkgs {
+                if (service != "shellchat") && (service != "ime-plugin-shell" && (service != "com") && (service != "status") && (service != "net")) {
+                    builder.add_service(service, false);
+                } else {
+                    builder.add_service(service, true);
+                }
+            }
+            for app in get_cratespecs() {
+                builder.add_app(&app, false);
+            }
+        }
         Some("perf-image") => {
             // `--feature vaultperf` will make `vault` the performance manager, in exclusion of shellchat
             if !builder.has_feature("shellperf") && !builder.has_feature("vaultperf") {

--- a/xtask/src/verifier.rs
+++ b/xtask/src/verifier.rs
@@ -32,7 +32,7 @@ pub fn check_project_consistency() -> Result<(), DynError> {
 }
 
 pub fn verify(spec: CrateSpec) -> Result<(), DynError> {
-    if let CrateSpec::CratesIo(name, version) = spec {
+    if let CrateSpec::CratesIo(name, version, _xip) = spec {
         let mut cache_path = Path::new(&env::var("CARGO_HOME").unwrap()).to_path_buf();
         cache_path.push("registry");
         cache_path.push("src");


### PR DESCRIPTION
This patch intends to align all the executable objects (kernel, processes) to pages. It also introduces the skeleton of an IniF, which is basically just IniE with the terms search/replaced for now.

The patch also includes the ability to mark a process as `xip` when you add it to the services list. By default, it is not `xip`, but when adding a single service to the list one can toggle its `xip` flag.

Just before calling create-image, the services list is then split into an IniE and IniF list and passed onto the image creator as such. At the moment IniF is more of a no-op, it just packs it in as an IniE but with a different flag (and the loader wouldn't be able to parse the image either), but it creates a scaffolding for later on handling the `xip` processes differently. The aim is to have the IniE processes placed from the bottom-up in the kernel image address space, and the IniF processes packed into a separate `apps.img` blob that is signed but written to a different location in flash than the kernel.

Of course, the `xous.img` is intimately coupled to the `apps.img` because the args have to be updated to search for and load the apps; but now, the args are located in a page-sized region at the top of kernel, so it's conceivable that we can easily swap out the args + signature pages without affecting the kernel data itself. It would require building some sort of argument packer + signing mechanism into the existing kernel on the device itself (instead of having it all in the loader). Not a problem to solve today, but eventually solvable?

This is lightly tested on hardware and it works. I figure if the offsets didn't work it'd be immediately obvious on boot.