### PR TITLE
Refactor item cache

### DIFF
--- a/apps/vault/locales/i18n.json
+++ b/apps/vault/locales/i18n.json
@@ -447,6 +447,13 @@
         "ja": "USB機能を切り替え中...",
         "zh": "切换 USB 功能..."
     },
+    "vault.reloading_database": {
+        "en": "Reloading database...",
+        "en-tts": "Reloading database...",
+        "fr": "Rechargement de la base de données...*MT*",
+        "ja": "データベースをリロードしています...",
+        "zh": "正在重新加载数据库..."
+    },
     "vault.select_font": {
         "en": "Select a font style",
         "en-tts": "Select a font style",

--- a/apps/vault/src/actions.rs
+++ b/apps/vault/src/actions.rs
@@ -512,14 +512,14 @@ impl<'a> ActionManager<'a> {
                 extra.push_str("; ");
                 extra.push_str(t!("vault.u2f.appinfo.authcount", xous::LANG));
                 extra.push_str(&pw.count.to_string());
-                let li = ListItem {
-                    name: desc.to_string(), // these allocs will be slow, but we do it only once on boot
-                    extra: extra.to_string(),
-                    dirty: true,
-                    guid: guid.to_string(),
-                    atime: pw.atime,
-                    count: pw.count,
-                };
+                let li = ListItem::new(
+                    desc.to_string(), // these allocs will be slow, but we do it only once on boot
+                    extra.to_string(),
+                    true,
+                    guid.to_string(),
+                    pw.atime,
+                    pw.count,
+                );
                 log::debug!("updating {} to list item {}", li.extra, li.key());
                 assert!(
                     self.item_lists.lock().unwrap().insert_unique(entry.mode, li).is_some(),
@@ -923,9 +923,9 @@ impl<'a> ActionManager<'a> {
                                         }
                                         #[cfg(feature="vaultperf")]
                                         self.perfentry(&self.pm, PERFMETA_NONE, 3, std::line!());
-                                        if prev_entry.name != desc { // this check should be redundant, but, leave it in to be safe
-                                            prev_entry.name.clear();
-                                            prev_entry.name.push_str(&desc);
+                                        if prev_entry.name() != &desc { // this check should be redundant, but, leave it in to be safe
+                                            prev_entry.name_clear();
+                                            prev_entry.name_push_str(&desc);
                                         }
                                         #[cfg(feature="vaultperf")]
                                         self.perfentry(&self.pm, PERFMETA_NONE, 3, std::line!());
@@ -946,14 +946,14 @@ impl<'a> ActionManager<'a> {
                                         extra.push_str(t!("vault.u2f.appinfo.authcount", xous::LANG));
                                         extra.push_str(&pw_rec.count.to_string());
 
-                                        let li = ListItem {
-                                            name: desc.to_string(), // these allocs will be slow, but we do it only once on boot
-                                            extra: extra.to_string(),
-                                            dirty: true,
-                                            guid: key.name,
-                                            atime: pw_rec.atime,
-                                            count: pw_rec.count,
-                                        };
+                                        let li = ListItem::new(
+                                            desc.to_string(), // these allocs will be slow, but we do it only once on boot
+                                            extra.to_string(),
+                                            true,
+                                            key.name,
+                                            pw_rec.atime,
+                                            pw_rec.count,
+                                        );
                                         il.push(self.mode_cache, li);
                                         #[cfg(feature="vaultperf")]
                                         self.perfentry(&self.pm, PERFMETA_ENDBLOCK, 4, std::line!());
@@ -1022,14 +1022,14 @@ impl<'a> ActionManager<'a> {
                                         ai.count,
                                     );
                                     let desc = format!("{} (U2F)", ai.name);
-                                    let li = ListItem {
-                                        name: desc,
+                                    let li = ListItem::new(
+                                        desc,
                                         extra,
-                                        dirty: true,
-                                        guid: key.name,
-                                        count: ai.count,
-                                        atime: ai.atime,
-                                    };
+                                        true,
+                                        key.name,
+                                        ai.count,
+                                        ai.atime,
+                                    );
                                     self.item_lists.lock().unwrap().insert_unique(self.mode_cache, li);
                                 } else {
                                     let err = format!("{}:{}:{}: ({})[moved data]...",
@@ -1080,14 +1080,14 @@ impl<'a> ActionManager<'a> {
                                                 };
                                                 let desc = format!("{} / {} (FIDO2)", result.rp_id, String::from_utf8(result.credential_id).unwrap_or("---".to_string()));
                                                 let extra = format!("{}", name);
-                                                let li = ListItem {
-                                                    name: desc,
+                                                let li = ListItem::new(
+                                                    desc,
                                                     extra,
-                                                    dirty: true,
-                                                    guid: key.name,
-                                                    count: 0,
-                                                    atime: 0,
-                                                };
+                                                    true,
+                                                    key.name,
+                                                    0,
+                                                    0,
+                                                );
                                                 self.item_lists.lock().unwrap().insert_unique(self.mode_cache, li);
                                             }
                                             None => {
@@ -1139,14 +1139,14 @@ impl<'a> ActionManager<'a> {
                                         if totp.is_hotp {"HOTP"} else {"TOTP"}
                                     );
                                     let desc = format!("{}", totp.name);
-                                    let li = ListItem {
-                                        name: desc,
+                                    let li = ListItem::new(
+                                        desc,
                                         extra,
-                                        dirty: true,
-                                        guid: key.name,
-                                        count: 0,
-                                        atime: 0,
-                                    };
+                                        true,
+                                        key.name,
+                                        0,
+                                        0,
+                                    );
                                     self.item_lists.lock().unwrap().insert_unique(self.mode_cache, li);
                                 } else {
                                     let err = format!("{}:{}:{}: ({})[moved data]...",

--- a/apps/vault/src/actions.rs
+++ b/apps/vault/src/actions.rs
@@ -872,6 +872,7 @@ impl<'a> ActionManager<'a> {
     ///   - `format!()` is very slow, so we use `push_str()` where possible
     ///   - allocations are slow, so we try to avoid them at all costs
     pub(crate) fn retrieve_db(&mut self) {
+        self.modals.dynamic_notification(Some(t!("vault.reloading_database", xous::LANG)), None).ok();
         #[cfg(feature="vaultperf")]
         self.pm.stop_and_reset();
         #[cfg(feature="vaultperf")]
@@ -1153,6 +1154,7 @@ impl<'a> ActionManager<'a> {
         }
         self.item_lists.lock().unwrap().filter_reset(self.mode_cache);
         log::debug!("heap usage B: {}", heap_usage());
+        self.modals.dynamic_notification_close().ok();
         #[cfg(feature="vaultperf")]
         {
             self.perfentry(&self.pm, PERFMETA_ENDBLOCK, 0, std::line!());

--- a/apps/vault/src/itemcache.rs
+++ b/apps/vault/src/itemcache.rs
@@ -187,6 +187,9 @@ impl FilteredListView {
             filter_range: None,
         }
     }
+    pub fn is_db_empty(&self) -> bool {
+        self.list.len() == 0
+    }
     pub fn expand(&mut self, capacity: usize) {
         self.list.reserve(capacity.saturating_sub(self.list.len()))
     }
@@ -466,6 +469,9 @@ impl ItemLists {
             totp: FilteredListView::new(),
             pw: FilteredListView::new(),
         }
+    }
+    pub fn is_db_empty(&self, list_type: VaultMode) -> bool {
+        self.li(list_type).is_db_empty()
     }
     fn li_mut(&mut self, list_type: VaultMode) -> &mut FilteredListView {
         match list_type {

--- a/apps/vault/src/itemcache.rs
+++ b/apps/vault/src/itemcache.rs
@@ -1,0 +1,331 @@
+use core::num::NonZeroUsize;
+use std::collections::BTreeMap;
+use std::cmp::Ordering;
+use crate::{VaultMode, SelectedEntry};
+use crate::ux::framework::NavDir;
+use std::sync::{Arc, Mutex};
+
+/// Display list for items. "name" is the key by which the list is sorted.
+/// "extra" is more information about the item, which should not be part of the sort.
+#[derive(Debug)]
+pub struct ListItem {
+    pub name: String,
+    pub extra: String,
+    pub dirty: bool,
+    /// this is the name of the key used to refer to the item
+    pub guid: String,
+    /// stash a copy so we can compare to the DB record and avoid re-generating the atime/count string if it hasn't changed.
+    pub atime: u64,
+    pub count: u64,
+}
+impl ListItem {
+    pub fn clone(&self) -> ListItem {
+        ListItem {
+            name: self.name.to_string(),
+            extra: self.extra.to_string(),
+            dirty: self.dirty,
+            guid: self.guid.to_string(),
+            atime: self.atime,
+            count: self.count,
+        }
+    }
+    /// This is made available for edit/delete routines to generate the key without having to
+    /// make a whole ListItem record (which is somewhat expensive).
+    pub fn key_from_parts(name: &str, guid: &str) -> String {
+        name.to_lowercase() + &guid.to_string()
+    }
+    pub fn key(&self) -> String {
+        Self::key_from_parts(&self.name, &self.guid)
+    }
+}
+impl Ord for ListItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.name.cmp(&other.name) {
+            Ordering::Equal => {
+                self.guid.cmp(&other.guid)
+            },
+            Ordering::Greater => Ordering::Greater,
+            Ordering::Less => Ordering::Less,
+        }
+    }
+}
+impl PartialOrd for ListItem {
+
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl PartialEq for ListItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.guid == other.guid
+    }
+}
+impl Eq for ListItem {}
+
+pub struct ItemLists {
+    fido: BTreeMap::<String, Arc<Mutex<ListItem>>>,
+    totp: BTreeMap::<String, Arc<Mutex<ListItem>>>,
+    pw: BTreeMap::<String, Arc<Mutex<ListItem>>>,
+    /// create a mostly static list of references that we can use to index into the corresponding database
+    /// this gets around both lifetime issues by putting the references in this scope, and also gets
+    /// around slow alloc issues having to deal with copies when avoiding lifetimes.
+    filtered_list: Vec::<Option<Arc<Mutex<ListItem>>>>,
+    /// records the longest possible length of all three lists, so filtered_list() capacity can be adjusted accordingly
+    max_len: usize,
+    /// memoize the filtered length so we don't have to search it every time
+    valid_len: usize,
+    items_per_screen: NonZeroUsize,
+    selection_index: usize,
+}
+impl ItemLists {
+    pub fn new() -> Self {
+        ItemLists {
+            fido: BTreeMap::new(),
+            totp: BTreeMap::new(),
+            pw: BTreeMap::new(),
+            filtered_list: Vec::new(),
+            max_len: 0,
+            valid_len: 0,
+            items_per_screen: NonZeroUsize::new(1).unwrap(),
+            selection_index: 0,
+        }
+    }
+    pub fn insert(&mut self, list_type: VaultMode, key: String, item: ListItem) -> Option<ListItem> {
+        let maybe_replaced = match list_type {
+            VaultMode::Fido => self.fido.insert(key, Arc::new(Mutex::new(item))),
+            VaultMode::Totp => self.totp.insert(key, Arc::new(Mutex::new(item))),
+            VaultMode::Password => self.pw.insert(key, Arc::new(Mutex::new(item))),
+        };
+        let new_len = match list_type {
+            VaultMode::Fido => self.fido.len(),
+            VaultMode::Totp => self.totp.len(),
+            VaultMode::Password => self.pw.len(),
+        };
+        for _ in 0..new_len.saturating_sub(self.filtered_list.len()) {
+            // fills in any growth with null records, guaranteeing that
+            // we can always index into the vector.
+            self.filtered_list.push(None);
+        }
+        self.max_len = new_len;
+        if let Some(replaced) = maybe_replaced {
+            Some(
+                Arc::<_>::try_unwrap(replaced).unwrap().into_inner().unwrap()
+            )
+        } else {
+            None
+        }
+    }
+    pub fn get(&self, list_type: VaultMode, key: &String) -> Option<&Arc<Mutex<ListItem>>> {
+        match list_type {
+            VaultMode::Fido => self.fido.get(key),
+            VaultMode::Password => self.pw.get(key),
+            VaultMode::Totp => self.pw.get(key),
+        }
+    }
+    pub fn remove(&mut self, list_type: VaultMode, key: String) -> Option<ListItem> {
+        let maybe_item = match list_type {
+            VaultMode::Fido => self.fido.remove(&key),
+            VaultMode::Totp => self.totp.remove(&key),
+            VaultMode::Password => self.pw.remove(&key),
+        };
+        if let Some(item) = maybe_item {
+            self.filtered_list.retain(|x|
+                if let Some(filter_item) = x {
+                    if filter_item.lock().unwrap().guid == item.lock().unwrap().guid {
+                        false // don't retain
+                    } else {
+                        true
+                    }
+                } else {
+                    true
+                }
+            );
+            Some(
+                Arc::<_>::try_unwrap(item).unwrap().into_inner().unwrap()
+            )
+        } else {
+            None
+        }
+    }
+    pub fn set_items_per_screen(&mut self, ips: i16) {
+        self.items_per_screen = NonZeroUsize::new(ips as usize).unwrap_or(NonZeroUsize::new(1).unwrap());
+    }
+    pub fn clear_filter(&mut self) {
+        self.filtered_list.iter_mut().for_each(|i| *i = None);
+        self.valid_len = 0;
+        self.selection_index = 0;
+    }
+    pub fn clear(&mut self, list_type: VaultMode) {
+        self.filtered_list.iter_mut().for_each(|i| *i = None);
+        self.valid_len = 0;
+        match list_type {
+            VaultMode::Fido => self.fido.clear(),
+            VaultMode::Totp => self.totp.clear(),
+            VaultMode::Password => self.pw.clear(),
+        }
+        // maybe do a search for what is the new max_len? for now we can just "leave it", it just means we have some excess capacity which is good: less mallocs.
+    }
+    pub fn clear_all(&mut self) {
+        self.filtered_list.iter_mut().for_each(|i| *i = None);
+        self.valid_len = 0;
+        self.fido.clear();
+        self.totp.clear();
+        self.pw.clear();
+        self.max_len = 0;
+    }
+    /// Sets up a filter for the selected list type, returns a default selection index.
+    pub fn filter(&mut self, list_type: VaultMode, criteria: &str) {
+        let tt = ticktimer_server::Ticktimer::new().unwrap();
+        let mut ts = [0u64; 5];
+        ts[0] = tt.elapsed_ms();
+        // clear the list
+        self.filtered_list.iter_mut().for_each(|i| *i = None);
+        ts[1] = tt.elapsed_ms();
+        self.valid_len = 0;
+
+        let itemlist = match list_type {
+            VaultMode::Fido => &mut self.fido,
+            VaultMode::Totp => &mut self.totp,
+            VaultMode::Password => &mut self.pw,
+        };
+        ts[2] = tt.elapsed_ms();
+        let mut filter_index = 0;
+        for item in itemlist.values_mut() {
+            if item.lock().unwrap().name.to_lowercase().starts_with(criteria) {
+                item.lock().unwrap().dirty = true;
+                self.filtered_list[filter_index] = Some(item.clone());
+                filter_index += 1;
+            }
+        }
+        ts[3] = tt.elapsed_ms();
+        self.valid_len = filter_index;
+        if self.selection_index >= self.valid_len {
+            if self.valid_len > 0 {
+                self.selection_index = self.valid_len - 1;
+            } else {
+                self.selection_index = 0;
+            }
+        }
+        ts[4] = tt.elapsed_ms();
+        for(index, &elapsed) in ts[1..].iter().enumerate() {
+            log::info!("{}: {}", index + 1, elapsed - ts[0]);
+        }
+    }
+    pub fn nav(&mut self, list_type: VaultMode, dir: NavDir) {
+        match dir {
+            NavDir::Up => {
+                if self.selection_index > 0 {
+                    let starting_page = self.get_page();
+                    self.mark_as_dirty(self.selection_index);
+                    self.selection_index -= 1;
+                    self.mark_as_dirty(self.selection_index);
+                    if starting_page != self.get_page() {
+                        self.mark_screen_as_dirty(self.selection_index);
+                    }
+                }
+            }
+            NavDir::Down => {
+                if self.selection_index < self.valid_len {
+                    let starting_page = self.get_page();
+                    self.mark_as_dirty(self.selection_index);
+                    self.selection_index += 1;
+                    self.mark_as_dirty(self.selection_index);
+                    if starting_page != self.get_page() {
+                        self.mark_screen_as_dirty(self.selection_index);
+                    }
+                }
+            }
+            NavDir::PageUp => {
+                if self.selection_index > self.items_per_screen.get() {
+                    self.mark_screen_as_dirty(self.selection_index);
+                    self.selection_index -= self.items_per_screen.get();
+                    self.mark_screen_as_dirty(self.selection_index);
+                } else {
+                    self.mark_as_dirty(self.selection_index);
+                    self.selection_index = 0;
+                    self.mark_as_dirty(self.selection_index);
+                }
+            }
+            NavDir::PageDown => {
+                if self.selection_index < self.valid_len - self.items_per_screen.get() {
+                    self.mark_screen_as_dirty(self.selection_index);
+                    self.selection_index += self.items_per_screen.get();
+                    self.mark_screen_as_dirty(self.selection_index);
+                } else {
+                    self.mark_as_dirty(self.selection_index);
+                    self.selection_index = self.valid_len - 1;
+                    self.mark_as_dirty(self.selection_index);
+                }
+            }
+        }
+    }
+    fn mark_as_dirty(&mut self, index: usize) {
+        if self.valid_len > 0 {
+            if let Some(record) = self.filtered_list[index.min(self.valid_len - 1)].as_mut() {
+                record.lock().unwrap().dirty = true;
+            }
+        }
+    }
+    fn mark_screen_as_dirty(&mut self, index: usize) {
+        let page = index as i16 / self.items_per_screen.get() as i16;
+        for item in self.filtered_list[
+            ((page as usize) * self.items_per_screen.get()).min(self.valid_len) ..
+            ((1 + page as usize) * self.items_per_screen.get()).min(self.valid_len)
+        ].iter_mut() {
+            if let Some(record) = item {
+                record.lock().unwrap().dirty = true;
+            }
+        }
+    }
+    pub fn get_page(&self) -> usize {
+        self.selection_index / self.items_per_screen.get()
+    }
+    pub fn selected_index(&self) -> usize {
+        self.selection_index % self.items_per_screen.get()
+    }
+    pub fn selected_page(&mut self) -> &mut [Option<Arc<Mutex<ListItem>>>] {
+        let page = self.get_page();
+        &mut self.filtered_list[
+            (page * self.items_per_screen.get()).min(self.valid_len) ..
+            ((1 + page) * self.items_per_screen.get()).min(self.valid_len)
+        ]
+    }
+    pub fn selected_guid(&self) -> String {
+        // we unwrap() here because this function is responsible for consistency of the filtered list.
+        self.filtered_list[self.selection_index].as_ref().unwrap().lock().unwrap().guid.to_owned()
+    }
+    pub fn selected_extra(&self) -> String {
+        // we unwrap() here because this function is responsible for consistency of the filtered list.
+        self.filtered_list[self.selection_index].as_ref().unwrap().lock().unwrap().extra.to_owned()
+    }
+    pub fn selected_update_extra(&mut self, extra: String) {
+        self.filtered_list[self.selection_index].as_mut().unwrap().lock().unwrap().extra = extra;
+        self.filtered_list[self.selection_index].as_mut().unwrap().lock().unwrap().dirty = true;
+    }
+    pub fn selected_update_atime(&mut self, atime: u64) {
+        self.filtered_list[self.selection_index].as_mut().unwrap().lock().unwrap().atime = atime;
+        self.filtered_list[self.selection_index].as_mut().unwrap().lock().unwrap().dirty = true;
+    }
+    pub fn mark_selected_as_dirty(&mut self) {
+        // we unwrap() here because this function is responsible for consistency of the filtered list.
+        self.filtered_list[self.selection_index].as_mut().unwrap().lock().unwrap().dirty = true;
+    }
+    pub fn selected_entry(&self, mode: VaultMode) -> Option<SelectedEntry> {
+        if self.selection_index > self.valid_len {
+            None
+        } else {
+            if let Some(entry) = &self.filtered_list[self.selection_index] {
+                Some(
+                    SelectedEntry {
+                        key_name: xous_ipc::String::from_str(entry.lock().unwrap().guid.to_string()),
+                        description: xous_ipc::String::from_str(entry.lock().unwrap().name.to_string()),
+                        mode
+                    }
+                )
+            } else {
+                None
+            }
+        }
+    }
+
+}

--- a/apps/vault/src/itemcache.rs
+++ b/apps/vault/src/itemcache.rs
@@ -1,16 +1,77 @@
 use core::num::NonZeroUsize;
-use std::collections::BTreeMap;
 use std::cmp::Ordering;
 use crate::{VaultMode, SelectedEntry};
 use crate::ux::framework::NavDir;
-use std::sync::{Arc, Mutex};
+use std::ops::Range;
 
+pub struct ListKey {
+    pub name: String,
+    pub guid: String,
+}
+impl ListKey {
+    pub fn key_from_parts(name: &str, guid: &str) -> Self {
+        ListKey {
+            name: name.to_owned(),
+            guid: guid.to_owned(),
+        }
+    }
+    pub fn reserved() -> Self {
+        ListKey {
+            name: String::with_capacity(256),
+            guid: String::with_capacity(256),
+        }
+    }
+    // re-uses the existing storage to avoid allocations
+    pub fn reset_from_parts(&mut self, name: &str, guid: &str) {
+        self.name.clear();
+        self.name.push_str(name);
+        self.guid.clear();
+        self.guid.push_str(guid);
+    }
+}
+impl PartialEq for ListKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.guid == other.guid
+    }
+}
+impl PartialOrd for ListKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(
+            match self.name.to_lowercase().cmp(&other.name.to_lowercase()) {
+                Ordering::Equal => {
+                    self.guid.cmp(&other.guid)
+                },
+                Ordering::Greater => Ordering::Greater,
+                Ordering::Less => Ordering::Less,
+            }
+        )
+    }
+}
+impl PartialEq::<ListItem> for ListKey {
+    fn eq(&self, other: &ListItem) -> bool {
+        self.name == other.name && self.guid == other.guid
+    }
+}
+impl PartialOrd::<ListItem> for ListKey {
+    fn partial_cmp(&self, other: &ListItem) -> Option<Ordering> {
+        Some(
+            match self.name.to_lowercase().cmp(&other.name.to_lowercase()) {
+                Ordering::Equal => {
+                    self.guid.cmp(&other.guid)
+                },
+                Ordering::Greater => Ordering::Greater,
+                Ordering::Less => Ordering::Less,
+            }
+        )
+    }
+}
 /// Display list for items. "name" is the key by which the list is sorted.
 /// "extra" is more information about the item, which should not be part of the sort.
 #[derive(Debug)]
 pub struct ListItem {
     pub name: String,
     pub extra: String,
+    /// used by drawing routines to optimize refresh time
     pub dirty: bool,
     /// this is the name of the key used to refer to the item
     pub guid: String,
@@ -19,7 +80,8 @@ pub struct ListItem {
     pub count: u64,
 }
 impl ListItem {
-    pub fn clone(&self) -> ListItem {
+    // good riddance.
+    /* pub fn clone(&self) -> ListItem {
         ListItem {
             name: self.name.to_string(),
             extra: self.extra.to_string(),
@@ -28,7 +90,7 @@ impl ListItem {
             atime: self.atime,
             count: self.count,
         }
-    }
+    } */
     /// This is made available for edit/delete routines to generate the key without having to
     /// make a whole ListItem record (which is somewhat expensive).
     pub fn key_from_parts(name: &str, guid: &str) -> String {
@@ -40,7 +102,7 @@ impl ListItem {
 }
 impl Ord for ListItem {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.name.cmp(&other.name) {
+        match self.name.to_lowercase().cmp(&other.name.to_lowercase()) {
             Ordering::Equal => {
                 self.guid.cmp(&other.guid)
             },
@@ -50,9 +112,27 @@ impl Ord for ListItem {
     }
 }
 impl PartialOrd for ListItem {
-
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+impl PartialOrd::<ListKey> for ListItem {
+    fn partial_cmp(&self, other: &ListKey) -> Option<Ordering> {
+        // log::info!("self {}:{}\nother: {}:{}", self.name, self.guid, other.name, other.guid);
+        Some(
+            match self.name.to_lowercase().cmp(&other.name.to_lowercase()) {
+                Ordering::Equal => {
+                    self.guid.cmp(&other.guid)
+                },
+                Ordering::Greater => Ordering::Greater,
+                Ordering::Less => Ordering::Less,
+            }
+        )
+    }
+}
+impl PartialEq::<ListKey> for ListItem {
+    fn eq(&self, other: &ListKey) -> bool {
+        self.name == other.name && self.guid == other.guid
     }
 }
 impl PartialEq for ListItem {
@@ -62,285 +142,189 @@ impl PartialEq for ListItem {
 }
 impl Eq for ListItem {}
 
-pub struct ItemLists {
-    fido: BTreeMap::<String, Arc<Mutex<ListItem>>>,
-    totp: BTreeMap::<String, Arc<Mutex<ListItem>>>,
-    pw: BTreeMap::<String, Arc<Mutex<ListItem>>>,
-    /// create a mostly static list of references that we can use to index into the corresponding database
-    /// this gets around both lifetime issues by putting the references in this scope, and also gets
-    /// around slow alloc issues having to deal with copies when avoiding lifetimes.
-    filtered_list: Vec::<Option<Arc<Mutex<ListItem>>>>,
-    /// records the longest possible length of all three lists, so filtered_list() capacity can be adjusted accordingly
-    max_len: usize,
-    /// memoize the filtered length so we don't have to search it every time
-    valid_len: usize,
-    items_per_screen: NonZeroUsize,
+pub struct FilteredListView {
+    list: Vec<ListItem>,
+    sorted: bool,
     selection_index: usize,
+    items_per_screen: NonZeroUsize,
+    filter_range: Option<Range::<usize>>,
 }
-impl ItemLists {
+impl FilteredListView {
     pub fn new() -> Self {
-        ItemLists {
-            fido: BTreeMap::new(),
-            totp: BTreeMap::new(),
-            pw: BTreeMap::new(),
-            filtered_list: Vec::new(),
-            max_len: 0,
-            valid_len: 0,
-            items_per_screen: NonZeroUsize::new(1).unwrap(),
+        Self {
+            list: Vec::new(),
+            sorted: false,
             selection_index: 0,
+            items_per_screen: NonZeroUsize::new(1).unwrap(),
+            filter_range: None,
         }
     }
-    /// safety: caller must call fixup_filter() after successive calls to this are done.
-    pub unsafe fn bulk_insert(&mut self, list_type: VaultMode, key: String, item: ListItem) {
-        match list_type {
-            VaultMode::Fido => self.fido.insert(key, Arc::new(Mutex::new(item))),
-            VaultMode::Totp => self.totp.insert(key, Arc::new(Mutex::new(item))),
-            VaultMode::Password => self.pw.insert(key, Arc::new(Mutex::new(item))),
-        };
+    pub fn expand(&mut self, capacity: usize) {
+        self.list.reserve(capacity.saturating_sub(self.list.len()))
     }
-    pub fn fixup_filter(&mut self) {
-        // grow the filter to accommodate the largest possible list
-        let new_len = self.fido.len()
-        .max(self.totp.len())
-        .max(self.pw.len());
-        // clear the existing records
-        self.filtered_list.iter_mut().for_each(|i| *i = None);
-        self.valid_len = 0;
-        // fill in any growth with null records, guaranteeing that we can always index using slice offsets
-        for _ in 0..new_len.saturating_sub(self.filtered_list.len()) {
-            self.filtered_list.push(None);
-        }
-        self.max_len = new_len;
+    pub fn push(&mut self, item: ListItem) {
+        self.list.push(item);
+        self.sorted = false;
     }
-    pub fn insert(&mut self, list_type: VaultMode, key: String, item: ListItem) -> Option<ListItem> {
-        let maybe_replaced = match list_type {
-            VaultMode::Fido => self.fido.insert(key, Arc::new(Mutex::new(item))),
-            VaultMode::Totp => self.totp.insert(key, Arc::new(Mutex::new(item))),
-            VaultMode::Password => self.pw.insert(key, Arc::new(Mutex::new(item))),
-        };
-        let new_len = match list_type {
-            VaultMode::Fido => self.fido.len(),
-            VaultMode::Totp => self.totp.len(),
-            VaultMode::Password => self.pw.len(),
-        };
-        // clear the filter, because we don't know where in the sort that the updated record should go...
-        self.filtered_list.iter_mut().for_each(|i| *i = None);
-        self.valid_len = 0;
-        // fill in any growth with null records, guaranteeing that we can always index using slice offsets
-        for _ in 0..new_len.saturating_sub(self.filtered_list.len()) {
-            self.filtered_list.push(None);
-        }
-        self.max_len = self.max_len.max(new_len);
-        if let Some(replaced) = maybe_replaced {
-            Some(
-                Arc::<_>::try_unwrap(replaced).unwrap().into_inner().unwrap()
-            )
-        } else {
-            None
-        }
-    }
-    pub fn get(&self, list_type: VaultMode, key: &String) -> Option<&Arc<Mutex<ListItem>>> {
-        match list_type {
-            VaultMode::Fido => self.fido.get(key),
-            VaultMode::Password => self.pw.get(key),
-            VaultMode::Totp => self.pw.get(key),
-        }
-    }
-    pub fn remove(&mut self, list_type: VaultMode, key: String) -> Option<ListItem> {
-        let maybe_item = match list_type {
-            VaultMode::Fido => self.fido.remove(&key),
-            VaultMode::Totp => self.totp.remove(&key),
-            VaultMode::Password => self.pw.remove(&key),
-        };
-        if let Some(item) = maybe_item {
-            log::debug!("count bef: {}", Arc::<_>::strong_count(&item));
-            self.filtered_list.retain(|x|
-                if let Some(filter_item) = x {
-                    if Arc::as_ptr(filter_item) == Arc::as_ptr(&item) {
-                        false // don't retain
-                    } else {
-                        true
-                    }
-                } else {
-                    true
-                }
-            );
-            log::debug!("count aft: {}", Arc::<_>::strong_count(&item));
-            Some(
-                Arc::<_>::try_unwrap(item).unwrap().into_inner().unwrap()
-            )
-        } else {
-            None
-        }
-    }
-    pub fn set_items_per_screen(&mut self, ips: i16) {
-        self.items_per_screen = NonZeroUsize::new(ips as usize).unwrap_or(NonZeroUsize::new(1).unwrap());
-    }
-    pub fn clear_filter(&mut self) {
-        self.filtered_list.iter_mut().for_each(|i| *i = None);
-        self.valid_len = 0;
+    pub fn clear(&mut self) {
+        log::info!("filter clear");
+        self.list.clear();
+        self.sorted = false;
         self.selection_index = 0;
+        self.filter_range = None;
     }
-    pub fn clear(&mut self, list_type: VaultMode) {
-        self.filtered_list.iter_mut().for_each(|i| *i = None);
-        self.valid_len = 0;
-        match list_type {
-            VaultMode::Fido => self.fido.clear(),
-            VaultMode::Totp => self.totp.clear(),
-            VaultMode::Password => self.pw.clear(),
-        }
-        // maybe do a search for what is the new max_len? for now we can just "leave it", it just means we have some excess capacity which is good: less mallocs.
-    }
-    pub fn clear_all(&mut self) {
-        self.filtered_list.iter_mut().for_each(|i| *i = None);
-        self.valid_len = 0;
-        self.fido.clear();
-        self.totp.clear();
-        self.pw.clear();
-        self.max_len = 0;
-    }
-    /// Sets up a filter for the selected list type, returns a default selection index.
-    pub fn filter(&mut self, list_type: VaultMode, criteria: &str) {
-        let tt = ticktimer_server::Ticktimer::new().unwrap();
-        let mut ts = [0u64; 5];
-        ts[0] = tt.elapsed_ms();
-        // clear the list
-        self.filtered_list.iter_mut().for_each(|i| *i = None);
-        ts[1] = tt.elapsed_ms();
-        self.valid_len = 0;
-
-        let itemlist = match list_type {
-            VaultMode::Fido => &mut self.fido,
-            VaultMode::Totp => &mut self.totp,
-            VaultMode::Password => &mut self.pw,
-        };
-        ts[2] = tt.elapsed_ms();
-        let mut filter_index = 0;
-        // search the whole list for now -- maybe optimize to a subset later on,
-        // but would require keeping two copies of the filtered list because we can't do
-        // in-place operation on an already filtered list
-        for item in itemlist.values_mut() {
-            if item.lock().unwrap().name.to_lowercase().starts_with(criteria) {
-                item.lock().unwrap().dirty = true;
-                self.filtered_list[filter_index] = Some(item.clone());
-                filter_index += 1;
+    pub fn set_items_per_screen(&mut self, ips: usize) {
+        if ips != self.items_per_screen.get() {
+            for item in self.list.iter_mut() {
+                item.dirty = true;
             }
         }
-        ts[3] = tt.elapsed_ms();
-        self.valid_len = filter_index;
-        if self.selection_index >= self.valid_len {
-            if self.valid_len > 0 {
-                self.selection_index = self.valid_len - 1;
-            } else {
-                self.selection_index = 0;
+        self.items_per_screen = NonZeroUsize::new(ips).unwrap_or(NonZeroUsize::new(1).unwrap());
+    }
+    pub fn insert_unique(&mut self, item: ListItem) -> Option<ListItem> {
+        if !self.sorted {
+            self.list.sort();
+            self.sorted = true;
+        }
+        self.filter_range = None;
+        match self.list.binary_search_by(|probe| probe.cmp(&item)) {
+            Ok(index) => Some(std::mem::replace(&mut self.list[index], item)),
+            Err(index) => {
+                self.list.insert(index, item);
+                None
+            }
+        }
+    }
+    pub fn remove(&mut self, item: ListKey) -> Option<ListItem> {
+        if !self.sorted {
+            self.list.sort();
+            self.sorted = true;
+        }
+        self.filter_range = None;
+        match self.list.binary_search_by(|probe| probe.partial_cmp(&item).unwrap()) {
+            Ok(index) => {
+                Some(self.list.remove(index))
+            },
+            Err(_index) => None
+        }
+    }
+    pub fn get(&mut self, item: &ListKey) -> Option<&mut ListItem> {
+        if !self.sorted {
+            self.list.sort();
+            self.sorted = true;
+        }
+        match self.list.binary_search_by(|probe| probe.partial_cmp(item).unwrap()) {
+            Ok(index) => {
+                Some(&mut self.list[index])
+            },
+            Err(_index) => None
+        }
+    }
+    pub fn filter(&mut self, criteria: &String) {
+        let tt = ticktimer_server::Ticktimer::new().unwrap();
+        let mut ts = [0u64; 6];
+        ts[0] = tt.elapsed_ms();
+        // always ensure the list is sorted
+        if !self.sorted {
+            self.list.sort();
+            self.sorted = true;
+        }
+        ts[1] = tt.elapsed_ms();
+        // sanity checks on the request
+        if criteria.len() == 0 {
+            self.filter_reset();
+            return;
+        }
+        if self.list.len() == 0 {
+            log::info!("zero-length list!");
+            return;
+        }
+        // step 1. binary search to find if the criteria is even anywhere in the list.
+        match self.list.binary_search_by(|probe| probe.name.partial_cmp(criteria).unwrap()) {
+            Ok(mut index) | Err(mut index) => {
+                if !self.list[index].name.to_lowercase().starts_with(criteria) {
+                    self.filter_range = None
+                } else {
+                    // step 2. we have to go backwards in the list because if we have several matches, we are
+                    // not guaranteed to be at the first match. Find that first match with a linear search.
+                    ts[2] = tt.elapsed_ms();
+                    while index.saturating_sub(1) > 0 {
+                        if self.list[index - 1].name.to_lowercase().starts_with(criteria) {
+                            index -= 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    // the index now starts at the range of matches. Find the end of matches with another linear search.
+                    let mut end_index = index + 1;
+                    ts[3] = tt.elapsed_ms();
+                    while end_index < self.list.len() {
+                        if self.list[end_index].name.to_lowercase().starts_with(criteria) {
+                            end_index += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    self.filter_range = Some(index..end_index)
+                }
             }
         }
         ts[4] = tt.elapsed_ms();
+        if let Some(r) = &self.filter_range {
+            if self.selection_index >= r.len() {
+                self.selection_index = 0;
+            }
+        }
+        self.mark_filtered_as_dirty();
+        ts[5] = tt.elapsed_ms();
         for(index, &elapsed) in ts[1..].iter().enumerate() {
             log::info!("{}: {}", index + 1, elapsed - ts[0]);
         }
     }
-    /// Sets the filter's buffer to point to the entire contents of the specified list (no filtering)
-    pub fn filter_reset(&mut self, list_type: VaultMode) {
-        // clear the list
-        self.filtered_list.iter_mut().for_each(|i| *i = None);
-        self.valid_len = 0;
-
-        let itemlist = match list_type {
-            VaultMode::Fido => &mut self.fido,
-            VaultMode::Totp => &mut self.totp,
-            VaultMode::Password => &mut self.pw,
-        };
-        assert!(itemlist.len() <= self.filtered_list.len(), "consistency error in filter vector size");
-        for (item, filt)
-        in itemlist.values_mut().zip(self.filtered_list.iter_mut()) {
-            item.lock().unwrap().dirty = true;
-            *filt = Some(item.clone());
-        }
-        self.valid_len = itemlist.len();
-        if self.selection_index >= self.valid_len {
-            if self.valid_len > 0 {
-                self.selection_index = self.valid_len - 1;
-            } else {
-                self.selection_index = 0;
+    fn mark_filtered_as_dirty(&mut self) {
+        if let Some(r) = self.filter_range.clone() {
+            for i in self.list[r].iter_mut() {
+                i.dirty = true;
             }
         }
+    }
+    pub fn filter_reset(&mut self) {
+        self.filter_range = Some(0..self.list.len());
+        self.mark_filtered_as_dirty();
     }
     pub fn filter_len(&self) -> usize {
-        self.valid_len
-    }
-    pub fn nav(&mut self, dir: NavDir) {
-        match dir {
-            NavDir::Up => {
-                if self.selection_index > 0 {
-                    let starting_page = self.get_page();
-                    self.mark_as_dirty(self.selection_index);
-                    self.selection_index -= 1;
-                    self.mark_as_dirty(self.selection_index);
-                    if starting_page != self.get_page() {
-                        self.mark_screen_as_dirty(self.selection_index);
-                    }
-                }
-            }
-            NavDir::Down => {
-                if self.selection_index < self.valid_len {
-                    let starting_page = self.get_page();
-                    self.mark_as_dirty(self.selection_index);
-                    self.selection_index += 1;
-                    self.mark_as_dirty(self.selection_index);
-                    if starting_page != self.get_page() {
-                        self.mark_screen_as_dirty(self.selection_index);
-                    }
-                }
-            }
-            NavDir::PageUp => {
-                if self.selection_index > self.items_per_screen.get() {
-                    self.mark_screen_as_dirty(self.selection_index);
-                    self.selection_index -= self.items_per_screen.get();
-                    self.mark_screen_as_dirty(self.selection_index);
-                } else {
-                    self.mark_as_dirty(self.selection_index);
-                    self.selection_index = 0;
-                    self.mark_as_dirty(self.selection_index);
-                }
-            }
-            NavDir::PageDown => {
-                if self.selection_index < self.valid_len - self.items_per_screen.get() {
-                    self.mark_screen_as_dirty(self.selection_index);
-                    self.selection_index += self.items_per_screen.get();
-                    self.mark_screen_as_dirty(self.selection_index);
-                } else {
-                    self.mark_as_dirty(self.selection_index);
-                    self.selection_index = self.valid_len - 1;
-                    self.mark_as_dirty(self.selection_index);
-                }
-            }
-        }
-    }
-    fn mark_as_dirty(&mut self, index: usize) {
-        if self.valid_len > 0 {
-            if let Some(record) = self.filtered_list[index.min(self.valid_len - 1)].as_mut() {
-                record.lock().unwrap().dirty = true;
-            }
+        if let Some(r) = &self.filter_range {
+            log::info!("filter len {}", r.len());
+            r.len()
+        } else {
+            log::info!("filter is not present (0)");
+            0
         }
     }
     pub fn mark_all_dirty(&mut self) {
-        for maybe_item in self.filtered_list.iter_mut() {
-            if let Some(item) = maybe_item {
-                item.lock().unwrap().dirty = true;
-            }
+        for item in self.list.iter_mut() {
+            item.dirty = true;
         }
     }
-    fn mark_screen_as_dirty(&mut self, index: usize) {
-        let page = index as i16 / self.items_per_screen.get() as i16;
-        for item in self.filtered_list[
-            ((page as usize) * self.items_per_screen.get()).min(self.valid_len) ..
-            ((1 + page as usize) * self.items_per_screen.get()).min(self.valid_len)
-        ].iter_mut() {
-            if let Some(record) = item {
-                record.lock().unwrap().dirty = true;
-            }
+    fn mark_filtered_selection_as_dirty(&mut self, index: usize) {
+        let index = index + self.filter_start();
+        if index < self.list.len() {
+            self.list[index].dirty = true;
         }
+    }
+    fn mark_filtered_screen_as_dirty(&mut self, index: usize) {
+        let index = index + self.filter_start();
+        let page = index / self.items_per_screen.get();
+        let listlen = self.list.len();
+        for item in self.list[
+            ((page as usize) * self.items_per_screen.get()).min(listlen) ..
+            ((1 + page as usize) * self.items_per_screen.get()).min(listlen)
+        ].iter_mut() {
+            item.dirty = true;
+        }
+    }
+    fn filter_start(&self) -> usize {
+        self.filter_range.clone().unwrap_or(0..0).start
     }
     pub fn get_page(&self) -> usize {
         self.selection_index / self.items_per_screen.get()
@@ -348,51 +332,195 @@ impl ItemLists {
     pub fn selected_index(&self) -> usize {
         self.selection_index % self.items_per_screen.get()
     }
-    pub fn selected_page(&mut self) -> &mut [Option<Arc<Mutex<ListItem>>>] {
+    pub fn selected_page(&mut self) -> &mut [ListItem] {
+        let filterlen = self.filter_len();
         let page = self.get_page();
-        &mut self.filtered_list[
-            (page * self.items_per_screen.get()).min(self.valid_len) ..
-            ((1 + page) * self.items_per_screen.get()).min(self.valid_len)
+        let filtered_range = &mut self.list[self.filter_range.clone().unwrap_or(0..0)];
+        &mut filtered_range[
+            (page * self.items_per_screen.get()).min(filterlen) ..
+            ((1 + page) * self.items_per_screen.get()).min(filterlen)
         ]
     }
+    pub fn nav(&mut self, dir: NavDir) {
+        log::info!("index bef: {}, filter: {:?}", self.selection_index, self.filter_range);
+        match dir {
+            NavDir::Up => {
+                if self.selection_index > 0 {
+                    let starting_page = self.get_page();
+                    self.mark_filtered_selection_as_dirty(self.selection_index);
+                    self.selection_index -= 1;
+                    self.mark_filtered_selection_as_dirty(self.selection_index);
+                    if starting_page != self.get_page() {
+                        self.mark_filtered_screen_as_dirty(self.selection_index);
+                    }
+                }
+            }
+            NavDir::Down => {
+                if self.selection_index < self.filter_len() {
+                    let starting_page = self.get_page();
+                    self.mark_filtered_selection_as_dirty(self.selection_index);
+                    self.selection_index += 1;
+                    self.mark_filtered_selection_as_dirty(self.selection_index);
+                    if starting_page != self.get_page() {
+                        self.mark_filtered_screen_as_dirty(self.selection_index);
+                    }
+                }
+            }
+            NavDir::PageUp => {
+                if self.selection_index > self.items_per_screen.get() {
+                    self.mark_filtered_screen_as_dirty(self.selection_index);
+                    self.selection_index -= self.items_per_screen.get();
+                    self.mark_filtered_screen_as_dirty(self.selection_index);
+                } else {
+                    self.mark_filtered_selection_as_dirty(self.selection_index);
+                    self.selection_index = 0;
+                    self.mark_filtered_selection_as_dirty(self.selection_index);
+                }
+            }
+            NavDir::PageDown => {
+                if self.selection_index < self.filter_len() - self.items_per_screen.get() {
+                    self.mark_filtered_screen_as_dirty(self.selection_index);
+                    self.selection_index += self.items_per_screen.get();
+                    self.mark_filtered_screen_as_dirty(self.selection_index);
+                } else {
+                    self.mark_filtered_selection_as_dirty(self.selection_index);
+                    self.selection_index = self.filter_len() - 1;
+                    self.mark_filtered_selection_as_dirty(self.selection_index);
+                }
+            }
+        }
+        log::info!("index after: {}", self.selection_index);
+    }
     pub fn selected_guid(&self) -> String {
-        // we unwrap() here because this function is responsible for consistency of the filtered list.
-        self.filtered_list[self.selection_index].as_ref().unwrap().lock().unwrap().guid.to_owned()
+        self.list[self.selection_index + self.filter_start()].guid.to_owned()
     }
     pub fn selected_extra(&self) -> String {
-        // we unwrap() here because this function is responsible for consistency of the filtered list.
-        self.filtered_list[self.selection_index].as_ref().unwrap().lock().unwrap().extra.to_owned()
+        self.list[self.selection_index + self.filter_start()].extra.to_owned()
     }
     pub fn selected_update_extra(&mut self, extra: String) {
-        self.filtered_list[self.selection_index].as_mut().unwrap().lock().unwrap().extra = extra;
-        self.filtered_list[self.selection_index].as_mut().unwrap().lock().unwrap().dirty = true;
+        let start = self.filter_start();
+        self.list[self.selection_index + start].extra = extra
     }
     pub fn selected_update_atime(&mut self, atime: u64) {
-        self.filtered_list[self.selection_index].as_mut().unwrap().lock().unwrap().atime = atime;
-        self.filtered_list[self.selection_index].as_mut().unwrap().lock().unwrap().dirty = true;
-    }
-    pub fn mark_selected_as_dirty(&mut self) {
-        // we unwrap() here because this function is responsible for consistency of the filtered list.
-        self.filtered_list[self.selection_index].as_mut().unwrap().lock().unwrap().dirty = true;
+        let start = self.filter_start();
+        self.list[self.selection_index + start].atime = atime
     }
     pub fn selected_entry(&self, mode: VaultMode) -> Option<SelectedEntry> {
-        let ret = if self.selection_index > self.valid_len {
-            None
-        } else {
-            if let Some(entry) = &self.filtered_list[self.selection_index] {
-                let guarded_entry = entry.lock().unwrap();
+        if let Some(r) = self.filter_range.clone() {
+            log::info!("filter range: {:?}", r);
+            log::info!("selection index: {}", self.selection_index);
+            log::info!("filter start: {}", self.filter_start());
+            if r.contains(&(self.selection_index + self.filter_start())) {
                 Some(
                     SelectedEntry {
-                        key_name: xous_ipc::String::from_str(guarded_entry.guid.to_string()),
-                        description: xous_ipc::String::from_str(guarded_entry.name.to_string()),
+                        key_guid: xous_ipc::String::from_str(&self.list[self.selection_index + self.filter_start()].guid),
+                        description: xous_ipc::String::from_str(&self.list[self.selection_index + self.filter_start()].name),
                         mode
                     }
                 )
             } else {
                 None
             }
-        };
-        ret
+        } else {
+            None
+        }
     }
-
+}
+pub struct ItemLists {
+    fido: FilteredListView,
+    totp: FilteredListView,
+    pw: FilteredListView,
+}
+impl ItemLists {
+    pub fn new() -> Self {
+        ItemLists {
+            fido: FilteredListView::new(),
+            totp: FilteredListView::new(),
+            pw: FilteredListView::new(),
+        }
+    }
+    fn li_mut(&mut self, list_type: VaultMode) -> &mut FilteredListView {
+        match list_type {
+            VaultMode::Fido => &mut self.fido,
+            VaultMode::Totp => &mut self.totp,
+            VaultMode::Password => &mut self.pw,
+        }
+    }
+    fn li(&self, list_type: VaultMode) -> &FilteredListView {
+        match list_type {
+            VaultMode::Fido => &self.fido,
+            VaultMode::Totp => &self.totp,
+            VaultMode::Password => &self.pw,
+        }
+    }
+    pub fn push(&mut self, list_type: VaultMode, item: ListItem) {
+        self.li_mut(list_type).push(item);
+    }
+    pub fn expand(&mut self, list_type: VaultMode, capacity: usize) {
+        self.li_mut(list_type).expand(capacity);
+    }
+    pub fn insert_unique(&mut self, list_type: VaultMode, item: ListItem) -> Option<ListItem> {
+        self.li_mut(list_type).insert_unique(item)
+    }
+    pub fn get(&mut self, list_type: VaultMode, key: &ListKey) -> Option<&mut ListItem> {
+        self.li_mut(list_type).get(key)
+    }
+    pub fn remove(&mut self, list_type: VaultMode, key: ListKey) -> Option<ListItem> {
+        self.li_mut(list_type).remove(key)
+    }
+    pub fn set_items_per_screen(&mut self, ips: i16) {
+        self.fido.set_items_per_screen(ips as usize);
+        self.totp.set_items_per_screen(ips as usize);
+        self.pw.set_items_per_screen(ips as usize);
+    }
+    pub fn mark_all_dirty(&mut self) {
+        self.fido.mark_all_dirty();
+        self.totp.mark_all_dirty();
+        self.pw.mark_all_dirty();
+    }
+    pub fn clear_filter(&mut self) {
+    }
+    pub fn clear(&mut self, list_type: VaultMode) {
+        self.li_mut(list_type).clear();
+    }
+    pub fn clear_all(&mut self) {
+        self.fido.clear();
+        self.pw.clear();
+        self.totp.clear();
+    }
+    /// Sets up a filter for the selected list type, returns a default selection index.
+    pub fn filter(&mut self, list_type: VaultMode, criteria: &String) {
+        self.li_mut(list_type).filter(criteria);
+    }
+    /// Sets the filter's buffer to point to the entire contents of the specified list (no filtering)
+    pub fn filter_reset(&mut self, list_type: VaultMode) {
+        self.li_mut(list_type).filter_reset();
+    }
+    pub fn filter_len(&self, list_type: VaultMode) -> usize {
+        self.li(list_type).filter_len()
+    }
+    pub fn nav(&mut self, list_type: VaultMode, dir: NavDir) {
+        self.li_mut(list_type).nav(dir);
+    }
+    pub fn selected_index(&self, list_type: VaultMode) -> usize {
+        self.li(list_type).selected_index()
+    }
+    pub fn selected_guid(&self, list_type: VaultMode) -> String {
+        self.li(list_type).selected_guid()
+    }
+    pub fn selected_extra(&self, list_type: VaultMode) -> String {
+        self.li(list_type).selected_extra()
+    }
+    pub fn selected_update_extra(&mut self, list_type: VaultMode, extra: String) {
+        self.li_mut(list_type).selected_update_extra(extra)
+    }
+    pub fn selected_update_atime(&mut self, list_type: VaultMode, atime: u64) {
+        self.li_mut(list_type).selected_update_atime(atime)
+    }
+    pub fn selected_entry(&self, list_type: VaultMode) -> Option<SelectedEntry> {
+        self.li(list_type).selected_entry(list_type)
+    }
+    pub fn selected_page(&mut self, list_type: VaultMode) -> &mut [ListItem] {
+        self.li_mut(list_type).selected_page()
+    }
 }

--- a/apps/vault/src/main.rs
+++ b/apps/vault/src/main.rs
@@ -113,7 +113,7 @@ const ERR_TIMEOUT_MS: usize = 5000;
 
 fn main() -> ! {
     log_server::init_wait().unwrap();
-    log::set_max_level(log::LevelFilter::Info);
+    log::set_max_level(log::LevelFilter::Debug);
     log::info!("my PID is {}", xous::process::id());
 
     let xns = xous_names::XousNames::new().unwrap();
@@ -171,7 +171,9 @@ fn main() -> ! {
                     Some(ActionOp::MenuEditStage2) => {
                         let buffer = unsafe { Buffer::from_memory_message(msg.body.memory_message().unwrap()) };
                         let entry = buffer.to_original::<SelectedEntry, _>().unwrap();
+                        log::debug!("bef activate");
                         manager.activate();
+                        log::debug!("bef edit");
                         manager.menu_edit(entry);
                         manager.retrieve_db();
                         manager.deactivate();
@@ -657,6 +659,7 @@ fn main() -> ! {
             }
             Some(VaultOp::MenuEditStage1) => {
                 // stage 1 happens here because the filtered list and selection entry are in the responsive UX section.
+                log::debug!("selecting entry for edit");
                 if let Some(entry) = vaultux.selected_entry() {
                     let buf = Buffer::into_buf(entry).expect("IPC error");
                     buf.send(actions_conn, ActionOp::MenuEditStage2.to_u32().unwrap()).expect("messaging error");

--- a/apps/vault/src/main.rs
+++ b/apps/vault/src/main.rs
@@ -9,6 +9,8 @@ mod prereqs;
 mod vendor_commands;
 mod storage;
 mod migration_v1;
+mod itemcache;
+use itemcache::*;
 
 use locales::t;
 
@@ -19,14 +21,14 @@ use vault::{
     SELF_CONN, Transport, VaultOp
 };
 
-use actions::{ActionOp, start_actions_thread};
-use crate::ux::framework::{ListItem, NavDir};
+use actions::ActionOp;
+use crate::ux::framework::NavDir;
 use crate::prereqs::ntp_updater;
 use crate::vendor_commands::VendorSession;
 
 use ux::framework::{VaultUx, DEFAULT_FONT, FONT_LIST, name_to_style};
 use xous_ipc::Buffer;
-use xous::{send_message, Message};
+use xous::{send_message, Message, msg_blocking_scalar_unpack};
 use usbd_human_interface_device::device::fido::*;
 use num_traits::*;
 
@@ -34,8 +36,6 @@ use std::thread;
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use std::collections::BTreeMap;
-
 
 // CTAP2 testing notes:
 //
@@ -108,16 +108,6 @@ pub struct SelectedEntry {
     pub description: xous_ipc::String::<256>,
     pub mode: VaultMode,
 }
-pub struct ItemLists {
-    pub fido: BTreeMap::<String, ListItem>,
-    pub totp: BTreeMap::<String, ListItem>,
-    pub pw: BTreeMap::<String, ListItem>,
-}
-impl ItemLists {
-    pub fn new() -> Self {
-        ItemLists { fido: BTreeMap::new(), totp: BTreeMap::new(), pw: BTreeMap::new() }
-    }
-}
 
 const ERR_TIMEOUT_MS: usize = 5000;
 
@@ -147,14 +137,92 @@ fn main() -> ! {
     // redraws of the background list to block/fail.
     let actions_sid = xous::create_server().unwrap();
     SELF_CONN.store(conn, Ordering::SeqCst);
-    start_actions_thread(
-        conn,
-        actions_sid,
-        mode.clone(),
-        item_lists.clone(),
-        action_active.clone(),
-        opensk_mutex.clone(),
-    );
+    let _ = thread::spawn({
+        let main_conn = conn.clone();
+        let sid = actions_sid.clone();
+        let mode = mode.clone();
+        let item_lists = item_lists.clone();
+        let action_active = action_active.clone();
+        let opensk_mutex = opensk_mutex.clone();
+        move || {
+            let mut manager = crate::actions::ActionManager::new(main_conn, mode, item_lists, action_active, opensk_mutex);
+            loop {
+                let msg = xous::receive_message(sid).unwrap();
+                let opcode: Option<ActionOp> = FromPrimitive::from_usize(msg.body.id());
+                log::debug!("{:?}", opcode);
+                match opcode {
+                    Some(ActionOp::MenuAddnew) => {
+                        manager.activate();
+                        manager.menu_addnew();
+                        // this is necessary so the next redraw shows the newly added entry
+                        // no cache clear is called for because new entries will always add to the list;
+                        // there is no risk of "stale" entries persisting
+                        manager.retrieve_db();
+                        manager.deactivate();
+                    },
+                    Some(ActionOp::MenuDeleteStage2) => {
+                        let buffer = unsafe { Buffer::from_memory_message(msg.body.memory_message().unwrap()) };
+                        let entry = buffer.to_original::<SelectedEntry, _>().unwrap();
+                        manager.activate();
+                        manager.menu_delete(entry);
+                        manager.retrieve_db();
+                        manager.deactivate();
+                    },
+                    Some(ActionOp::MenuEditStage2) => {
+                        let buffer = unsafe { Buffer::from_memory_message(msg.body.memory_message().unwrap()) };
+                        let entry = buffer.to_original::<SelectedEntry, _>().unwrap();
+                        manager.activate();
+                        manager.menu_edit(entry);
+                        manager.retrieve_db();
+                        manager.deactivate();
+                    },
+                    Some(ActionOp::MenuUnlockBasis) => {
+                        manager.activate();
+                        manager.unlock_basis();
+                        manager.item_lists.lock().unwrap().clear(VaultMode::Password); // clear the cached item list for passwords (totp/fido are not cached and don't need clearing)
+                        manager.retrieve_db();
+                        manager.deactivate();
+                    },
+                    Some(ActionOp::MenuManageBasis) => {
+                        manager.activate();
+                        manager.manage_basis();
+                        manager.item_lists.lock().unwrap().clear(VaultMode::Password); // clear the cached item list for passwords
+                        manager.retrieve_db();
+                        manager.deactivate();
+                    }
+                    Some(ActionOp::MenuClose) => {
+                        // dummy activate/de-activate cycle because we have to trigger a redraw of the underlying UX
+                        manager.activate();
+                        manager.deactivate();
+                    },
+                    Some(ActionOp::UpdateOneItem) => {
+                        let buffer = unsafe { Buffer::from_memory_message(msg.body.memory_message().unwrap()) };
+                        let entry = buffer.to_original::<SelectedEntry, _>().unwrap();
+                        manager.activate();
+                        manager.update_db_entry(entry);
+                        manager.deactivate();
+                    }
+                    Some(ActionOp::UpdateMode) => msg_blocking_scalar_unpack!(msg, _, _, _, _,{
+                        manager.retrieve_db();
+                        xous::return_scalar(msg.sender, 1).unwrap();
+                    }),
+                    Some(ActionOp::Quit) => {
+                        break;
+                    }
+                    None => {
+                        log::error!("msg could not be decoded {:?}", msg);
+                    }
+                    #[cfg(feature="vault-testing")]
+                    Some(ActionOp::GenerateTests) => {
+                        manager.populate_tests();
+                        manager.retrieve_db();
+                    }
+                }
+            }
+            xous::destroy_server(sid).ok();
+        }
+    });
+
     let actions_conn = xous::connect(actions_sid).unwrap();
 
     // spawn the FIDO USB->UX update kicker thread. It is responsible for issuing a UX refresh command
@@ -369,7 +437,7 @@ fn main() -> ! {
         menu_mgr,
         actions_conn,
         mode.clone(),
-        item_lists,
+        item_lists.clone(),
         action_active.clone()
     );
     vaultux.update_mode();

--- a/apps/vault/src/main.rs
+++ b/apps/vault/src/main.rs
@@ -104,7 +104,7 @@ pub enum VaultMode {
 
 #[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Copy, Clone)]
 pub struct SelectedEntry {
-    pub key_name: xous_ipc::String::<256>,
+    pub key_guid: xous_ipc::String::<256>,
     pub description: xous_ipc::String::<256>,
     pub mode: VaultMode,
 }
@@ -171,9 +171,7 @@ fn main() -> ! {
                     Some(ActionOp::MenuEditStage2) => {
                         let buffer = unsafe { Buffer::from_memory_message(msg.body.memory_message().unwrap()) };
                         let entry = buffer.to_original::<SelectedEntry, _>().unwrap();
-                        log::debug!("bef activate");
                         manager.activate();
-                        log::debug!("bef edit");
                         manager.menu_edit(entry);
                         manager.retrieve_db();
                         manager.deactivate();

--- a/apps/vault/src/main.rs
+++ b/apps/vault/src/main.rs
@@ -113,7 +113,7 @@ const ERR_TIMEOUT_MS: usize = 5000;
 
 fn main() -> ! {
     log_server::init_wait().unwrap();
-    log::set_max_level(log::LevelFilter::Debug);
+    log::set_max_level(log::LevelFilter::Info);
     log::info!("my PID is {}", xous::process::id());
 
     let xns = xous_names::XousNames::new().unwrap();

--- a/apps/vault/src/storage.rs
+++ b/apps/vault/src/storage.rs
@@ -833,7 +833,7 @@ fn utc_now() -> DateTime<Utc> {
     DateTime::from_utc(naive, Utc)
 }
 
-fn hex(data: Vec<u8>) -> String {
+pub fn hex(data: Vec<u8>) -> String {
     use std::fmt::Write;
     let mut s = String::with_capacity(2 * data.len());
     for byte in data {

--- a/apps/vault/src/ux/framework.rs
+++ b/apps/vault/src/ux/framework.rs
@@ -13,66 +13,10 @@ use std::sync::atomic::Ordering as AtomicOrdering;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::AtomicBool;
 use std::convert::TryFrom;
-use std::cmp::Ordering;
 use usb_device_xous::UsbDeviceType;
 use locales::t;
 use num_traits::*;
-
-/// Display list for items. "name" is the key by which the list is sorted.
-/// "extra" is more information about the item, which should not be part of the sort.
-pub struct ListItem {
-    pub name: String,
-    pub extra: String,
-    pub dirty: bool,
-    /// this is the name of the key used to refer to the item
-    pub guid: String,
-    /// stash a copy so we can compare to the DB record and avoid re-generating the atime/count string if it hasn't changed.
-    pub atime: u64,
-    pub count: u64,
-}
-impl ListItem {
-    pub fn clone(&self) -> ListItem {
-        ListItem {
-            name: self.name.to_string(),
-            extra: self.extra.to_string(),
-            dirty: self.dirty,
-            guid: self.guid.to_string(),
-            atime: self.atime,
-            count: self.count,
-        }
-    }
-    /// This is made available for edit/delete routines to generate the key without having to
-    /// make a whole ListItem record (which is somewhat expensive).
-    pub fn key_from_parts(name: &str, guid: &str) -> String {
-        name.to_lowercase() + &guid.to_string()
-    }
-    pub fn key(&self) -> String {
-        Self::key_from_parts(&self.name, &self.guid)
-    }
-}
-impl Ord for ListItem {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match self.name.cmp(&other.name) {
-            Ordering::Equal => {
-                self.guid.cmp(&other.guid)
-            },
-            Ordering::Greater => Ordering::Greater,
-            Ordering::Less => Ordering::Less,
-        }
-    }
-}
-impl PartialOrd for ListItem {
-
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-impl PartialEq for ListItem {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.guid == other.guid
-    }
-}
-impl Eq for ListItem {}
+use crate::ListItem;
 
 pub enum NavDir {
     Up,
@@ -103,8 +47,6 @@ pub struct VaultUx {
     item_lists: Arc::<Mutex::<ItemLists>>,
     /// list of items displayable after filtering
     filtered_list: Vec::<ListItem>,
-    /// the index into the item_list that is selected
-    selection_index: usize,
     /// last filter query, so we can re-use it when mode is changed
     last_query: String,
 
@@ -186,6 +128,7 @@ impl VaultUx {
         let glyph_height = gam.glyph_height_hint(style).unwrap();
         let item_height = (glyph_height * 2) as i16 + margin.y * 2 + 2; // +2 because of the border width
         let items_per_screen = available_height / item_height;
+        item_lists.lock().unwrap().set_items_per_screen(items_per_screen);
 
         let current_time = get_current_unix_time().unwrap_or(0);
 
@@ -198,7 +141,6 @@ impl VaultUx {
             mode,
             title_dirty: true,
             item_lists,
-            selection_index: 0,
             filtered_list: Vec::new(),
             pddb: RefCell::new(pddb),
             style,
@@ -217,17 +159,18 @@ impl VaultUx {
     }
 
     pub(crate) fn basis_change(&mut self) {
-        self.item_lists.lock().unwrap().pw.clear();
-        self.item_lists.lock().unwrap().fido.clear();
-        self.item_lists.lock().unwrap().totp.clear();
+        self.item_lists.lock().unwrap().clear_all();
     }
 
     pub(crate) fn update_mode(&mut self) {
         self.title_dirty = true;
-        self.filtered_list.clear();
-        self.selection_index = 0;
-        let query = self.last_query.to_string();
-        self.filter(&query);
+        {
+            let mut guarded_list = self.item_lists.lock().unwrap();
+            guarded_list.clear_filter();
+            let query = self.last_query.to_string();
+            guarded_list
+            .filter(self.mode.lock().unwrap().clone(), &query);
+        }
         self.swap_submenu();
     }
 
@@ -307,6 +250,7 @@ impl VaultUx {
         let glyph_height = self.gam.glyph_height_hint(self.style).unwrap();
         self.item_height = (glyph_height * 2) as i16 + self.margin.y * 2 + 2; // +2 because of the border width
         self.items_per_screen = available_height / self.item_height;
+        self.item_lists.lock().unwrap().set_items_per_screen(self.items_per_screen);
     }
     pub(crate) fn set_glyph_style(&mut self, style: GlyphStyle) {
         self.pddb.borrow().delete_key(VAULT_CONFIG_DICT, VAULT_CONFIG_KEY_FONT, Some(pddb::PDDB_DEFAULT_SYSTEM_BASIS))
@@ -326,79 +270,8 @@ impl VaultUx {
         self.pddb.borrow().sync().ok();
         self.get_glyph_style();
     }
-    fn mark_as_dirty(&mut self, index: usize) {
-        let list_len = self.filtered_list.len();
-        if list_len > 0 {
-            self.filtered_list[index.min(list_len - 1)].dirty = true;
-        }
-    }
-    fn mark_screen_as_dirty(&mut self, index: usize) {
-        let page = index as i16 / self.items_per_screen;
-        let list_len = self.filtered_list.len();
-        for item in self.filtered_list[
-            ((page as usize) * self.items_per_screen as usize).min(list_len) ..
-            ((1 + page as usize) * self.items_per_screen as usize).min(list_len)
-        ].iter_mut() {
-            item.dirty = true;
-        }
-    }
-    fn backpropagate_item(&mut self, mut updated_item: ListItem) -> bool {
-        let il = &mut self.item_lists.lock().unwrap();
-        let item_list = match self.mode.lock().unwrap().clone() {
-            VaultMode::Fido => &mut il.fido,
-            VaultMode::Totp => &mut il.totp,
-            VaultMode::Password => &mut il.pw,
-        };
-        updated_item.dirty = true;
-        item_list.insert(updated_item.key(), updated_item).is_some()
-    }
     pub(crate) fn nav(&mut self, dir: NavDir) {
-        match dir {
-            NavDir::Up => {
-                if self.selection_index > 0 {
-                    let starting_page = self.get_page();
-                    self.mark_as_dirty(self.selection_index);
-                    self.selection_index -= 1;
-                    self.mark_as_dirty(self.selection_index);
-                    if starting_page != self.get_page() {
-                        self.mark_screen_as_dirty(self.selection_index);
-                    }
-                }
-            }
-            NavDir::Down => {
-                if self.selection_index < self.filtered_list.len() {
-                    let starting_page = self.get_page();
-                    self.mark_as_dirty(self.selection_index);
-                    self.selection_index += 1;
-                    self.mark_as_dirty(self.selection_index);
-                    if starting_page != self.get_page() {
-                        self.mark_screen_as_dirty(self.selection_index);
-                    }
-                }
-            }
-            NavDir::PageUp => {
-                if self.selection_index > self.items_per_screen as usize {
-                    self.mark_screen_as_dirty(self.selection_index);
-                    self.selection_index -= self.items_per_screen as usize;
-                    self.mark_screen_as_dirty(self.selection_index);
-                } else {
-                    self.mark_as_dirty(self.selection_index);
-                    self.selection_index = 0;
-                    self.mark_as_dirty(self.selection_index);
-                }
-            }
-            NavDir::PageDown => {
-                if self.selection_index < self.filtered_list.len() - self.items_per_screen as usize {
-                    self.mark_screen_as_dirty(self.selection_index);
-                    self.selection_index += self.items_per_screen as usize;
-                    self.mark_screen_as_dirty(self.selection_index);
-                } else {
-                    self.mark_as_dirty(self.selection_index);
-                    self.selection_index = self.filtered_list.len() - 1;
-                    self.mark_as_dirty(self.selection_index);
-                }
-            }
-        }
+        self.item_lists.lock().unwrap().nav(self.mode.lock().unwrap().clone(), dir);
     }
     /// accept a new input string
     pub(crate) fn input(&mut self, line: &str) -> Result<(), xous::Error> {
@@ -406,9 +279,6 @@ impl VaultUx {
         self.filter(line);
         self.last_query = line.to_string();
         Ok(())
-    }
-    fn get_page(&self) -> i16 {
-        self.selection_index as i16 / self.items_per_screen
     }
 
     fn clear_area(&mut self) {
@@ -446,39 +316,41 @@ impl VaultUx {
         let mut dirty_tl: Option<Point> = None;
         let mut dirty_br: Option<Point> = None;
 
-        let page = self.get_page();
-        let list_len = self.filtered_list.len();
-        for item in self.filtered_list[
-            ((page as usize) * self.items_per_screen as usize).min(list_len) ..
-            ((1 + page as usize) * self.items_per_screen as usize).min(list_len)
-        ].iter() {
-            if item.dirty && dirty_tl.is_none() {
-                // start the dirty area
-                dirty_tl = Some(Point::new(0, insert_at));
-            }
-            if !item.dirty && dirty_tl.is_some() && dirty_br.is_none() {
-                // end the dirty area
-                dirty_br = Some(Point::new(self.screensize.y, insert_at));
-            }
-            if let Some(tl) = dirty_tl {
-                if let Some(br) = dirty_br {
-                    // start & end found: now draw a rectangle over it
-                    self.gam.draw_rectangle(self.content,
-                        Rectangle::new_with_style(
-                            tl,
-                            br,
-                        DrawStyle {
-                            fill_color: Some(PixelColor::Light),
-                            stroke_color: None,
-                            stroke_width: 0
-                        }
-                    )).expect("can't clear content area");
-                    // reset the search
-                    dirty_tl = None;
-                    dirty_br = None;
+        let mut guarded_list = self.item_lists.lock().unwrap();
+        let current_page = guarded_list.selected_page();
+        for item in current_page.iter() {
+            if let Some(item_mutex) = item {
+                let item = item_mutex.lock().unwrap();
+                if item.dirty && dirty_tl.is_none() {
+                    // start the dirty area
+                    dirty_tl = Some(Point::new(0, insert_at));
                 }
+                if !item.dirty && dirty_tl.is_some() && dirty_br.is_none() {
+                    // end the dirty area
+                    dirty_br = Some(Point::new(self.screensize.y, insert_at));
+                }
+                if let Some(tl) = dirty_tl {
+                    if let Some(br) = dirty_br {
+                        // start & end found: now draw a rectangle over it
+                        self.gam.draw_rectangle(self.content,
+                            Rectangle::new_with_style(
+                                tl,
+                                br,
+                            DrawStyle {
+                                fill_color: Some(PixelColor::Light),
+                                stroke_color: None,
+                                stroke_width: 0
+                            }
+                        )).expect("can't clear content area");
+                        // reset the search
+                        dirty_tl = None;
+                        dirty_br = None;
+                    }
+                }
+                insert_at += self.item_height;
+            } else {
+                log::error!("Filtered list consistency error!")
             }
-            insert_at += self.item_height;
         }
         if let Some(tl) = dirty_tl {
             // handle the case that we were dirty all the way to the bottom
@@ -595,78 +467,80 @@ impl VaultUx {
             return Ok(());
         }
         // ---- draw list body area ----
-        let page = self.get_page();
-        let selected = self.selection_index as i16 % self.items_per_screen;
-        let list_len = self.filtered_list.len();
-        for (index, item) in self.filtered_list[
-            ((page as usize) * self.items_per_screen as usize).min(list_len) ..
-            ((1 + page as usize) * self.items_per_screen as usize).min(list_len)
-        ].iter_mut().enumerate() {
+        let selected = self.item_lists.lock().unwrap().selected_index();
+        let mut guarded_list = self.item_lists.lock().unwrap();
+        let current_page = guarded_list.selected_page();
+        for (index, maybe_item) in current_page.iter_mut().enumerate() {
             if insert_at - 1 > self.screensize.y - self.item_height { // -1 because of the overlapping border
                 break;
             }
-            if item.dirty {
-                let mut box_text = TextView::new(self.content,
-                    graphics_server::TextBounds::BoundingBox(
-                        Rectangle::new(
-                            Point::new(0, insert_at),
-                            Point::new(self.screensize.x, insert_at + self.item_height)
+            if let Some(item_mutex) = maybe_item {
+                let mut item = item_mutex.lock().unwrap();
+                if item.dirty {
+                    let mut box_text = TextView::new(self.content,
+                        graphics_server::TextBounds::BoundingBox(
+                            Rectangle::new(
+                                Point::new(0, insert_at),
+                                Point::new(self.screensize.x, insert_at + self.item_height)
+                            )
                         )
-                    )
-                );
-                box_text.draw_border = true;
-                box_text.rounded_border = None;
-                box_text.clear_area = true;
-                box_text.style = self.style;
-                box_text.margin = self.margin;
-                if index == selected as usize {
-                    box_text.border_width = 4;
-                }
-                match mode_at_entry {
-                    VaultMode::Fido | VaultMode::Password => {write!(box_text, "{}\n{}", item.name, item.extra).ok();},
-                    VaultMode::Totp => {
-                        let fields = item.extra.split(':').collect::<Vec<&str>>();
-                        if fields.len() == 5 {
-                            let shared_secret = base32::decode(
-                                base32::Alphabet::RFC4648 { padding: false }, fields[0])
-                                .unwrap_or(vec![]);
-                            let digit_count = u8::from_str_radix(fields[1], 10).unwrap_or(6);
-                            let step_seconds = u64::from_str_radix(fields[2], 10).unwrap_or(30);
-                            let algorithm = TotpAlgorithm::try_from(fields[3]).unwrap_or(TotpAlgorithm::HmacSha1);
-                            let is_hotp = fields[4].to_uppercase() == "HOTP";
-                            let totp = TotpEntry {
-                                step_seconds: if !is_hotp {step_seconds} else {1},  // step_seconds is re-used by hotp as the code.
-                                shared_secret,
-                                digit_count,
-                                algorithm
-                            };
-                            if !is_hotp {
-                                let code = generate_totp_code(
-                                    get_current_unix_time().unwrap_or(0),
-                                    &totp
-                                ).unwrap_or(t!("vault.error.record_error", xous::LANG).to_string());
-                                // why code on top? because the item.name can be very long, and it can wrap which would cause
-                                // the code to become hidden.
-                                write!(box_text, "{}\n{}", code, item.name).ok();
+                    );
+                    box_text.draw_border = true;
+                    box_text.rounded_border = None;
+                    box_text.clear_area = true;
+                    box_text.style = self.style;
+                    box_text.margin = self.margin;
+                    if index == selected {
+                        box_text.border_width = 4;
+                    }
+                    match mode_at_entry {
+                        VaultMode::Fido | VaultMode::Password => {write!(box_text, "{}\n{}", item.name, item.extra).ok();},
+                        VaultMode::Totp => {
+                            let fields = item.extra.split(':').collect::<Vec<&str>>();
+                            if fields.len() == 5 {
+                                let shared_secret = base32::decode(
+                                    base32::Alphabet::RFC4648 { padding: false }, fields[0])
+                                    .unwrap_or(vec![]);
+                                let digit_count = u8::from_str_radix(fields[1], 10).unwrap_or(6);
+                                let step_seconds = u64::from_str_radix(fields[2], 10).unwrap_or(30);
+                                let algorithm = TotpAlgorithm::try_from(fields[3]).unwrap_or(TotpAlgorithm::HmacSha1);
+                                let is_hotp = fields[4].to_uppercase() == "HOTP";
+                                let totp = TotpEntry {
+                                    step_seconds: if !is_hotp {step_seconds} else {1},  // step_seconds is re-used by hotp as the code.
+                                    shared_secret,
+                                    digit_count,
+                                    algorithm
+                                };
+                                if !is_hotp {
+                                    let code = generate_totp_code(
+                                        get_current_unix_time().unwrap_or(0),
+                                        &totp
+                                    ).unwrap_or(t!("vault.error.record_error", xous::LANG).to_string());
+                                    // why code on top? because the item.name can be very long, and it can wrap which would cause
+                                    // the code to become hidden.
+                                    write!(box_text, "{}\n{}", code, item.name).ok();
+                                } else {
+                                    let code = generate_totp_code(
+                                        step_seconds,
+                                        &totp
+                                    ).unwrap_or(t!("vault.error.record_error", xous::LANG).to_string());
+                                    // why code on top? because the item.name can be very long, and it can wrap which would cause
+                                    // the code to become hidden.
+                                    write!(box_text, "HOTP {}\n{}", code, item.name).ok();
+                                }
                             } else {
-                                let code = generate_totp_code(
-                                    step_seconds,
-                                    &totp
-                                ).unwrap_or(t!("vault.error.record_error", xous::LANG).to_string());
-                                // why code on top? because the item.name can be very long, and it can wrap which would cause
-                                // the code to become hidden.
-                                write!(box_text, "HOTP {}\n{}", code, item.name).ok();
+                                write!(box_text, "{}", t!("vault.error.record_error", xous::LANG)).ok();
                             }
-                        } else {
-                            write!(box_text, "{}", t!("vault.error.record_error", xous::LANG)).ok();
-                        }
-                    },
+                        },
+                    }
+                    self.gam.post_textview(&mut box_text).expect("couldn't post list item");
+                    item.dirty = false;
                 }
-                self.gam.post_textview(&mut box_text).expect("couldn't post list item");
-                item.dirty = false;
-            }
 
-            insert_at += self.item_height;
+                insert_at += self.item_height;
+            } else {
+                log::error!("Consistency bug! Filtered list has invalid items");
+            }
         }
 
         log::trace!("vault app redraw##");
@@ -684,55 +558,23 @@ impl VaultUx {
     }
 
     pub(crate) fn filter(&mut self, criteria: &str) {
-        let tt = ticktimer_server::Ticktimer::new().unwrap();
-        let mut ts = [0u64; 5];
-        ts[0] = tt.elapsed_ms();
-        self.filtered_list.clear();
-        ts[1] = tt.elapsed_ms();
-        let il = &self.item_lists.lock().unwrap();
-        let item_list = match self.mode.lock().unwrap().clone() {
-            VaultMode::Fido => &il.fido,
-            VaultMode::Totp => &il.totp,
-            VaultMode::Password => &il.pw,
-        };
-        ts[2] = tt.elapsed_ms();
-        for item in item_list.values() {
-            if item.name.to_lowercase().starts_with(criteria) {
-                let mut staged_item = item.clone();
-                staged_item.dirty = true;
-                self.filtered_list.push(staged_item);
-            }
-        }
-        ts[3] = tt.elapsed_ms();
-        // the selection index must always be at a valid point
-        if self.selection_index >= self.filtered_list.len() {
-            if self.filtered_list.len() > 0 {
-                self.selection_index = self.filtered_list.len() - 1;
-            } else {
-                self.selection_index = 0;
-            }
-        }
-        ts[4] = tt.elapsed_ms();
-        for(index, &elapsed) in ts[1..].iter().enumerate() {
-            log::debug!("{}: {}", index + 1, elapsed - ts[0]);
-        }
+        self.item_lists.lock().unwrap()
+        .filter(self.mode.lock().unwrap().clone(), criteria);
     }
 
     pub(crate) fn set_autotype_delay_ms(&self, rate: usize) {
         self.usb_dev.set_autotype_delay_ms(rate);
     }
     pub(crate) fn autotype(&mut self) -> Result<(), xous::Error> {
-        if self.selection_index >= self.filtered_list.len() {
-            return Err(xous::Error::InvalidPID);
-        }
         let mode_cache = (*self.mode.lock().unwrap()).clone();
         match mode_cache {
             VaultMode::Password => {
-                let entry = &self.filtered_list[self.selection_index].guid;
+                let entry = self.item_lists.lock().unwrap().selected_guid();
                 // we re-fetch the entry for autotype, because the PDDB could have unmounted a basis.
+                let atime = utc_now().timestamp() as u64;
                 let updated_pw = match self.pddb.borrow().get(
                     vault::VAULT_PASSWORD_DICT,
-                    entry,
+                    &entry,
                     None,
                     false, false, None,
                     Some(vault::basis_change)
@@ -745,7 +587,7 @@ impl VaultUx {
                                     match self.usb_dev.send_str(&pw.password) {
                                         Ok(_) => {
                                             pw.count += 1;
-                                            pw.atime = utc_now().timestamp() as u64;
+                                            pw.atime = atime;
                                             pw
                                         },
                                         Err(e) => {
@@ -773,7 +615,7 @@ impl VaultUx {
                 // this get determines which basis the key is in
                 let basis = match self.pddb.borrow().get(
                     vault::VAULT_PASSWORD_DICT,
-                    entry,
+                    &entry,
                     None, true, true,
                     Some(256), Some(vault::basis_change)
                 ) {
@@ -787,14 +629,14 @@ impl VaultUx {
                     }
                 };
 
-                match self.pddb.borrow().delete_key(vault::VAULT_PASSWORD_DICT, entry, Some(&basis)) {
+                match self.pddb.borrow().delete_key(vault::VAULT_PASSWORD_DICT, &entry, Some(&basis)) {
                     Ok(_) => {}
                     Err(_e) => {
                         return Err(xous::Error::InternalError);
                     }
                 }
                 match self.pddb.borrow().get(
-                    vault::VAULT_PASSWORD_DICT, entry, Some(&basis),
+                    vault::VAULT_PASSWORD_DICT, &entry, Some(&basis),
                     false, true, Some(vault::VAULT_ALLOC_HINT),
                     Some(vault::basis_change)
                 ) {
@@ -815,11 +657,11 @@ impl VaultUx {
                 }
                 self.pddb.borrow().sync().ok();
                 // force a redraw of the record as the access count updated
-                self.filtered_list[self.selection_index].dirty = true;
-                self.backpropagate_item(self.filtered_list[self.selection_index].clone());
+                self.item_lists.lock().unwrap().selected_update_atime(atime);
             }
             VaultMode::Totp => {
-                let fields = self.filtered_list[self.selection_index].extra.split(':').collect::<Vec<&str>>();
+                let extra = self.item_lists.lock().unwrap().selected_extra();
+                let fields = extra.split(':').collect::<Vec<&str>>();
                 if fields.len() == 5 {
                     let shared_secret = base32::decode(
                         base32::Alphabet::RFC4648 { padding: false }, fields[0])
@@ -849,7 +691,7 @@ impl VaultUx {
                         Ok(_) => {
                             if is_hotp {
                                 // update the count once the HOTP has been typed successfully
-                                let entry = self.filtered_list[self.selection_index].guid.to_string();
+                                let entry = self.item_lists.lock().unwrap().selected_guid();
 
                                 // this get determines which basis the key is in
                                 let (basis, hotp_rec) = match self.pddb.borrow().get(
@@ -892,15 +734,15 @@ impl VaultUx {
                                     }
                                 }
                                 // update the "extra" field, because the timestep field has been altered
-                                self.filtered_list[self.selection_index].extra = format!("{}:{}:{}:{}:{}",
-                                    hotp_rec.secret,
-                                    hotp_rec.digits,
-                                    hotp_rec.timestep,
-                                    hotp_rec.algorithm,
-                                    if hotp_rec.is_hotp {"HOTP"} else {"TOTP"}
+                                self.item_lists.lock().unwrap().selected_update_extra(
+                                    format!("{}:{}:{}:{}:{}",
+                                        hotp_rec.secret,
+                                        hotp_rec.digits,
+                                        hotp_rec.timestep,
+                                        hotp_rec.algorithm,
+                                        if hotp_rec.is_hotp {"HOTP"} else {"TOTP"}
+                                    )
                                 );
-                                self.filtered_list[self.selection_index].dirty = true;
-                                self.backpropagate_item(self.filtered_list[self.selection_index].clone());
                                 // now write to disk
                                 match self.pddb.borrow().get(
                                     vault::VAULT_TOTP_DICT, &entry, Some(&basis),
@@ -934,18 +776,9 @@ impl VaultUx {
         Ok(())
     }
     pub(crate) fn selected_entry(&self) -> Option<SelectedEntry> {
-        if self.selection_index >= self.filtered_list.len() {
-            None
-        } else {
-            let entry = &self.filtered_list[self.selection_index];
-            Some(
-                SelectedEntry {
-                    key_name: xous_ipc::String::from_str(entry.guid.to_string()),
-                    mode: (*self.mode.lock().unwrap()).clone(),
-                    description: xous_ipc::String::from_str(entry.name.to_string()),
-                }
-            )
-        }
+        self.item_lists.lock().unwrap().selected_entry(
+            (*self.mode.lock().unwrap()).clone()
+        )
     }
     pub(crate) fn ensure_hid(&self) {
         self.usb_dev.ensure_core(self.usb_type).unwrap();

--- a/apps/vault/src/ux/framework.rs
+++ b/apps/vault/src/ux/framework.rs
@@ -467,7 +467,7 @@ impl VaultUx {
                 break;
             }
             if item.dirty {
-                log::debug!("drawing {}", item.name);
+                log::debug!("drawing {}", item.name());
                 let mut box_text = TextView::new(self.content,
                     graphics_server::TextBounds::BoundingBox(
                         Rectangle::new(
@@ -485,7 +485,7 @@ impl VaultUx {
                     box_text.border_width = 4;
                 }
                 match mode_at_entry {
-                    VaultMode::Fido | VaultMode::Password => {write!(box_text, "{}\n{}", item.name, item.extra).ok();},
+                    VaultMode::Fido | VaultMode::Password => {write!(box_text, "{}\n{}", item.name(), item.extra).ok();},
                     VaultMode::Totp => {
                         let fields = item.extra.split(':').collect::<Vec<&str>>();
                         if fields.len() == 5 {
@@ -509,7 +509,7 @@ impl VaultUx {
                                 ).unwrap_or(t!("vault.error.record_error", xous::LANG).to_string());
                                 // why code on top? because the item.name can be very long, and it can wrap which would cause
                                 // the code to become hidden.
-                                write!(box_text, "{}\n{}", code, item.name).ok();
+                                write!(box_text, "{}\n{}", code, item.name()).ok();
                             } else {
                                 let code = generate_totp_code(
                                     step_seconds,
@@ -517,7 +517,7 @@ impl VaultUx {
                                 ).unwrap_or(t!("vault.error.record_error", xous::LANG).to_string());
                                 // why code on top? because the item.name can be very long, and it can wrap which would cause
                                 // the code to become hidden.
-                                write!(box_text, "HOTP {}\n{}", code, item.name).ok();
+                                write!(box_text, "HOTP {}\n{}", code, item.name()).ok();
                             }
                         } else {
                             write!(box_text, "{}", t!("vault.error.record_error", xous::LANG)).ok();

--- a/services/dns/src/main.rs
+++ b/services/dns/src/main.rs
@@ -307,7 +307,7 @@ impl Message {
 
 pub struct Resolver {
     /// DnsServerManager is a service of the Net crate that automatically updates the DNS server list
-    mgr: net::DnsServerManager,
+    mgr: net::protocols::DnsServerManager,
     socket: UdpSocket,
     buf: [u8; DNS_PKT_MAX_LEN],
     trng: trng::Trng,
@@ -328,7 +328,7 @@ impl Resolver {
                                                 // blocking is probably what we actually want this time.
 
         Resolver {
-            mgr: net::DnsServerManager::register(&xns)
+            mgr: net::protocols::DnsServerManager::register(&xns)
                 .expect("Couldn't register the DNS server list auto-manager"),
             socket,
             buf: [0; DNS_PKT_MAX_LEN],

--- a/services/net/src/lib.rs
+++ b/services/net/src/lib.rs
@@ -7,7 +7,6 @@ use xous_ipc::Buffer;
 use num_traits::*;
 
 pub mod protocols;
-pub use protocols::*;
 pub use smoltcp::time::Duration;
 pub use api::*;
 pub use smoltcp::wire::IpEndpoint;

--- a/services/pddb/src/lib.rs
+++ b/services/pddb/src/lib.rs
@@ -1046,7 +1046,7 @@ impl Pddb {
                         index += size_of::<u32>();
                         let pos = u32::from_le_bytes(msg_mem.as_slice()[index..index + size_of::<u32>()].try_into().unwrap());
                         index += size_of::<u32>();
-                        log::debug!("unpacking message at {}({})", size, pos);
+                        log::trace!("unpacking message at {}({})", size, pos);
                         if size != 0 && pos != 0 {
                             //log::info!("extract archive: {}, {}, {}, {}", index, size, pos, msg_mem.len());
                             //log::info!("{:x?}", &msg_mem.as_slice::<u8>()[index..index + (size as usize)]);

--- a/services/shellchat/src/cmds/net_cmd.rs
+++ b/services/shellchat/src/cmds/net_cmd.rs
@@ -28,7 +28,7 @@ pub struct NetCmd {
     callback_conn: u32,
     dns: dns::Dns,
     #[cfg(any(feature="precursor", feature="renode"))]
-    ping: Option<net::Ping>,
+    ping: Option<net::protocols::Ping>,
     #[cfg(feature="tls")]
     ws: Option<WebSocket<MaybeTlsStream<TcpStream>>>,
     #[cfg(feature="shellperf")]
@@ -635,7 +635,7 @@ impl<'a> ShellCmdApi<'a> for NetCmd {
                             Ok(ipaddr) => {
                                 log::debug!("sending ping to {:?}", ipaddr);
                                 if self.ping.is_none() {
-                                    self.ping = Some(net::Ping::non_blocking_handle(
+                                    self.ping = Some(net::protocols::Ping::non_blocking_handle(
                                         XousServerId::ServerName(xous_ipc::String::from_str(crate::SERVER_NAME_SHELLCHAT)),
                                         self.callback_id.unwrap() as usize,
                                     ));


### PR DESCRIPTION
This refactors the item cache in `vault` to improve performance by ~100x.

It turns out that sorting is faster than copying, by a couple orders of magnitude.

The original version of the code used a `BTreeMap` to ensure two properties about the item cache:

1. only one entry per key
2. items are in-order after reading from the PDDB, so that they are displayed in alphabetical order when browsing

A `filter` was then applied to the `BTreeMap` to create a view of the data that would include a subset of the PDDB information based on the search string entered. The `filter` would have to copy entries out of the map into a vector because of lifetime issues, and the fact that the structure spans two threads (one thread handling the UX interactions, another thread handling the core logic). 

It turns out that cloning data structures, particularly strings, is pretty expensive due to the way that Rust does it. It tends `push` data one character at a type, so it repeatedly calls libstd's alloc routine to grab another character. This would be OK except that alloc actually has several sort/search operations going on underneath it because it has to solve a bin packing problem (NP-hard) every time you want a new piece of data.

Simply put: sorting repeatedly is faster than repeatedly solving a bin packing problem to figure out where to put new data. It also turns out that `Drop` is very expensive as well because you have to re-walk that data structure for every element you drop and after so many bytes dropped the allocator will run a sweep to consolidate the bins (and that threshold is pretty small compared to the amount of small temporary variables used to shuttle data back and forth between searches and iterations).

I think maybe we could consider an allocator better tuned for Rust, the `dlmalloc` allocator we used is good at preventing fragmentation but not so great at parceling out tiny amounts of data rapidly. I think on "big" machines it's not such a problem because you can afford multiple allocation pools and also to over-provision memory to handle fast repeated allocations as would be the case of a Rust string copy, but for Precursor `dlmalloc` is probably a reasonable choice all things considered.

This is now the fourth refactor of the code. The previous refactor (which wasn't even merged) tried to eliminate allocations by using references to the `BTreeMap` elements, but, unfortunately Rust's borrow checker was very concerned that someone might come in and modify the mapping while the filter was active, and thus we had to wrap *every* item in an `Arc`/`Mutex`, which means that simply sorting the list would require acquiring the lock hundreds of times to compare each element in the off-chance that someone modifies the BTreeMap while the filter is happening (structurally it's not allowed by the way the UX is set up, but, in theory someone could have taken the structure and handed it to another thread that tried to manipulate records concurrently, I guess). Also creating the Arc/Mutex is an allocation in itself, so building the database took even longer than before (from 6000ms up to 12000ms+ for a 500-element list0. The net improvement of this approach was small, about 80% faster (from about 3000ms down to 2200ms). So acquiring locks is faster than copying data, but only slightly so.

Anyways, the item cache now creates a "pre-allocated" vec, sized to that of the entire PDDB database for each of the three views (totp, fido, passwords) and then tries very hard never to allocate again. This is less efficient in terms of RAM usage in one respect, but actually because of the accounting overhead incurred by dlmalloc to allocate tiny bits of data it might actually have less total heap usage. The item cache also pulls some of the more routine UX operations into the cache itself, to minimize the amount of shared references in the code.

The code *looks* like it should be horribly inefficient, because every operation that accesses the cache has to ensure that it's sorted, and if it's not, a sort is performed. In practice we reduce sorts a bit by using a marker variable to track if the vec has been modified since the last sort. 

All this together improves the performance of filtering by about 100x -- it goes from about 3000ms to filter a 500-element list to around 30-40ms to do the exact same operation. 
