### PR TITLE
Fix `ProcessStartup'

### DIFF
--- a/xous-rs/src/arch/riscv/process.rs
+++ b/xous-rs/src/arch/riscv/process.rs
@@ -83,6 +83,7 @@ impl TryFrom<[usize; 7]> for ProcessInit {
 }
 
 /// When a new process is created, this platform-specific structure is returned.
+#[repr(C)]
 #[derive(Debug, PartialEq)]
 pub struct ProcessStartup {
     /// The process ID of the new process


### PR DESCRIPTION
Previously, `ProcessStartup' did not have `repr(C)' above it. This meant that it was using rust layout, which is weird and is not compatible with `_xous_syscall_return_result'.
This should fix issue #381. 