### PR TITLE
Suggested method to preserve intent of `drop` to fix clippy warning

### DIFF
--- a/services/pddb/src/libstd/mod.rs
+++ b/services/pddb/src/libstd/mod.rs
@@ -517,7 +517,6 @@ pub(crate) fn close_key(
             return Err(crate::PddbRetcode::UnexpectedEof);
         }
     };
-    core::mem::drop(file);
 
     // If this SID is unused, close the connection.
     if let Some(cid) = conn {

--- a/services/pddb/src/main.rs
+++ b/services/pddb/src/main.rs
@@ -1096,6 +1096,7 @@ fn wrapped_main() -> ! {
                         if let Err(e) = result {
                             xous::return_scalar(msg.sender, e as usize)
                         } else {
+                            fd_mapping.remove(&msg.sender.pid());
                             xous::return_scalar2(msg.sender, 0, 0)
                         }.ok();
                     }


### PR DESCRIPTION
However, I didn't write this library (and I don't have a test suite for it), so I'm not quite sure if this preserves the invariants on the `fd_mapping()` structure. Needs @xobs' review.

Basically, rust 1.71.0 flags a warning that the `drop` call inside of the `close_key()` method does nothing.

I think the intent was to ensure that the memory for the key inside `fd_mapping()` was de-allocated after the key was closed.

I think the right way to fix it is, should the `close_key` call succeed, simply call `.remove()` on `fd_mapping`.

But I am worried that maybe it was intended that the `fd` should persist for some reason across calls or what not because I don't fully understand the semantics of this library, which is why I am asking for @xobs review.