### PR TITLE
Add virt_to_phys_pid syscall

### DIFF
--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -1142,6 +1142,14 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
                 Err(_) => Err(xous_kernel::Error::BadAddress),
             }
         }
+        #[cfg(feature = "v2p")]
+        SysCall::VirtToPhysPid(pid, vaddr) => {
+            let phys_addr = crate::arch::mem::virt_to_phys_pid(pid, vaddr as usize);
+            match phys_addr {
+                Ok(pa) => Ok(xous_kernel::Result::Scalar1(pa)),
+                Err(_) => Err(xous_kernel::Error::BadAddress),
+            }
+        }
         /* https://github.com/betrusted-io/xous-core/issues/90
         SysCall::SetExceptionHandler(pc, sp) => SystemServices::with_mut(|ss| {
             ss.set_exception_handler(pid, pc, sp)


### PR DESCRIPTION
This syscall allows services to obtain a physical address from a mapping of a specific process. A particular use case for this is a way for a GUI server to allow client "apps" to allocate a frame buffer and then "register" it by passing FB's virtual address to the GUI server. GUI server is then makes `virt_to_phys_pid` syscall to obtain a physical address of a frame buffer and configures an LCD controller peripheral or a DMA controller to access this physical memory location.