### PR TITLE
Fix xous-rs documentation tests

### DIFF
--- a/xous-rs/src/syscall.rs
+++ b/xous-rs/src/syscall.rs
@@ -439,15 +439,15 @@ pub enum SysCall {
     ///
     /// ## Arguments
     ///
-    ///     * **Index**: The item to adjust. Currently the following limits
-    ///                  are supported:
-    ///                         1: Maximum heap size
-    ///                         2: Current heap size
-    ///     * **Current Limit**: Pass the current limit value here. The current
-    ///                 limit must match in order for the new limit to take
-    ///                 effect. This is used to avoid a race condition if two
-    ///                 threads try to set the same limit.
-    ///     * **Proposed Limit**: The new value that you would like to use.
+    /// * **Index**: The item to adjust. Currently the following limits
+    ///              are supported:
+    ///                     1: Maximum heap size
+    ///                     2: Current heap size
+    /// * **Current Limit**: Pass the current limit value here. The current
+    ///             limit must match in order for the new limit to take
+    ///             effect. This is used to avoid a race condition if two
+    ///             threads try to set the same limit.
+    /// * **Proposed Limit**: The new value that you would like to use.
     ///
     /// ## Returns
     ///
@@ -455,7 +455,7 @@ pub enum SysCall {
     ///
     /// ## Errors
     ///
-    ///     * **InvalidLimit**: The specified index was not valid
+    /// * **InvalidLimit**: The specified index was not valid
     AdjustProcessLimit(
         usize, /* process limit index */
         usize, /* expected current limit */
@@ -488,9 +488,9 @@ pub enum SysCall {
     ///
     /// ## Arguments
     ///
-    ///     * **MessageSender**: This is the `sender` from the message envelope.
-    ///                         It is a unique ID that identifies this message,
-    ///                         as well as the server it came from.
+    /// * **MessageSender**: This is the `sender` from the message envelope.
+    ///                      It is a unique ID that identifies this message,
+    ///                      as well as the server it came from.
     ///
     /// The remaining arguments depend on whether the message was a `BlockingScalar`
     /// message or a `MemoryMessage`. Note that this function should NOT be called


### PR DESCRIPTION
`rustdoc` was misinterpreting the indentation and thought that those were Rust example code blocks.