### PR TITLE
elf.rs: fix alignment edge case (take 2)

### DIFF
--- a/tools/src/elf.rs
+++ b/tools/src/elf.rs
@@ -372,11 +372,12 @@ pub fn process_minielf(b: &[u8]) -> Result<MiniElf, ElfReadError> {
         if s.get_type() != Ok(ShType::NoBits) {
             let section_data = s.raw_data(&elf);
             let pad_amount = if let Some(next_section) = section_iter.peek() {
-                if next_section.get_type() != Ok(ShType::NoBits) {
-                    if section_data.len() % next_section.align() as usize != 0 {
-                        next_section.align() as usize - (section_data.len() % next_section.align() as usize)
+                if section_data.len() % next_section.align() as usize != 0 {
+                    let pad_amount = next_section.align() as usize - (section_data.len() % next_section.align() as usize);
+                    if s.address() + size + pad_amount as u64 > next_section.address() {
+                        (next_section.address() - (s.address() + size)) as usize
                     } else {
-                        0
+                        pad_amount
                     }
                 } else {
                     0


### PR DESCRIPTION
The previous PR (#342) didn't seem to fix all occurences of the section edge case. That check doesn't cover the case when the next section isn't `NoBits`.

Loader panics with the same error

```
panicked at 'init section addresses are not strictly increasing (new virt: 000109c0, last virt: 000109c4)', loader/src/phase1.rs:222:25
```

given the following section allocaiton:

```
 2    IniE: entrypoint @ 0003ac00, loaded from 00001000.  Sections:
        Loaded from 00001000 - Section .ARM.exidx      2256 bytes loading into 000100f4..000109c4 flags: NONE
        Loaded from 000018d0 - Section .rodata        28776 bytes loading into 000109c0..00017a28 flags: NONE
        Loaded from 00008938 - Section .text         112656 bytes loading into 00027a28..00043238 flags: EXECUTE
        Loaded from 00024148 - Section .data             56 bytes loading into 00053238..00053270 flags: WRITE
        Loaded from 00024180 - Section .bss             596 bytes loading into 00053270..000534c4 flags: WRITE | NOCOPY
```

This PR replaces the previously added check with another that makes sure the added padding won't overflow to the next section.