### PR TITLE
xtask: support multiple different targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5157,6 +5157,7 @@ dependencies = [
  "atty",
  "chrono",
  "filetime",
+ "lazy_static",
  "rustc_version 0.4.0",
  "serde",
  "serde_json",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,4 +18,5 @@ serde = { version = "1.0.130", features = ["derive"] }
 tempfile = "3.3.0"
 ureq = { version = "2.5.0", features = ["json"] }
 svd2utra = "0.1.11"
+lazy_static = "1.4.0"
 # toml_edit = "0.14.4" # would be used to verify Cargo.toml files, but it's too hard to do this right now.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -41,7 +41,9 @@ const PRECURSOR_SOC_VERSION: &str = "70190e2";
 const MIN_XOUS_VERSION: &str = "v0.9.8-791";
 
 /// target triple for precursor builds
-const TARGET_TRIPLE: &str = "riscv32imac-unknown-xous-elf";
+pub(crate) const TARGET_TRIPLE_RISCV32: &str = "riscv32imac-unknown-xous-elf";
+/// target triple for ARM builds
+pub(crate) const TARGET_TRIPLE_ARM: &str = "armv7a-unknown-xous-elf";
 
 // because I have nowhere else to note this. The commit that contains the rkyv-enum derive
 // refactor to work around warnings thrown by Rust 1.64.0 is: f815ed85b58b671178fbf53b4cea34186fc406eb
@@ -159,7 +161,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some("install-toolkit") | Some("install-toolchain") => {
             let arg = env::args().nth(2);
             ensure_compiler(
-                &Some(TARGET_TRIPLE),
+                &Some(TARGET_TRIPLE_RISCV32),
                 true,
                 arg.map(|x| x == "--force").unwrap_or(false),
             )?
@@ -367,6 +369,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             builder.target_precursor(PRECURSOR_SOC_VERSION)
                    .add_services(&user_pkgs.into_iter().map(String::from).collect())
                    .add_feature("avalanchetest");
+        }
+
+        // ------ ARM hardware image configs ------
+        Some("arm-tiny") => {
+            builder.target_arm()
+                .add_services(&base_pkgs.into_iter().map(String::from).collect())
+                .add_services(&get_cratespecs());
         }
 
         // ---- other single-purpose commands ----

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -399,8 +399,7 @@ pub(crate) fn whycheproof_import() -> Result<(), crate::DynError> {
 }
 
 pub(crate) fn track_language_changes(last_lang: &str) -> Result<(), crate::DynError> {
-    let last_config = format!("target/{}/LAST_LANG", TARGET_TRIPLE_RISCV32);
-    std::fs::create_dir_all(format!("target/{}/", TARGET_TRIPLE_RISCV32)).unwrap();
+    let last_config = "target/LAST_LANG";
     let mut contents = String::new();
 
     let changed = match OpenOptions::new()

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -1,3 +1,5 @@
+use lazy_static::lazy_static;
+use std::collections::HashMap;
 use std::{
     fs::{File, OpenOptions},
     io::{Read, Write},
@@ -5,10 +7,22 @@ use std::{
     process::Command,
 };
 
-use crate::TARGET_TRIPLE;
 use crate::{cargo, project_root};
+use crate::{TARGET_TRIPLE_RISCV32, TARGET_TRIPLE_ARM};
 
 const TOOLCHAIN_RELEASE_URL: &str = "https://api.github.com/repos/betrusted-io/rust/releases";
+const TOOLCHAIN_RELEASE_URL_ARM: &str =
+    "https://api.github.com/repos/Foundation-Devices/rust/releases";
+
+lazy_static! {
+    static ref TOOLCHAIN_RELEASE_URLS: HashMap<String, String> = HashMap::from([
+        (TARGET_TRIPLE_RISCV32.to_owned(), TOOLCHAIN_RELEASE_URL.to_owned()),
+        (
+            TARGET_TRIPLE_ARM.to_owned(),
+            TOOLCHAIN_RELEASE_URL_ARM.to_owned()
+        ),
+    ]);
+}
 
 /// Since we use the same TARGET for all calls to `build()`,
 /// cache it inside an atomic boolean. If this is `true` then
@@ -86,12 +100,12 @@ pub(crate) fn ensure_compiler(
     }
 
     // If the sysroot exists, then we're good.
-    let target = target.unwrap_or(TARGET_TRIPLE);
+    let target = target.unwrap_or(TARGET_TRIPLE_RISCV32);
     if let Some(path) = get_sysroot(Some(target))? {
         let mut version_path = PathBuf::from(&path);
         version_path.push("lib");
         version_path.push("rustlib");
-        version_path.push(TARGET_TRIPLE);
+        version_path.push(target);
         if remove_existing {
             println!("Target path exists, removing it");
             std::fs::remove_dir_all(version_path)
@@ -99,13 +113,13 @@ pub(crate) fn ensure_compiler(
             println!("Also removing target directories for existing toolchain");
             let mut target_main = project_root();
             target_main.push("target");
-            target_main.push(TARGET_TRIPLE);
+            target_main.push(target);
             std::fs::remove_dir_all(target_main).ok();
 
             let mut target_loader = project_root();
             target_loader.push("loader");
             target_loader.push("target");
-            target_loader.push(TARGET_TRIPLE);
+            target_loader.push(target);
             std::fs::remove_dir_all(target_loader).ok();
         } else {
             DONE_COMPILER_CHECK.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -162,8 +176,16 @@ pub(crate) fn ensure_compiler(
         println!();
     }
 
-    fn get_toolchain_url(major: u64, minor: u64, patch: u64) -> Result<String, String> {
-        let j: serde_json::Value = ureq::get(TOOLCHAIN_RELEASE_URL)
+    fn get_toolchain_url(
+        target: &str,
+        major: u64,
+        minor: u64,
+        patch: u64,
+    ) -> Result<String, String> {
+        let url = TOOLCHAIN_RELEASE_URLS
+            .get(target)
+            .ok_or_else(|| format!("Can't find toolchain URL for target {}", target))?;
+        let j: serde_json::Value = ureq::get(&url)
             .set("Accept", "application/vnd.github.v3+json")
             .call()
             .map_err(|e| format!("{}", e))?
@@ -218,12 +240,12 @@ pub(crate) fn ensure_compiler(
         }
 
         if let Some((_k, v)) = tag_urls.into_iter().last() {
-            // println!("Found candidate entry: v{} url {}", k, v);
+            // println!("Found candidate entry: v{} url {}", _k, v);
             return Ok(v);
         }
         Err(format!("No toolchains found for Rust {}", target_prefix))
     }
-    let toolchain_url = get_toolchain_url(ver.major, ver.minor, ver.patch)?;
+    let toolchain_url = get_toolchain_url(target, ver.major, ver.minor, ver.patch)?;
 
     println!(
         "Attempting to install toolchain for {} into {}",
@@ -377,8 +399,8 @@ pub(crate) fn whycheproof_import() -> Result<(), crate::DynError> {
 }
 
 pub(crate) fn track_language_changes(last_lang: &str) -> Result<(), crate::DynError> {
-    let last_config = format!("target/{}/LAST_LANG", TARGET_TRIPLE);
-    std::fs::create_dir_all(format!("target/{}/", TARGET_TRIPLE)).unwrap();
+    let last_config = format!("target/{}/LAST_LANG", TARGET_TRIPLE_RISCV32);
+    std::fs::create_dir_all(format!("target/{}/", TARGET_TRIPLE_RISCV32)).unwrap();
     let mut contents = String::new();
 
     let changed = match OpenOptions::new()

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -10,13 +10,13 @@ use std::{
 use crate::{cargo, project_root};
 use crate::{TARGET_TRIPLE_RISCV32, TARGET_TRIPLE_ARM};
 
-const TOOLCHAIN_RELEASE_URL: &str = "https://api.github.com/repos/betrusted-io/rust/releases";
+const TOOLCHAIN_RELEASE_URL_RISCV32: &str = "https://api.github.com/repos/betrusted-io/rust/releases";
 const TOOLCHAIN_RELEASE_URL_ARM: &str =
     "https://api.github.com/repos/Foundation-Devices/rust/releases";
 
 lazy_static! {
     static ref TOOLCHAIN_RELEASE_URLS: HashMap<String, String> = HashMap::from([
-        (TARGET_TRIPLE_RISCV32.to_owned(), TOOLCHAIN_RELEASE_URL.to_owned()),
+        (TARGET_TRIPLE_RISCV32.to_owned(), TOOLCHAIN_RELEASE_URL_RISCV32.to_owned()),
         (
             TARGET_TRIPLE_ARM.to_owned(),
             TOOLCHAIN_RELEASE_URL_ARM.to_owned()


### PR DESCRIPTION
As a part of a series of upcoming PRs extending Xous to support ARMv7-A, it extends `xtask` build system with an ARM target and sets a path forward to adding support for multiple targets and architectures. I'm not clear about the best way forward with Xous `libstd` though. It had received ARM support in [our fork](https://github.com/Foundation-Devices/rust) and due to that I've added the code to choose and download a specific `libstd` bundle depending on the target. Probably a better way might be is to include ARM support into the ["default" libstd](https://github.com/betrusted-io/rust) instead, thus keeping a single download URL.

It also adds `arm-tiny` subcommand as an example, but it's not expected to work until ARM support lands in `utralib`, `kernel` and `loader`.

Our effort of adding ARM support is based on [Microchip SAMA5D2x chip series](https://www.microchip.com/en-us/products/microcontrollers-and-microprocessors/32-bit-mpus/sama5/sama5d2-series). The end goal is to get Xous running on an off-the-shelf [SAMA5D27 dev board](https://www.microchip.com/en-us/development-tool/atsama5d27-som1-ek1).