### PR TITLE
Sleep device on lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,6 +1157,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "early_settings"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "rkyv",
+ "spinor",
+ "utralib",
+ "xous 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-api-log",
+ "xous-api-names",
+ "xous-api-susres",
+ "xous-api-ticktimer",
+ "xous-ipc 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,6 +2153,7 @@ dependencies = [
 name = "keyboard"
 version = "0.1.0"
 dependencies = [
+ "early_settings",
  "llio",
  "log",
  "num-derive",
@@ -2587,9 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -3932,6 +3952,7 @@ dependencies = [
  "crossbeam",
  "digest 0.9.0",
  "dns",
+ "early_settings",
  "gam",
  "graphics-server",
  "keyboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ default-members = [
   "services/dns",
   "services/modals",
   "services/usb-device-xous",
+  "services/early_settings",
   "libs/userprefs"
 ]
 members = [
@@ -72,6 +73,7 @@ members = [
   "services/net",
   "services/dns",
   "services/modals",
+  "services/early_settings",
   "apps/ball",
   "apps/hello",
   "apps/mtxcli",

--- a/services/early_settings/Cargo.toml
+++ b/services/early_settings/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "early_settings"
+version = "0.1.0"
+authors = ["gsora <gsora@disroot.org>"]
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = {version = "0.4", features = ["max_level_trace", "release_max_level_trace"]}
+log-server = {package = "xous-api-log", version = "0.1.30"}
+ticktimer-server = {package = "xous-api-ticktimer", version = "0.9.30"}
+xous = "0.9.35"
+xous-ipc = "0.9.35"
+xous-names = {package = "xous-api-names", version = "0.9.32"}
+susres = {package = "xous-api-susres", version = "0.9.30"}
+spinor = {path = "../../services/spinor"}
+
+num-derive = {version = "0.3.3", default-features = false}
+num-traits = {version = "0.2.14", default-features = false}
+rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
+
+utralib = {version = "0.1.15", optional = true, default-features = false }
+once_cell = "1.17.1"

--- a/services/early_settings/README.md
+++ b/services/early_settings/README.md
@@ -1,0 +1,15 @@
+# `early_settings`
+
+This crate provides a service and API to access some settings stored in the first 4096 bytes of FLASH.
+
+Settings currently stored here:
+ - keymap
+ - early sleep flag
+
+**Do not store any personal informations here, user settings must go into `libs/userprefs`!**
+
+This scratch area is provided for extreme edge cases:
+ - keymap must live here because users need to write their password in order to mount PDDB
+ - early sleep is used in the "lock device" lifecycle, placing it here is the most convenient thing to do to achieve that use-case
+
+If you're thinking of placing something in here please open an issue or shoot us a Matrix message on `#xous-apps:matrix.org`.

--- a/services/early_settings/src/lib.rs
+++ b/services/early_settings/src/lib.rs
@@ -1,0 +1,93 @@
+use core::sync::atomic::{AtomicU32, Ordering};
+use num_traits::*;
+use xous::{send_message, Message};
+
+pub const SERVER_NAME_ES: &str = "_EARLY_SETTINGS";
+
+#[derive(Debug, num_derive::FromPrimitive, num_derive::ToPrimitive)]
+pub enum Opcode {
+    SetKeymap,
+    GetKeymap,
+    EarlySleep,
+    SetEarlySleep,
+}
+
+#[derive(Debug)]
+pub struct EarlySettings {
+    conn: xous::CID,
+}
+
+impl EarlySettings {
+    pub fn new(xns: &xous_names::XousNames) -> Result<Self, xous::Error> {
+        REFCOUNT.fetch_add(1, Ordering::Relaxed);
+        let conn = xns
+            .request_connection_blocking(SERVER_NAME_ES)
+            .expect("Can't connect to EarlySettings");
+        Ok(EarlySettings { conn })
+    }
+
+    pub fn set_keymap(&self, map: usize) -> Result<(), xous::Error> {
+        send_message(
+            self.conn,
+            Message::new_blocking_scalar(
+                Opcode::SetKeymap.to_usize().unwrap(),
+                map.into(),
+                0,
+                0,
+                0,
+            ),
+        )
+        .map(|_| ())
+    }
+
+    pub fn get_keymap(&self) -> Result<usize, xous::Error> {
+        match send_message(
+            self.conn,
+            Message::new_blocking_scalar(Opcode::GetKeymap.to_usize().unwrap(), 0, 0, 0, 0),
+        ) {
+            Ok(xous::Result::Scalar1(code)) => Ok(code),
+            _ => Err(xous::Error::InternalError),
+        }
+    }
+
+    pub fn set_early_sleep(&self, value: bool) -> Result<(), xous::Error> {
+        send_message(
+            self.conn,
+            Message::new_blocking_scalar(
+                Opcode::SetEarlySleep.to_usize().unwrap(),
+                value as usize,
+                0,
+                0,
+                0,
+            ),
+        )
+        .map(|_| ())
+    }
+
+    pub fn early_sleep(&self) -> Result<bool, xous::Error> {
+        match send_message(
+            self.conn,
+            Message::new_blocking_scalar(Opcode::EarlySleep.to_usize().unwrap(), 0, 0, 0, 0),
+        ) {
+            Ok(xous::Result::Scalar1(value)) => match value {
+                0 => Ok(false),
+                1 => Ok(true),
+                _ => Ok(false), // instead of doing `value != 0` we're explicitly matching against specific values, because
+                            // reading off FLASH can yield a true value otherwise, even if it wasn't set before
+            },
+            _ => Err(xous::Error::InternalError),
+        }
+    }
+}
+
+static REFCOUNT: AtomicU32 = AtomicU32::new(0);
+impl Drop for EarlySettings {
+    fn drop(&mut self) {
+        // now de-allocate myself. It's unsafe because we are responsible to make sure nobody else is using the connection.
+        if REFCOUNT.fetch_sub(1, Ordering::Relaxed) == 1 {
+            unsafe {
+                xous::disconnect(self.conn).unwrap();
+            }
+        }
+    }
+}

--- a/services/early_settings/src/main.rs
+++ b/services/early_settings/src/main.rs
@@ -1,0 +1,82 @@
+use early_settings::{Opcode, SERVER_NAME_ES};
+use num_traits::FromPrimitive;
+use spinor::Spinor;
+use xous::{msg_blocking_scalar_unpack, MemoryRange};
+
+struct State {
+    settings_page: MemoryRange,
+    spinor: Spinor,
+}
+
+fn main() -> ! {
+    log_server::init_wait().unwrap();
+    log::set_max_level(log::LevelFilter::Info);
+    log::info!("my PID is {}", xous::process::id());
+
+    let xns = xous_names::XousNames::new().unwrap();
+
+    let state = State {
+        settings_page: xous::syscall::map_memory(
+            xous::MemoryAddress::new((xous::EARLY_SETTINGS + xous::FLASH_PHYS_BASE) as usize),
+            None,
+            4096,
+            xous::MemoryFlags::R,
+        )
+        .unwrap(),
+        spinor: spinor::Spinor::new(&xns).unwrap(),
+    };
+
+    let sid = xns
+        .register_name(SERVER_NAME_ES, None)
+        .expect("can't register server");
+
+    loop {
+        let msg = xous::receive_message(sid).unwrap(); // this blocks until we get a message
+        log::trace!("Message: {:?}", msg);
+        match FromPrimitive::from_usize(msg.body.id()) {
+            Some(Opcode::GetKeymap) => {
+                let settings: &[u8] = state.settings_page.as_slice();
+
+                let code = u32::from_le_bytes(settings[..4].try_into().unwrap());
+
+                xous::return_scalar(msg.sender, code as usize).unwrap();
+            }
+            Some(Opcode::SetKeymap) => msg_blocking_scalar_unpack!(msg, map, _, _, _, {
+                let code = (map as u32).to_le_bytes();
+                let settings: &[u8] = state.settings_page.as_slice();
+
+                state
+                    .spinor
+                    .patch(settings, xous::EARLY_SETTINGS, &code, 0)
+                    .expect("couldn't patch our keyboard code");
+
+                log::info!("writing early keymap: {}", map);
+
+                xous::return_scalar(msg.sender, 0).unwrap();
+            }),
+            Some(Opcode::SetEarlySleep) => msg_blocking_scalar_unpack!(msg, value, _, _, _, {
+                let code = (value as u32).to_le_bytes();
+                let settings: &[u8] = state.settings_page.as_slice();
+
+                state
+                    .spinor
+                    .patch(settings, xous::EARLY_SETTINGS, &code, 4)
+                    .expect("couldn't patch early reboot flag");
+
+                log::info!("writing must sleep on reboot: {}", value);
+
+                xous::return_scalar(msg.sender, 0).unwrap();
+            }),
+            Some(Opcode::EarlySleep) => {
+                let settings: &[u8] = state.settings_page.as_slice();
+
+                let value = u32::from_le_bytes(settings[4..8].try_into().unwrap());
+
+                log::info!("value read for early sleep: {}", value);
+
+                xous::return_scalar(msg.sender, value as usize).unwrap();
+            }
+            _ => log::warn!("unrecognized opcode"),
+        }
+    }
+}

--- a/services/keyboard/Cargo.toml
+++ b/services/keyboard/Cargo.toml
@@ -22,6 +22,7 @@ num-traits = {version = "0.2.14", default-features = false}
 rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
 
 utralib = {version = "0.1.17", optional = true, default-features = false }
+early_settings ={ path = "../early_settings"}
 
 [features]
 precursor = ["utralib/precursor"]

--- a/services/status/Cargo.toml
+++ b/services/status/Cargo.toml
@@ -30,6 +30,8 @@ usb-device-xous = {path="../usb-device-xous"}
 codec = {path="../codec"}
 userprefs = {path = "../../libs/userprefs"}
 dns = {path="../dns"}
+early_settings ={ path = "../early_settings"}
+
 
 num-derive = {version = "0.3.3", default-features = false}
 num-traits = {version = "0.2.14", default-features = false}

--- a/services/status/src/main.rs
+++ b/services/status/src/main.rs
@@ -153,6 +153,7 @@ fn wrapped_main() -> ! {
 
     // ------------------ acquire the status canvas GID
     let xns = xous_names::XousNames::new().unwrap();
+    let early_settings = early_settings::EarlySettings::new(&xns).unwrap();
     // 1 connection exactly -- from the GAM to set our canvas GID
     let status_gam_getter = xns
         .register_name(SERVER_NAME_STATUS_GID, Some(1))
@@ -625,6 +626,29 @@ fn wrapped_main() -> ! {
     }
     #[cfg(any(feature="precursor", feature="renode"))]
     llio.clear_wakeup_alarm().unwrap(); // this is here to clear any wake-up alarms that were set by a prior coldboot command
+
+    // get the last status
+    let must_sleep = early_settings.early_sleep().unwrap();
+    
+    // reset it for good measure
+    early_settings.set_early_sleep(false).unwrap();
+
+    if must_sleep {
+        while ((llio.adc_vbus().unwrap() as u32) * 503) > 150_000 {
+            modals.show_notification(t!("mainmenu.cant_sleep", xous::LANG), None).expect("couldn't notify that power is plugged in");
+        }
+
+        match susres.initiate_suspend() {
+            Ok(_) => {},
+            Err(xous::Error::Timeout) => {
+                // TODO: maybe this branch needs a different log message/flow?
+                modals.show_notification(t!("suspend.fail", xous::LANG), None).unwrap();
+            }
+            Err(_e) => {
+                panic!("Unhandled error on suspend request");
+            }
+        } 
+    }
 
     // spawn a thread to auto-mount the PDDB
     let _ = thread::spawn({
@@ -1103,6 +1127,10 @@ fn wrapped_main() -> ! {
                 if !pddb.try_unmount() { // sync the pddb prior to lock
                     modals.show_notification(t!("socup.unmount_fail", xous::LANG), None).ok();
                 } else {
+                    early_settings.set_early_sleep(true).unwrap();
+
+                    log::info!("forcing sleep on reboot");
+                
                     pddb.pddb_halt();
                     susres.reboot(true).expect("couldn't issue reboot command");
                 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -70,9 +70,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &base_pkgs[..],
         &[
             "graphics-server",  // raw (unprotected) frame buffer primitives
-            "keyboard",   // required by graphics-server
-            "spinor",     // required by keyboard - to save key mapping
-            "llio",       // required by spinor
+            "early_settings",   // required by keyboard
+            "keyboard",         // required by graphics-server
+            "spinor",           // required by keyboard - to save key mapping
+            "llio",             // required by spinor
         ]
     ].concat();
     // packages in the user image - most of the services at this layer have cross-dependencies


### PR DESCRIPTION
This PR forces the device to sleep when the user selects “Lock” in the main menu. 

It’s done in a kinda naive way: as soon as `status` starts, it checks whether the device should sleep. 

During the implementation I refactored access to the “early settings” area of FLASH in a separate service to multiplex access to that memory area. 

I also documented in the service’s README the fact that engineering solutions based on that memory area should only be done in extreme cases. 

The rationale behind this change is to allow users to either shut down the device when not in use, or sleep to save battery while still retaining PDDB security properties. 