### PR TITLE
graphics-server: convert "never" types in `backend::betrusted::claim_main_thread`

### DIFF
--- a/services/graphics-server/src/backend/betrusted.rs
+++ b/services/graphics-server/src/backend/betrusted.rs
@@ -17,7 +17,8 @@ pub enum Never {}
 #[inline]
 pub fn claim_main_thread(f: impl FnOnce(MainThreadToken) -> Never + Send + 'static) -> ! {
     // Just call the closure - this backend will work on any thread
-    f(MainThreadToken(()))
+    #[allow(unreachable_code)] // false positive
+    match f(MainThreadToken(())) {}
 }
 
 pub struct XousDisplay {


### PR DESCRIPTION
Fixes [image build failure](https://github.com/betrusted-io/xous-core/pull/374#issuecomment-1525990080) after #374.