### PR TITLE
Rust 1.69.0 fixes

### DIFF
--- a/kernel/src/arch/riscv/irq.rs
+++ b/kernel/src/arch/riscv/irq.rs
@@ -411,7 +411,7 @@ pub extern "C" fn trap_handler(
         ex
     );
     #[cfg(any(feature = "precursor", feature = "renode"))]
-    panic!(
+    println!(
         "{}: CPU Exception on PID {}: {}",
         if is_kernel_failure {
             "!!! KERNEL FAILURE !!!"

--- a/kernel/src/debug/gdb.rs
+++ b/kernel/src/debug/gdb.rs
@@ -295,7 +295,7 @@ pub fn report_stop(_pid: xous_kernel::PID, tid: xous_kernel::TID, _pc: usize) {
     };
 }
 
-pub fn report_terminated(_pid: xous_kernel::PID) {
+pub fn report_terminated(pid: xous_kernel::PID) {
     let Some(XousDebugState {
         mut target,
         server: gdb,
@@ -306,7 +306,6 @@ pub fn report_terminated(_pid: xous_kernel::PID) {
 
     let new_gdb = match gdb {
         GdbStubStateMachine::Running(inner) => {
-            println!("Reporting a STOP");
             match inner.report_stop(
                 &mut target,
                 MultiThreadStopReason::Signal(Signal::EXC_BAD_ACCESS),
@@ -326,9 +325,9 @@ pub fn report_terminated(_pid: xous_kernel::PID) {
             println!("GDB state was in Disconnect, which shouldn't be possible!");
             return;
         }
-        GdbStubStateMachine::Idle(_inner) => {
-            println!("GDB state was in Idle, which shouldn't be possible!");
-            return;
+        GdbStubStateMachine::Idle(inner) => {
+            println!("Please connect a debugger to debug process {}", pid);
+            GdbStubStateMachine::Idle(inner)
         }
     };
 

--- a/services/aes/src/vex/aes128.rs
+++ b/services/aes/src/vex/aes128.rs
@@ -21,7 +21,7 @@ fn set_encrypt_key_inner_128(user_key: &[u8], swap_final: bool) -> VexKeys128 {
             ^ (TE2[(temp >> 16) & 0xff] & 0xff000000)
             ^ (TE3[(temp >> 8) & 0xff] & 0x00ff0000)
             ^ (TE0[(temp) & 0xff] & 0x0000ff00)
-            ^ (TE1[(temp >> 24)] & 0x000000ff)
+            ^ (TE1[temp >> 24] & 0x000000ff)
             ^ rcon;
         rk[5 + rk_offset] = rk[1 + rk_offset] ^ rk[4 + rk_offset];
         rk[6 + rk_offset] = rk[2 + rk_offset] ^ rk[5 + rk_offset];
@@ -68,19 +68,19 @@ pub fn aes128_dec_key_schedule(user_key: &[u8]) -> VexKeys128 {
     /* apply the inverse MixColumn transform to all round keys but the first and the last: */
     let mut rk_offset = 4;
     for _ in 1..rounds {
-        rk[0 + rk_offset] = TD0[TE1[(rk[0 + rk_offset] as usize >> 24)] as usize & 0xff]
+        rk[0 + rk_offset] = TD0[TE1[rk[0 + rk_offset] as usize >> 24] as usize & 0xff]
             ^ TD1[TE1[(rk[0 + rk_offset] as usize >> 16) & 0xff] as usize & 0xff]
             ^ TD2[TE1[(rk[0 + rk_offset] as usize >> 8) & 0xff] as usize & 0xff]
             ^ TD3[TE1[(rk[0 + rk_offset] as usize) & 0xff] as usize & 0xff];
-        rk[1 + rk_offset] = TD0[TE1[(rk[1 + rk_offset] as usize >> 24)] as usize & 0xff]
+        rk[1 + rk_offset] = TD0[TE1[rk[1 + rk_offset] as usize >> 24] as usize & 0xff]
             ^ TD1[TE1[(rk[1 + rk_offset] as usize >> 16) & 0xff] as usize & 0xff]
             ^ TD2[TE1[(rk[1 + rk_offset] as usize >> 8) & 0xff] as usize & 0xff]
             ^ TD3[TE1[(rk[1 + rk_offset] as usize) & 0xff] as usize & 0xff];
-        rk[2 + rk_offset] = TD0[TE1[(rk[2 + rk_offset] as usize >> 24)] as usize & 0xff]
+        rk[2 + rk_offset] = TD0[TE1[rk[2 + rk_offset] as usize >> 24] as usize & 0xff]
             ^ TD1[TE1[(rk[2 + rk_offset] as usize >> 16) & 0xff] as usize & 0xff]
             ^ TD2[TE1[(rk[2 + rk_offset] as usize >> 8) & 0xff] as usize & 0xff]
             ^ TD3[TE1[(rk[2 + rk_offset] as usize) & 0xff] as usize & 0xff];
-        rk[3 + rk_offset] = TD0[TE1[(rk[3 + rk_offset] as usize >> 24)] as usize & 0xff]
+        rk[3 + rk_offset] = TD0[TE1[rk[3 + rk_offset] as usize >> 24] as usize & 0xff]
             ^ TD1[TE1[(rk[3 + rk_offset] as usize >> 16) & 0xff] as usize & 0xff]
             ^ TD2[TE1[(rk[3 + rk_offset] as usize >> 8) & 0xff] as usize & 0xff]
             ^ TD3[TE1[(rk[3 + rk_offset] as usize) & 0xff] as usize & 0xff];

--- a/services/aes/src/vex/aes256.rs
+++ b/services/aes/src/vex/aes256.rs
@@ -26,7 +26,7 @@ fn set_encrypt_key_inner_256(user_key: &[u8], swap_final: bool) -> VexKeys256 {
             ^ (TE2[(temp >> 16) & 0xff] & 0xff000000)
             ^ (TE3[(temp >> 8) & 0xff] & 0x00ff0000)
             ^ (TE0[(temp) & 0xff] & 0x0000ff00)
-            ^ (TE1[(temp >> 24)] & 0x000000ff)
+            ^ (TE1[temp >> 24] & 0x000000ff)
             ^ rcon;
         rk[9 + rk_offset] = rk[1 + rk_offset] ^ rk[8 + rk_offset];
         rk[10 + rk_offset] = rk[2 + rk_offset] ^ rk[9 + rk_offset];
@@ -39,7 +39,7 @@ fn set_encrypt_key_inner_256(user_key: &[u8], swap_final: bool) -> VexKeys256 {
 
         let temp = rk[11 + rk_offset] as usize;
         rk[12 + rk_offset] = rk[4 + rk_offset]
-            ^ (TE2[(temp >> 24)] & 0xff000000)
+            ^ (TE2[temp >> 24] & 0xff000000)
             ^ (TE3[(temp >> 16) & 0xff] & 0x00ff0000)
             ^ (TE0[(temp >> 8) & 0xff] & 0x0000ff00)
             ^ (TE1[(temp) & 0xff] & 0x000000ff);
@@ -90,19 +90,19 @@ pub fn aes256_dec_key_schedule(user_key: &[u8]) -> VexKeys256 {
     /* apply the inverse MixColumn transform to all round keys but the first and the last: */
     let mut rk_offset = 4;
     for _ in 1..rounds {
-        rk[0 + rk_offset] = TD0[TE1[(rk[0 + rk_offset] as usize >> 24)] as usize & 0xff]
+        rk[0 + rk_offset] = TD0[TE1[rk[0 + rk_offset] as usize >> 24] as usize & 0xff]
             ^ TD1[TE1[(rk[0 + rk_offset] as usize >> 16) & 0xff] as usize & 0xff]
             ^ TD2[TE1[(rk[0 + rk_offset] as usize >> 8) & 0xff] as usize & 0xff]
             ^ TD3[TE1[(rk[0 + rk_offset] as usize) & 0xff] as usize & 0xff];
-        rk[1 + rk_offset] = TD0[TE1[(rk[1 + rk_offset] as usize >> 24)] as usize & 0xff]
+        rk[1 + rk_offset] = TD0[TE1[rk[1 + rk_offset] as usize >> 24] as usize & 0xff]
             ^ TD1[TE1[(rk[1 + rk_offset] as usize >> 16) & 0xff] as usize & 0xff]
             ^ TD2[TE1[(rk[1 + rk_offset] as usize >> 8) & 0xff] as usize & 0xff]
             ^ TD3[TE1[(rk[1 + rk_offset] as usize) & 0xff] as usize & 0xff];
-        rk[2 + rk_offset] = TD0[TE1[(rk[2 + rk_offset] as usize >> 24)] as usize & 0xff]
+        rk[2 + rk_offset] = TD0[TE1[rk[2 + rk_offset] as usize >> 24] as usize & 0xff]
             ^ TD1[TE1[(rk[2 + rk_offset] as usize >> 16) & 0xff] as usize & 0xff]
             ^ TD2[TE1[(rk[2 + rk_offset] as usize >> 8) & 0xff] as usize & 0xff]
             ^ TD3[TE1[(rk[2 + rk_offset] as usize) & 0xff] as usize & 0xff];
-        rk[3 + rk_offset] = TD0[TE1[(rk[3 + rk_offset] as usize >> 24)] as usize & 0xff]
+        rk[3 + rk_offset] = TD0[TE1[rk[3 + rk_offset] as usize >> 24] as usize & 0xff]
             ^ TD1[TE1[(rk[3 + rk_offset] as usize >> 16) & 0xff] as usize & 0xff]
             ^ TD2[TE1[(rk[3 + rk_offset] as usize >> 8) & 0xff] as usize & 0xff]
             ^ TD3[TE1[(rk[3 + rk_offset] as usize) & 0xff] as usize & 0xff];

--- a/services/codec/src/main.rs
+++ b/services/codec/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
     log::trace!("registered with NS -- {:?}", codec_sid);
 
     let codec_conn = xous::connect(codec_sid).expect("couldn't make connection for the codec implementation");
-    let mut codec = Codec::new(codec_conn, &xns);
+    let mut codec = Box::new(Codec::new(codec_conn, &xns));
 
     let ticktimer = ticktimer_server::Ticktimer::new().unwrap();
     log::trace!("ready to accept requests");


### PR DESCRIPTION
This is a series of fixes and improvements required to work under Rust 1.69:

* The big fix is that `Codec` was blowing out the stack. It is now heap allocated.
* An issue with gdb was discovered where the debugger wasn't properly entered when a process crashed. It does now.
* A new warning has appeared. This is now fixed.