### PR TITLE
Fix #386: Ignore key codes over 0xf000 on insert

### DIFF
--- a/services/keyboard/src/main.rs
+++ b/services/keyboard/src/main.rs
@@ -938,18 +938,22 @@ fn main() -> ! {
                 #[cfg(all(feature="debuginject", not(feature="rawserial")))]
                 if let Some(conn) = listener_conn {
                     if key != '\u{0000}' {
-                        log::info!("injecting key '{}'({:x})", key, key as u32); // always be noisy about this, it's an exploit path
-                        xous::try_send_message(conn,
-                            xous::Message::new_scalar(listener_op.unwrap(),
-                                key as u32 as usize,
-                                '\u{0000}' as u32 as usize,
-                                '\u{0000}' as u32 as usize,
-                                '\u{0000}' as u32 as usize,
-                            )
-                        ).unwrap_or_else(|_| {
-                            log::info!("Input overflow, dropping keys!");
-                            xous::Result::Ok
-                        });
+                        if key > '\u{f000}' {
+                            log::info!("ignoring key '{}'({:x})", key, key as u32); // ignore macOS weird characters
+                        } else {
+                            log::info!("injecting key '{}'({:x})", key, key as u32); // always be noisy about this, it's an exploit path
+                            xous::try_send_message(conn,
+                                xous::Message::new_scalar(listener_op.unwrap(),
+                                    key as u32 as usize,
+                                    '\u{0000}' as u32 as usize,
+                                    '\u{0000}' as u32 as usize,
+                                    '\u{0000}' as u32 as usize,
+                                )
+                            ).unwrap_or_else(|_| {
+                                log::info!("Input overflow, dropping keys!");
+                                xous::Result::Ok
+                            });
+                        }
                     }
                 }
 

--- a/services/keyboard/src/main.rs
+++ b/services/keyboard/src/main.rs
@@ -938,8 +938,8 @@ fn main() -> ! {
                 #[cfg(all(feature="debuginject", not(feature="rawserial")))]
                 if let Some(conn) = listener_conn {
                     if key != '\u{0000}' {
-                        if key > '\u{f000}' {
-                            log::info!("ignoring key '{}'({:x})", key, key as u32); // ignore macOS weird characters
+                        if key >= '\u{f700}' && key <= '\u{f8ff}' {
+                            log::info!("ignoring key '{}'({:x})", key, key as u32); // ignore Apple PUA characters
                         } else {
                             log::info!("injecting key '{}'({:x})", key, key as u32); // always be noisy about this, it's an exploit path
                             xous::try_send_message(conn,


### PR DESCRIPTION
This closes #386 by ignoring any keys over 0xf000

Not sure this is a completely correct logic. Checked with key codes that seem to be injected on Latin, Cyrillic and japanese Kana keyboard on macOS Ventura.

