### PR TITLE
graphics-server: Call `minifb::Window::update_with_buffer` continuously

### DIFF
--- a/services/graphics-server/src/backend/betrusted.rs
+++ b/services/graphics-server/src/backend/betrusted.rs
@@ -212,9 +212,6 @@ impl XousDisplay {
         log::trace!("redraw {}/{}", busy_count, dirty_count);
     }
 
-    // note: this API is used by emulation, don't remove calls to it
-    pub fn update(&mut self) {}
-
     pub fn native_buffer(&mut self) -> &mut [u32; FB_SIZE] {
         unsafe { &mut *(self.fb.as_mut_ptr() as *mut [u32; FB_SIZE]) }
     }

--- a/services/graphics-server/src/backend/minifb.rs
+++ b/services/graphics-server/src/backend/minifb.rs
@@ -74,7 +74,6 @@ impl XousDisplay {
         self.emulated_buffer[FB_WIDTH_WORDS * 32..]
             .copy_from_slice(&self.srfb[FB_WIDTH_WORDS * 32..]);
         self.redraw();
-        self.update();
     }
 
     pub fn screen_size(&self) -> Point {
@@ -98,9 +97,6 @@ impl XousDisplay {
     pub fn redraw(&mut self) {
         self.emulated_to_native();
     }
-
-    // TODO: `update` is no longer needed for emulation; remove it
-    pub fn update(&mut self) {}
 
     fn emulated_to_native(&mut self) {
         const DEVBOOT_LINE: usize = 7;

--- a/services/graphics-server/src/main.rs
+++ b/services/graphics-server/src/main.rs
@@ -392,7 +392,6 @@ fn wrapped_main() -> ! {
                 }
                 Some(Opcode::Flush) => {
                     log::trace!("***gfx flush*** redraw##");
-                    display.update();
                     display.redraw();
                 }
                 Some(Opcode::Clear) => {
@@ -455,12 +454,10 @@ fn wrapped_main() -> ! {
                 }),
                 Some(Opcode::DrawSleepScreen) => msg_scalar_unpack!(msg, _, _, _, _, {
                     display.blit_screen(&logo::LOGO_MAP);
-                    display.update();
                     display.redraw();
                 }),
                 Some(Opcode::DrawBootLogo) => msg_scalar_unpack!(msg, _, _, _, _, {
                     display.blit_screen(&poweron::LOGO_MAP);
-                    display.update();
                     display.redraw();
                 }),
                 Some(Opcode::Devboot) => msg_scalar_unpack!(msg, ena, _, _, _, {
@@ -543,7 +540,6 @@ fn wrapped_main() -> ! {
                             testpat[lines * backend::FB_WIDTH_WORDS + (backend::FB_WIDTH_WORDS - 1)] |= 0x1_0000;
                         }
                         display.blit_screen(testpat);
-                        display.update();
                         display.redraw();
                         ticktimer.sleep_ms(DWELL).unwrap();
 
@@ -553,7 +549,6 @@ fn wrapped_main() -> ! {
                         }
                         // dirty bits already set
                         display.blit_screen(testpat);
-                        display.update();
                         display.redraw();
                         ticktimer.sleep_ms(DWELL).unwrap();
 
@@ -564,7 +559,6 @@ fn wrapped_main() -> ! {
                             }
                         }
                         display.blit_screen(testpat);
-                        display.update();
                         display.redraw();
                         ticktimer.sleep_ms(DWELL).unwrap();
 
@@ -574,7 +568,6 @@ fn wrapped_main() -> ! {
                             }
                         }
                         display.blit_screen(testpat);
-                        display.update();
                         display.redraw();
                         ticktimer.sleep_ms(DWELL).unwrap();
 
@@ -590,7 +583,6 @@ fn wrapped_main() -> ! {
                             testpat[lines * backend::FB_WIDTH_WORDS + (backend::FB_WIDTH_WORDS - 1)] |= 0x1_0000;
                         }
                         display.blit_screen(testpat);
-                        display.update();
                         display.redraw();
                         ticktimer.sleep_ms(DWELL).unwrap();
 
@@ -605,7 +597,6 @@ fn wrapped_main() -> ! {
                             testpat[lines * backend::FB_WIDTH_WORDS + (backend::FB_WIDTH_WORDS - 1)] |= 0x1_0000;
                         }
                         display.blit_screen(testpat);
-                        display.update();
                         display.redraw();
                         ticktimer.sleep_ms(DWELL).unwrap();
 


### PR DESCRIPTION
[`minifb::Window::update_with_buffer`][1] needs to be called continuously to pump input events. Fixes massive input latency in hosted mode.

[1]: https://docs.rs/minifb/0.23.0/minifb/struct.Window.html#method.update_with_buffer