### PR TITLE
fix: #320 adds the eh_frame tags and passes them to each process

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -71,25 +71,6 @@ pub unsafe extern "C" fn init(
     platform::init();
 
     println!("KMAIN (clean boot): Supervisor mode started...");
-    println!("RAM usage:");
-    let mut total_bytes = 0;
-    crate::services::SystemServices::with(|system_services| {
-        crate::mem::MemoryManager::with(|mm| {
-            for process in &system_services.processes {
-                if !process.free() {
-                    let bytes_used = mm.ram_used_by(process.pid);
-                    total_bytes += bytes_used;
-                    println!(
-                        "    PID {:>3}: {:>4} k {}",
-                        process.pid,
-                        bytes_used / 1024,
-                        system_services.process_name(process.pid).unwrap_or("")
-                    );
-                }
-            }
-        });
-    });
-    println!("{} k total", total_bytes / 1024);
 
     // rand::init() already clears the initial pipe, but pump the TRNG a little more out of no other reason than sheer paranoia
     platform::rand::get_u32();

--- a/kernel/src/services.rs
+++ b/kernel/src/services.rs
@@ -22,6 +22,15 @@ const MAX_SERVER_COUNT: usize = 128;
 
 pub use crate::arch::process::{INITIAL_TID, MAX_PROCESS_COUNT};
 
+#[allow(dead_code)]
+const MINIELF_FLG_W: u8 = 1;
+#[allow(dead_code)]
+const MINIELF_FLG_NC: u8 = 2;
+#[allow(dead_code)]
+const MINIELF_FLG_X: u8 = 4;
+const MINIELF_FLG_EHF: u8 = 8;
+const MINIELF_FLG_EHH: u8 = 0x10;
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ExceptionHandler {
     /// Address (in program space) where the exception handler is
@@ -342,6 +351,22 @@ impl SystemServices {
             }
         };
 
+        // we can *only* iterate through kernel args. We can't access it as a slice.
+        let mut arg_iter = args.iter().peekable();
+        loop {
+            if let Some(arg) = arg_iter.peek() {
+                println!("loop");
+                if arg.name == u32::from_le_bytes(*b"IniE") || arg.name == u32::from_le_bytes(*b"IniF") {
+                    println!("found!");
+                    break;
+                }
+            } else {
+                panic!("Could not re-discover start of user services");
+            }
+            arg_iter.next();
+        }
+        // at this point, arg.next() will have the offset of the first process argument.
+
         // Copy over the initial process list.  The pid is encoded in the SATP
         // value from the bootloader.  For each process, translate it from a raw
         // KernelArguments value to a SystemServices Process value.
@@ -366,6 +391,29 @@ impl SystemServices {
             if pid == 1 {
                 process.state = ProcessState::Running(0);
             } else {
+                // This code makes the following assumption:
+                //   - Arguments are in the same order as processes
+                //   - All processes take the form of IniE/IniF such that the flags are in the last word
+                //   - Process #1 is the kernel
+                // Any changes to this will break this code!
+                let mut eh_frame = 0;
+                let mut eh_frame_size = 0;
+                let mut eh_frame_header = 0;
+                let mut eh_frame_header_size = 0;
+                if let Some(arg) = arg_iter.next() {
+                    for section in arg.data.chunks_exact(2) {
+                        let flags = (section[1] >> 24) as u8;
+                        if flags & MINIELF_FLG_EHF != 0 {
+                            eh_frame = section[0];
+                            eh_frame_size = section[1] & 0xFF_FFFF;
+                        } else if flags & MINIELF_FLG_EHH != 0 {
+                            eh_frame_header = section[0];
+                            eh_frame_header_size = section[1] & 0xFF_FFFF;
+                        }
+                    }
+                }
+
+                // end of assumption area
                 process.state = ProcessState::Setup(ThreadInit::new(
                     unsafe { core::mem::transmute::<usize, _>(init.entrypoint) },
                     unsafe {
@@ -375,10 +423,10 @@ impl SystemServices {
                         )
                         .unwrap()
                     },
-                    pid,
-                    0,
-                    0,
-                    0,
+                    eh_frame as _,
+                    eh_frame_size as _,
+                    eh_frame_header as _,
+                    eh_frame_header_size as _,
                 ));
             }
             // log_process_update(file!(), line!(), process, old_state);

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -42,6 +42,10 @@ const MINIELF_FLG_W: u8 = 1;
 const MINIELF_FLG_NC: u8 = 2;
 #[allow(dead_code)]
 const MINIELF_FLG_X: u8 = 4;
+#[allow(dead_code)]
+const MINIELF_FLG_EHF: u8 = 8;
+#[allow(dead_code)]
+const MINIELF_FLG_EHH: u8 = 0x10;
 
 const VDBG: bool = false; // verbose debug
 const VVDBG: bool = false; // very verbose debug

--- a/tools/src/elf.rs
+++ b/tools/src/elf.rs
@@ -17,6 +17,8 @@ bitflags! {
         const WRITE = 1;
         const NOCOPY = 2;
         const EXECUTE = 4;
+        const EH_FRAME = 8;
+        const EH_HEADER = 0x10;
     }
 }
 
@@ -349,6 +351,11 @@ pub fn process_minielf(b: &[u8]) -> Result<MiniElf, ElfReadError> {
         }
         if s.flags() & SHF_WRITE != 0 {
             flags |= MiniElfFlags::WRITE;
+        }
+        if name == ".eh_frame_hdr" {
+            flags |= MiniElfFlags::EH_HEADER
+        } else if name == ".eh_frame" {
+            flags |= MiniElfFlags::EH_FRAME;
         }
 
         debug!("Adding {} to the file", name);


### PR DESCRIPTION
this commit adds the facilities to extract eh_frame[_header] sections and pass it to each process.

A bump is required to `std` to extract the passed parameters.