### PR TITLE
loader: move the kernel stack to kernel region

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -57,12 +57,13 @@ assigned to every process simply by mapping megapage 1023 (`0xffc00000`).
 | 0xff801000 | Context data (registers, etc.)
 | 0xff802000 | Return address from syscalls (never allocated)
 | 0xffc00000 | Kernel arguments, allocation tables
+| 0xffcc0000 | Kernel GDB UART CSR page
 | 0xffcd0000 | Kernel WFI CSR page
 | 0xffce0000 | Kernel TRNG CSR page
 | 0xffcf0000 | Supervisor UART CSR page
 | 0xffd00000 | Kernel binary image and data section
-| 0xfffefffc | "default" stack pointer (used by interrupt handlers)
-| 0xffff0000 | Kernel stack top
+| 0xfff80000 | Kernel stack top
+| 0xffff0000 | "default" stack pointer (used by interrupt handlers)
 | 0xfff00000 | {unused}
 ```
 

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -40,6 +40,7 @@ const USER_AREA_END: usize = 0xff00_0000;
 // All of the kernel structures must live within Megapage 1023,
 // and therefore are limited to 4 MB.
 const EXCEPTION_STACK_TOP: usize = 0xffff_0000;
+const KERNEL_STACK_TOP: usize = 0xfff8_0000;
 const KERNEL_LOAD_OFFSET: usize = 0xffd0_0000;
 const KERNEL_STACK_PAGE_COUNT: usize = 1;
 const KERNEL_ARGUMENT_OFFSET: usize = 0xffc0_0000;

--- a/loader/src/phase2.rs
+++ b/loader/src/phase2.rs
@@ -133,7 +133,7 @@ impl ProgramDescription {
         let pid_idx = (pid - 1) as usize;
         let is_kernel = pid == 1;
         let flag_defaults = FLG_R | FLG_W | FLG_VALID | if is_kernel { 0 } else { FLG_U };
-        let stack_addr = USER_STACK_TOP - 16;
+        let stack_addr = if is_kernel { KERNEL_STACK_TOP } else { USER_STACK_TOP } - 16;
         if is_kernel {
             assert!(self.text_offset as usize == KERNEL_LOAD_OFFSET);
             assert!(((self.text_offset + self.text_size) as usize) < EXCEPTION_STACK_TOP);


### PR DESCRIPTION
The kernel stack previously was located at the same relative offset as all other programs. While this worked, it is poor form.

Move the kernel stack into the kernel memory region (located in the last 4 megabytes of virtual address).