### PR TITLE
elf: fix a section alignment edge case

### DIFF
--- a/tools/src/elf.rs
+++ b/tools/src/elf.rs
@@ -372,8 +372,12 @@ pub fn process_minielf(b: &[u8]) -> Result<MiniElf, ElfReadError> {
         if s.get_type() != Ok(ShType::NoBits) {
             let section_data = s.raw_data(&elf);
             let pad_amount = if let Some(next_section) = section_iter.peek() {
-                if section_data.len() % next_section.align() as usize != 0 {
-                    next_section.align() as usize - (section_data.len() % next_section.align() as usize)
+                if next_section.get_type() != Ok(ShType::NoBits) {
+                    if section_data.len() % next_section.align() as usize != 0 {
+                        next_section.align() as usize - (section_data.len() % next_section.align() as usize)
+                    } else {
+                        0
+                    }
                 } else {
                     0
                 }


### PR DESCRIPTION
I stumbled upon a weird edge case that causes the loader to panic with the following message:

```
panicked at 'init section addresses are not strictly increasing (new virt: 00042870, last virt: 00042874)', loader/src/phase1.rs:222:25
```

And upon checking the allocated ELF section addresses:

```
2    IniE: entrypoint @ 0002e404, loaded from 00001000.  Sections:
        Loaded from 00001000 - Section .ARM.exidx      1088 bytes loading into 000100f4..00010534 flags: NONE
        Loaded from 00001440 - Section .rodata        12664 bytes loading into 00010534..000136ac flags: NONE
        Loaded from 000045b8 - Section .text          61864 bytes loading into 000236ac..00032854 flags: EXECUTE
        Loaded from 00013760 - Section .data             32 bytes loading into 00042854..00042874 flags: WRITE
        Loaded from 00013780 - Section .bss             488 bytes loading into 00042870..00042a58 flags: WRITE | NOCOPY
```

I noticed an overlap between `.data` and `.bss` section addresses. Seems like it's caused by an edge case in padding calculaiton, so I've added this workaround. It fixes the issue.