### PR TITLE
WIP: Chat status

### DIFF
--- a/apps/mtxchat/locales/i18n.json
+++ b/apps/mtxchat/locales/i18n.json
@@ -1,4 +1,16 @@
 {
+    "mtxchat.busy.connecting": {
+        "en": "Connecting...",
+        "en-tts": "Connecting..."
+    },
+    "mtxchat.busy.updating": {
+        "en": "Updating...",
+        "en-tts": "Updating..."
+    },
+    "mtxchat.busy.sending": {
+        "en": "Sending...",
+        "en-tts": "Sending..."
+    },
     "mtxchat.clock.warning": {
         "en": "WARNING: clock not set",
         "en-tts": "WARNING: clock not set",

--- a/apps/mtxchat/locales/i18n.json
+++ b/apps/mtxchat/locales/i18n.json
@@ -18,6 +18,10 @@
         "ja": "WARNING: clock not set *EN*",
         "zh": "WARNING: clock not set *EN*"
     },
+    "mtxchat.status.default" : {
+        "en": "Use ← for login menu",
+        "en-tts": "Use ← for login menu"
+    },
     "mtxchat.filter.failed": {
         "en": "error: could not create filter",
         "en-tts": "error: could not create filter",

--- a/apps/mtxchat/locales/i18n.json
+++ b/apps/mtxchat/locales/i18n.json
@@ -19,6 +19,10 @@
         "en": "Logging in...",
         "en-tts": "Logging in..."
     },
+    "mtxchat.busy.rx_events": {
+        "en": "Receiving events...",
+        "en-tts": "Receiving events..."
+    },
     "mtxchat.busy.new_listen": {
         "en": "Syncing all events from server...",
         "en-tts": "Syncing all events from server..."

--- a/apps/mtxchat/locales/i18n.json
+++ b/apps/mtxchat/locales/i18n.json
@@ -241,6 +241,10 @@
         "ja": "WiFi not connected.  Entering read-only mode *EN*",
         "zh": "WiFi not connected.  Entering read-only mode *EN*"
     },
+    "mtxchat.wifi.warning_status": {
+        "en": "No connection! Read-only.",
+        "en-tts": "No connection! Read-only."
+    },
     "mtxchat.listen.patience": {
         "en": "It takes a while to get new events from the [matrix] server.\nPlease be patient :-)",
         "en-tts": "It takes a while to get new events from the [matrix] server.\nPlease be patient."

--- a/apps/mtxchat/locales/i18n.json
+++ b/apps/mtxchat/locales/i18n.json
@@ -11,6 +11,18 @@
         "en": "Sending...",
         "en-tts": "Sending..."
     },
+    "mtxchat.busy.room_id": {
+        "en": "Getting room ID...",
+        "en-tts": "Getting room ID..."
+    },
+    "mtxchat.busy.login": {
+        "en": "Logging in...",
+        "en-tts": "Logging in..."
+    },
+    "mtxchat.busy.new_listen": {
+        "en": "Syncing all events from server...",
+        "en-tts": "Syncing all events from server..."
+    },
     "mtxchat.clock.warning": {
         "en": "WARNING: clock not set",
         "en-tts": "WARNING: clock not set",
@@ -244,10 +256,6 @@
     "mtxchat.wifi.warning_status": {
         "en": "No connection! Read-only.",
         "en-tts": "No connection! Read-only."
-    },
-    "mtxchat.listen.patience": {
-        "en": "It takes a while to get new events from the [matrix] server.\nPlease be patient :-)",
-        "en-tts": "It takes a while to get new events from the [matrix] server.\nPlease be patient."
     },
     "mtxchat.close.item": {
         "en": "Close menu",

--- a/apps/mtxchat/src/lib.rs
+++ b/apps/mtxchat/src/lib.rs
@@ -85,7 +85,6 @@ pub struct MtxChat<'a> {
     modals: Modals,
     new_username: bool,
     new_room: bool,
-    status: String,
     tt: Ticktimer,
 }
 impl<'a> MtxChat<'a> {
@@ -119,7 +118,6 @@ impl<'a> MtxChat<'a> {
             modals: modals,
             new_username: false,
             new_room: false,
-            status,
             tt: ticktimer_server::Ticktimer::new().unwrap(),
         }
     }
@@ -344,7 +342,6 @@ impl<'a> MtxChat<'a> {
             self.unset(USER_DOMAIN_KEY)
                 .expect("failed to unset user domain");
         }
-        self.chat.set_status_text(&self.status);
         self.chat.set_busy_state(false);
         self.logged_in
     }
@@ -450,11 +447,9 @@ impl<'a> MtxChat<'a> {
                     web::get_room_id(&mut url, &room_alias, &token, &mut self.agent)
                 {
                     self.set_debug(ROOM_ID_KEY, &room_id);
-                    self.chat.set_status_text(&self.status);
                     self.chat.set_busy_state(false);
                     return Some(room_id);
                 } else {
-                    self.chat.set_status_text(&self.status);
                     self.chat.set_busy_state(false);
                     "failed to get room_id"
                 }
@@ -660,7 +655,6 @@ impl<'a> MtxChat<'a> {
                 } else {
                     "FAILED TO SEND"
                 };
-                self.chat.set_status_text(&self.status);
                 self.chat.set_busy_state(false);
                 r
             }
@@ -697,7 +691,6 @@ impl<'a> MtxChat<'a> {
                 if let Some(conf) = self.netmgr.get_ipv4_config() {
                     if conf.dhcp == com_rs::DhcpState::Bound {
                         self.chat.set_busy_state(false);
-                        self.chat.set_status_text(&self.status);
                         return true;
                     }
                 }

--- a/apps/mtxchat/src/listen.rs
+++ b/apps/mtxchat/src/listen.rs
@@ -1,4 +1,4 @@
-use crate::{get_username, web, MTX_LONG_TIMEOUT};
+use crate::{get_username, web, MTX_LONG_TIMEOUT_MS};
 use chat::ChatOp;
 use modals::Modals;
 use std::sync::Arc;
@@ -18,7 +18,7 @@ pub fn listen(
 ) {
     let xns = xous_names::XousNames::new().unwrap();
     let modals = Modals::new(&xns).expect("can't connect to Modals server");
-    log::info!("client_sync for {} ms...", MTX_LONG_TIMEOUT);
+    log::info!("client_sync for {} ms...", MTX_LONG_TIMEOUT_MS);
 
     let mut agent = ureq::builder()
         .tls_connector(Arc::new(TlsConnector{}))
@@ -27,7 +27,7 @@ pub fn listen(
         url,
         filter,
         since,
-        MTX_LONG_TIMEOUT,
+        MTX_LONG_TIMEOUT_MS,
         &room_id,
         &token,
         &mut agent,

--- a/libs/chat/locales/i18n.json
+++ b/libs/chat/locales/i18n.json
@@ -20,8 +20,8 @@
         "en-tts": "no dialogues available to read"
     },
     "chat.status.initial" : {
-        "en": "Idle",
-        "en-tts": "Idle"
+        "en": "Use ← to raise menu",
+        "en-tts": "Use ← to raise menu"
     },
     "chat.help.navigation": {
         "en": "use ↑ & ↓ to scroll thru old posts\nuse ← & → to show menus\nF1-F4 dont do anything yet.",

--- a/libs/chat/locales/i18n.json
+++ b/libs/chat/locales/i18n.json
@@ -19,6 +19,10 @@
         "en": "no dialogues available to read",
         "en-tts": "no dialogues available to read"
     },
+    "chat.status.initial" : {
+        "en": "use ← for login menu",
+        "en-tts": "use ← for login menu"
+    },
     "chat.help.navigation": {
         "en": "use ↑ & ↓ to scroll thru old posts\nuse ← & → to show menus\nF1-F4 dont do anything yet.",
         "en-tts": "use ↑ & ↓ to scroll thru old posts\nuse ← & → to show menus\nF1-F4 dont do anything yet."

--- a/libs/chat/locales/i18n.json
+++ b/libs/chat/locales/i18n.json
@@ -20,8 +20,8 @@
         "en-tts": "no dialogues available to read"
     },
     "chat.status.initial" : {
-        "en": "use ← for login menu",
-        "en-tts": "use ← for login menu"
+        "en": "Idle",
+        "en-tts": "Idle"
     },
     "chat.help.navigation": {
         "en": "use ↑ & ↓ to scroll thru old posts\nuse ← & → to show menus\nF1-F4 dont do anything yet.",

--- a/libs/chat/src/api.rs
+++ b/libs/chat/src/api.rs
@@ -40,6 +40,8 @@ pub enum ChatOp {
     SetStatusText,
     /// Run or stop the busy animation.
     SetBusyAnimationState,
+    /// Set the status idle text (to be shown when exiting all busy states)
+    SetStatusIdleText,
     /// Update just the state of the busy animation, if any. Internal opcode.
     UpdateBusy,
     /// exit the application

--- a/libs/chat/src/api.rs
+++ b/libs/chat/src/api.rs
@@ -43,7 +43,10 @@ pub enum ChatOp {
     /// Set the status idle text (to be shown when exiting all busy states)
     SetStatusIdleText,
     /// Update just the state of the busy animation, if any. Internal opcode.
+    /// Will skip the update if called too often.
     UpdateBusy,
+    /// Force update the busy bar, without rate throttling. Internal opcode.
+    UpdateBusyForced,
     /// exit the application
     Quit,
 }

--- a/libs/chat/src/api.rs
+++ b/libs/chat/src/api.rs
@@ -36,6 +36,8 @@ pub enum ChatOp {
     /// Find a Post by timestamp and Author
     PostFind,
     PostFlag,
+    /// Set status bar text
+    SetStatusText,
     /// Run or stop the busy animation.
     SetBusyAnimationState,
     /// Update just the state of the busy animation, if any. Internal opcode.
@@ -133,8 +135,5 @@ pub enum AuthorFlag {
 
 #[derive(Archive, Serialize, Deserialize, Debug)]
 pub struct BusyMessage {
-    /// If None, restores the last non-busy status bar message, and stops the animation.
-    /// If Some, updates the status bar to contain the busy message and
-    /// starts the animation running.
-    pub busy_msg: Option<xous_ipc::String<128>>,
+    pub busy_msg: xous_ipc::String<128>,
 }

--- a/libs/chat/src/api.rs
+++ b/libs/chat/src/api.rs
@@ -36,8 +36,18 @@ pub enum ChatOp {
     /// Find a Post by timestamp and Author
     PostFind,
     PostFlag,
+    /// Run or stop the busy animation.
+    SetBusyAnimationState,
+    /// Update just the state of the busy animation, if any. Internal opcode.
+    UpdateBusy,
     /// exit the application
     Quit,
+}
+
+#[derive(Debug, num_derive::FromPrimitive, num_derive::ToPrimitive)]
+pub(crate) enum BusyAnimOp {
+    Start,
+    Pump,
 }
 
 #[derive(Debug, num_derive::FromPrimitive, num_derive::ToPrimitive)]
@@ -119,4 +129,12 @@ pub enum AuthorFlag {
     Bold,
     Hidden,
     Right,
+}
+
+#[derive(Archive, Serialize, Deserialize, Debug)]
+pub struct BusyMessage {
+    /// If None, restores the last non-busy status bar message, and stops the animation.
+    /// If Some, updates the status bar to contain the busy message and
+    /// starts the animation running.
+    pub busy_msg: Option<xous_ipc::String<128>>,
 }

--- a/libs/chat/src/lib.rs
+++ b/libs/chat/src/lib.rs
@@ -363,6 +363,9 @@ pub fn server(
             Some(ChatOp::UpdateBusy) => {
                 ui.redraw_busy().expect("CHAT couldn't redraw");
             }
+            Some(ChatOp::UpdateBusyForced) => {
+                ui.redraw_status_forced().expect("CHAT couldn't redraw");
+            }
             Some(ChatOp::SetStatusText) => {
                 let buffer = unsafe {
                     Buffer::from_memory_message(msg.body.memory_message().unwrap())

--- a/libs/chat/src/main.rs
+++ b/libs/chat/src/main.rs
@@ -3,9 +3,12 @@
 
 mod api;
 use api::*;
+use num_traits::FromPrimitive;
 use std::thread;
 
 use xous::{Error, CID, SID};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 pub fn main() -> ! {
     let xns = xous_names::XousNames::new().unwrap();
@@ -17,10 +20,21 @@ pub fn main() -> ! {
     let chat_sid = xous::create_server().unwrap();
     let chat_cid = xous::connect(chat_sid).unwrap();
 
+    let busy_bumper = xous::create_server().unwrap();
+    let busy_bumper_cid = xous::connect(busy_bumper).unwrap();
+
+    log::info!("starting idle animation runner");
+    let run_busy_animation = Arc::new(AtomicBool::new(false));
+    thread::spawn({
+        let run_busy_animation = run_busy_animation.clone();
+        move || {
+            busy_animator(busy_bumper, busy_bumper_cid, chat_cid, run_busy_animation);
+        }
+    });
     log::info!("Starting chat server",);
     thread::spawn({
         move || {
-            server(chat_sid, None, None);
+            server(chat_sid, None, None, run_busy_animation, busy_bumper_cid);
         }
     });
     xous::terminate_process(0)

--- a/libs/chat/src/ui.rs
+++ b/libs/chat/src/ui.rs
@@ -21,7 +21,7 @@ use xous::{MessageEnvelope, CID};
 
 use xous_names::XousNames;
 
-pub const BUSY_ANIMATION_RATE_MS: usize = 50;
+pub const BUSY_ANIMATION_RATE_MS: usize = 200;
 
 #[allow(dead_code)]
 pub(crate) struct Ui {
@@ -627,6 +627,7 @@ impl Ui {
     pub(crate) fn redraw_busy(&mut self) -> Result<(), xous::Error> {
         let curtime = self.tt.elapsed_ms();
         if curtime - self.status_last_update_ms > BUSY_ANIMATION_RATE_MS as u64 {
+            log::info!("update!");
             self.gam.post_textview(&mut self.status_tv)?;
             self.gam.redraw().expect("couldn't redraw screen");
             self.status_last_update_ms = curtime;

--- a/libs/chat/src/ui.rs
+++ b/libs/chat/src/ui.rs
@@ -131,17 +131,18 @@ impl Ui {
         // setup the initial status bar contents
         let margin = Point::new(4, 4);
         let status_height = gam.glyph_height_hint(
-            graphics_server::api::text::TEXTVIEW_DEFAULT_STYLE).unwrap() as u16
-            + margin.y as u16 * 2;
+            GlyphStyle::Regular).unwrap() as u16;
         let mut status_tv = TextView::new(canvas,
             TextBounds::BoundingBox(Rectangle::new(
                 Point::new(0, 0),
-                Point::new(screensize.x, status_height as i16)
+                Point::new(screensize.x, status_height as _),
             ))
         );
+        status_tv.style = GlyphStyle::Regular;
         status_tv.margin = margin;
         status_tv.draw_border = false;
         status_tv.clear_area = true;
+        status_tv.margin = Point::new(0, 0);
         write!(status_tv, "{}", t!("chat.status.initial", locales::LANG).to_string()).ok();
         let tt = ticktimer_server::Ticktimer::new().unwrap();
         let status_last_update_ms = tt.elapsed_ms();

--- a/services/gam/src/lib.rs
+++ b/services/gam/src/lib.rs
@@ -31,6 +31,7 @@ use ime_plugin_api::{ImefCallback, ApiToken};
 
 #[doc = include_str!("../README.md")]
 
+pub const RATE_LIMIT_MS: usize = 33;
 pub const SYSTEM_STYLE: GlyphStyle = GlyphStyle::Tall;
 
 // Add names here and insert them into the EXPECTED_BOOT_CONTEXTS structure below.

--- a/services/gam/src/lib.rs
+++ b/services/gam/src/lib.rs
@@ -154,6 +154,7 @@ impl Gam {
                 tv.bounds_computed = tvr.bounds_computed;
                 tv.cursor = tvr.cursor;
                 tv.overflow = tvr.overflow;
+                tv.busy_animation_state = tvr.busy_animation_state;
             }
             api::Return::NotCurrentlyDrawable => {
                 tv.bounds_computed = None;

--- a/services/gam/src/main.rs
+++ b/services/gam/src/main.rs
@@ -246,6 +246,7 @@ fn wrapped_main() -> ! {
                                 tv.cursor = tv_clone.cursor;
                                 tv.bounds_computed = tv_clone.bounds_computed;
                                 tv.overflow = tv_clone.overflow;
+                                tv.busy_animation_state = tv_clone.busy_animation_state;
 
                                 let ret = api::Return::RenderReturn(tv);
                                 buffer.replace(ret).unwrap();
@@ -287,6 +288,7 @@ fn wrapped_main() -> ! {
                         tv.cursor = tv_clone.cursor;
                         tv.bounds_computed = tv_clone.bounds_computed;
                         tv.overflow = tv_clone.overflow;
+                        tv.busy_animation_state = tv_clone.busy_animation_state;
 
                         let ret = api::Return::RenderReturn(tv);
                         buffer.replace(ret).unwrap();

--- a/services/gam/src/main.rs
+++ b/services/gam/src/main.rs
@@ -175,7 +175,7 @@ fn wrapped_main() -> ! {
                         continue; // don't allow any redraws if a powerdown is requested
                     }
                     let elapsed_time = ticktimer.elapsed_ms();
-                    if elapsed_time - last_time > 33 {  // rate limit updates, no point in going faster than the eye can see
+                    if elapsed_time - last_time > gam::RATE_LIMIT_MS as u64 {  // rate limit updates, no point in going faster than the eye can see
                         last_time = elapsed_time;
 
                         if deface(&gfx, &trng, &mut canvases) {

--- a/services/graphics-server/src/api/text.rs
+++ b/services/graphics-server/src/api/text.rs
@@ -79,6 +79,7 @@ impl From<usize> for TextOp {
 
 // roughly 168 bytes to represent the rest of the struct, and we want to fill out the 4096 byte page with text
 const TEXTVIEW_LEN: usize = 3072;
+const TEXTVIEW_DEFAULT_STYLE: GlyphStyle = GlyphStyle::Regular;
 
 #[derive(Copy, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct TextView {
@@ -129,7 +130,7 @@ impl TextView {
             clip_rect: None,
             bounds_hint,
             bounds_computed: None,
-            style: GlyphStyle::Regular,
+            style: TEXTVIEW_DEFAULT_STYLE,
             text: String::<3072>::new(),
             cursor: Cursor::new(0, 0, 0),
             insertion: None,

--- a/services/graphics-server/src/api/text.rs
+++ b/services/graphics-server/src/api/text.rs
@@ -79,7 +79,7 @@ impl From<usize> for TextOp {
 
 // roughly 168 bytes to represent the rest of the struct, and we want to fill out the 4096 byte page with text
 const TEXTVIEW_LEN: usize = 3072;
-const TEXTVIEW_DEFAULT_STYLE: GlyphStyle = GlyphStyle::Regular;
+pub const TEXTVIEW_DEFAULT_STYLE: GlyphStyle = GlyphStyle::Regular;
 
 #[derive(Copy, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct TextView {

--- a/services/graphics-server/src/op.rs
+++ b/services/graphics-server/src/op.rs
@@ -275,7 +275,7 @@ pub fn rectangle(fb: &mut LcdFB, rect: Rectangle, clip: Option<Rectangle>, xor: 
                 // This is to make it annoying for someone using an XOR rectangle to synthesize inverted
                 // text on an otherwise untrusted dialog box (I suspect it's not impossible, but introduces
                 // a likelihood of drawing artifacts especially across translations and font size selections).
-                if pixel.0.y % 20 < 18 {
+                if pixel.0.y % 25 != 5 {
                     xor_pixel(fb, pixel.0.x, pixel.0.y);
                 } else {
                     // don't allow XOR on some pixels to avoid this being used as a primitive to synthesize secure boxes

--- a/services/graphics-server/src/testing.rs
+++ b/services/graphics-server/src/testing.rs
@@ -56,7 +56,7 @@ pub fn tests() {
                         let mut tv = TextView::new(Gid::new([0, 0, 0, 0]),
                         TextBounds::BoundingBox(anim_rect));
                         tv.clip_rect = Some(clipping_area);
-                        tv.style = TEST_STYLE;
+                        tv.style = GlyphStyle::Small;
                         tv.ellipsis = false;
                         write!(tv, "Test of busy animation").unwrap();
                         tv.insertion = None;


### PR DESCRIPTION
This is intermediate progress on issue #426.

The animation doesn't work yet, but wanted to clear the overall API with @nworbnhoj before getting stuck in the weeds debugging something that doesn't meet the requirement. 

So, first, this PR implements a simple status bar primitive, it looks a little like this:

![image](https://github.com/betrusted-io/xous-core/assets/1168375/e8349277-167c-4e0e-9abc-800a6f60f4be)

The initial status is just that message you see on the top. 

At a high level, the usage for the busy message is something like this:

https://github.com/betrusted-io/xous-core/blob/4142549804b69ce6e0b8722c3dd68cbc72643013/apps/mtxchat/src/lib.rs#L632-L641

What this is supposed to do is change the status message to the argument of `set_busy_state()`, and then start an animation that runs in the background while a message is being sent (in practice it's not happening, but I don't want to dig into that until this API is reviewed). 

If `set_busy_state()`'s argument is `Some(String)`, then, the status bar gets updated to the argument, while the previous message is "stashed" in a message cache. At this point, a helper server starts running which pings the redraw loop in the `Chat` server to cause the bar to animate.

If `set_busy_state()`'s argument is `None`, then, the status bar is reverted to the previously stashed message, and the animation is stopped.

Note that if you set multiple busy messages without clearing the busy state, the original status is still maintained, and new messages just overwrite the previous one.

As mentioned before, the underlying calls don't work but this PR contains a set of patches that have all the code in place to make it happen.

As I try to use the `set_busy_state()` call, I feel like....it's not quite right. It's too easy to forget to clear the busy state, and you have to find all the places where something "busy" is happening. The original idea was to have the chat library automatically manage the busy state but now that I've dug into the mtxchat implementation a bit I realize the UI code is modular from the chat state code, which makes sense. However, the question now becomes what's the best way to couple the "business" of the chat state into the UI.
