### PR TITLE
Sigchat skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
   "apps/mtxchat",
   "apps/mtxcli",
   "apps/repl",
+  "apps/sigchat",
   "apps/vault",
   "apps/vault/tools/vaultbackup-rs",
   "apps/transientdisk",

--- a/apps/manifest.json
+++ b/apps/manifest.json
@@ -56,6 +56,15 @@
             }
         }
     },
+    "sigchat": {
+        "context_name": "signal",
+        "menu_name": {
+            "appmenu.sigchat": {
+                "en": "Signal"
+            }
+        },
+        "submenu": 1
+    },
     "vault": {
         "context_name": "Key Vault",
         "menu_name": {

--- a/apps/sigchat/Cargo.toml
+++ b/apps/sigchat/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "sigchat"
+version = "0.1.0"
+authors = ["john <john@nhoj.info>"]
+edition = "2018"
+description = "Matrix chat"
+
+# Dependency versions enforced by Cargo.lock.
+[dependencies]
+log = "0.4.14"
+num-derive = { version = "0.3.3", default-features = false}
+num-traits = { version = "0.2.14", default-features = false}
+xous = "0.9.52"
+xous-ipc = "0.9.52"
+log-server = { package = "xous-api-log", version = "0.1.48" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.48" }
+xous-names = { package = "xous-api-names", version = "0.9.50" }
+gam = { path = "../../services/gam" }
+graphics-server = { path = "../../services/graphics-server" }
+trng = { path = "../../services/trng"}
+locales = { path = "../../locales"}
+ime-plugin-api = { path = "../../services/ime-plugin-api"}
+ime-plugin-shell = { path = "../../services/ime-plugin-shell"}
+content-plugin-api = { path = "../../services/content-plugin-api"} # all content canvas providers must provide this API
+codec = { path = "../../services/codec"}
+com = { path = "../../services/com"}
+com_rs = { git = "https://github.com/betrusted-io/com_rs", rev = "891bdd3ca8e41f81510d112483e178aea3e3a921" }
+llio = { path = "../../services/llio"}
+net = { path = "../../services/net" }
+pddb = { path = "../../services/pddb" }
+# new dependencies for sigcli
+chat = { path = "../../libs/chat" }
+modals = { path = "../../services/modals" }
+percent-encoding = "2.2"
+rkyv = {version = "0.4.3", default-features = false, features = ["const_generics"]}
+rustls = { version = "0.21.7" }
+serde = { version = "1.0", features = [ "derive" ] }
+tls = { path = "../../libs/tls" }
+ureq = { version = "2.7.1", features = ["json"] }
+url = "2.2.2"
+
+[features]
+default = []

--- a/apps/sigchat/README.md
+++ b/apps/sigchat/README.md
@@ -30,6 +30,8 @@ The `sigchat` code is primarily concerned with the Signal specific protocols, wh
 The Chat library provides the UI to display a series of Signal post (Posts) in a Signal group (Dialogue) stored in the pddb. Each Dialogue is stored in the `pddb:dict` `sigchat.dialogue` under a descriptive `pddb:key` (ie ``).
 
 `sigchat` passes a menu to the Chat UI:
+* `register` to register a new Signal account with a phone number
+* `link` this device to an existing Signal account.
 
 The `sigchat` servers is set to receive:
 * `SigchatOp::Post` A memory msg containing an outbount user post

--- a/apps/sigchat/README.md
+++ b/apps/sigchat/README.md
@@ -1,0 +1,42 @@
+# mtxchat
+
+This is the skeleton of a Signal chat application.
+
+The UI and local storage are provided by the xous chat library.
+
+Contributions to development of apps/sigchat and libs/chat are most welcome.
+
+
+## Build
+
+Run sigchat in hosted mode with ```cargo xtask run --app sigchat ```
+
+Build sigchat for the Precursor device with ``` cargo xtask app-image --app sigchat```
+
+
+## Prerequisites:
+
+
+## Functionality
+
+sigchat provides the following basic functionality:
+* 
+
+
+## Structure
+
+The `sigchat` code is primarily concerned with the Signal specific protocols, while the Chat library handles the UI and pddb storage.
+
+The Chat library provides the UI to display a series of Signal post (Posts) in a Signal group (Dialogue) stored in the pddb. Each Dialogue is stored in the `pddb:dict` `sigchat.dialogue` under a descriptive `pddb:key` (ie ``).
+
+`sigchat` passes a menu to the Chat UI:
+
+The `sigchat` servers is set to receive:
+* `SigchatOp::Post` A memory msg containing an outbount user post
+* `SigchatOp::Event` A scalar msg containing important Chat UI events
+* `sigchat::Menu` A scalar msg containing click on a sigchat MenuItem
+* `SigchatOp::Rawkeys` A scalar msg for each keystroke  
+
+
+## Troubleshooting
+

--- a/apps/sigchat/locales/i18n.json
+++ b/apps/sigchat/locales/i18n.json
@@ -1,0 +1,27 @@
+{
+    "sigchat.pddb.warning": {
+        "en": "WARNING: pddb not mounted",
+        "en-tts": "WARNING: pddb not mounted",
+        "fr": "AVERTISSEMENT: pddb pas monté",
+        "ja": "WARNING: pddb not mounted *EN*",
+        "zh": "WARNING: pddb not mounted *EN*"
+    },
+    "sigchat.wifi.connected": {
+        "en": "WiFi connected",
+        "en-tts": "WiFi connected",
+        "fr": "WiFi connecté",
+        "ja": "WiFi connected *EN*",
+        "zh": "WiFi connected *EN*"
+    },
+    "sigchat.wifi.warning": {
+        "en": "WiFi not connected. Entering read-only mode",
+        "en-tts": "WiFi not connected Entering read-only mode",
+        "fr": "WiFi pas connecté",
+        "ja": "WiFi not connected.  Entering read-only mode *EN*",
+        "zh": "WiFi not connected.  Entering read-only mode *EN*"
+    },
+    "sigchat.close.item": {
+        "en": "Close menu",
+        "en-tts": "Close menu"
+    }
+}

--- a/apps/sigchat/locales/i18n.json
+++ b/apps/sigchat/locales/i18n.json
@@ -1,4 +1,16 @@
 {
+    "sigchat.account.failed": {
+        "en": "Failed to obtain Signal Account",
+        "en-tts": "Failed to obtain Signal Account"
+    },
+    "sigchat.number": {
+        "en": "Number",
+        "en-tts": "Number"
+    },
+    "sigchat.number.title": {
+        "en": "Phone Number",
+        "en-tts": "Phone Number"
+    },
     "sigchat.pddb.warning": {
         "en": "WARNING: pddb not mounted",
         "en-tts": "WARNING: pddb not mounted",

--- a/apps/sigchat/locales/i18n.json
+++ b/apps/sigchat/locales/i18n.json
@@ -1,7 +1,20 @@
 {
     "sigchat.account.failed": {
-        "en": "Failed to obtain Signal Account",
-        "en-tts": "Failed to obtain Signal Account"
+        "en": "Failed to setup Signal Account",
+        "en-tts": "Failed to setup Signal Account"
+    },
+    "sigchat.account.link": {
+        "en": "Link to an existing Signal Account",
+        "en-tts": "Link to an existing Signal Account"
+    },
+    "sigchat.account.register": {
+        "en": "Register a new Signal Account",
+        "en-tts": "Register a new Signal Account"
+    },
+    "sigchat.account.title": {
+        "en": "Setup Signal on this device.",
+        "en-tts": "Setup Signal on this device."
+    },
     },
     "sigchat.number": {
         "en": "Number",

--- a/apps/sigchat/locales/i18n.json
+++ b/apps/sigchat/locales/i18n.json
@@ -15,6 +15,17 @@
         "en": "Setup Signal on this device.",
         "en-tts": "Setup Signal on this device."
     },
+    "sigchat.menu.close": {
+        "en": "Close menu",
+        "en-tts": "Close menu"
+    },
+    "sigchat.register": {
+        "en": "Register",
+        "en-tts": "Register"
+    },
+    "sigchat.link": {
+        "en": "Link",
+        "en-tts": "Link"
     },
     "sigchat.number": {
         "en": "Number",

--- a/apps/sigchat/src/account.rs
+++ b/apps/sigchat/src/account.rs
@@ -1,0 +1,128 @@
+mod service_environment;
+
+use pddb::Pddb;
+use service_environment::ServiceEnvironment;
+use std::io::{Error, ErrorKind, Read, Write};
+use std::str::FromStr;
+
+#[allow(dead_code)]
+pub struct Account {
+    pddb: Pddb,
+    pddb_dict: String,
+    service_environment: ServiceEnvironment,
+    number: String,
+    registered: bool,
+}
+
+const SERVICE_ENVIRONMENT_KEY: &str = "service_environment";
+const NUMBER_KEY: &str = "number";
+const REGISTERED_KEY: &str = "registered";
+
+impl Account {
+    pub fn new(pddb_dict: &str, number: &str) -> Result<Account, Error> {
+        let pddb = pddb::Pddb::new();
+        pddb.try_mount();
+        set(
+            &pddb,
+            pddb_dict,
+            SERVICE_ENVIRONMENT_KEY,
+            Some(&ServiceEnvironment::Staging.to_string()),
+        )?;
+        set(&pddb, pddb_dict, NUMBER_KEY, Some(&number))?;
+        set(&pddb, pddb_dict, REGISTERED_KEY, Some(&false.to_string()))?;
+        Account::read(pddb_dict)
+    }
+
+    pub fn read(pddb_dict: &str) -> Result<Account, Error> {
+        let pddb = pddb::Pddb::new();
+        pddb.try_mount();
+        match (
+            get(&pddb, pddb_dict, SERVICE_ENVIRONMENT_KEY),
+            get(&pddb, pddb_dict, NUMBER_KEY),
+            get(&pddb, pddb_dict, REGISTERED_KEY),
+        ) {
+            (Ok(Some(service_environment)), Ok(Some(number)), Ok(Some(registered))) => {
+                Ok(Account {
+                    pddb: pddb,
+                    pddb_dict: pddb_dict.to_string(),
+                    service_environment: ServiceEnvironment::from_str(&service_environment)
+                        .unwrap(),
+                    number: number,
+                    registered: registered.parse().unwrap(),
+                })
+            }
+            (Err(e), _, _) => Err(e),
+            (_, Err(e), _) => Err(e),
+            (_, _, Err(e)) => Err(e),
+            (_, _, _) => Err(Error::from(ErrorKind::InvalidData)),
+        }
+    }
+
+    pub fn number(&self) -> &str {
+        &self.number
+    }
+
+    #[allow(dead_code)]
+    pub fn set_number(&mut self, value: &str) -> Result<(), Error> {
+        match self.set(NUMBER_KEY, Some(value)) {
+            Ok(_) => self.number = value.to_string(),
+            Err(e) => log::warn!("failed to set signal account number: {e}"),
+        }
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    fn get(&self, key: &str) -> Result<Option<String>, Error> {
+        get(&self.pddb, &self.pddb_dict, key)
+    }
+
+    #[allow(dead_code)]
+    fn set(&self, key: &str, value: Option<&str>) -> Result<(), Error> {
+        set(&self.pddb, &self.pddb_dict, key, value)
+    }
+}
+
+fn get(pddb: &Pddb, dict: &str, key: &str) -> Result<Option<String>, Error> {
+    let value = match pddb.get(dict, key, None, true, false, None, None::<fn()>) {
+        Ok(mut pddb_key) => {
+            let mut buffer = [0; 256];
+            match pddb_key.read(&mut buffer) {
+                Ok(len) => match String::from_utf8(buffer[..len].to_vec()) {
+                    Ok(s) => Some(s),
+                    Err(e) => {
+                        log::warn!("failed to String: {:?}", e);
+                        None
+                    }
+                },
+                Err(e) => {
+                    log::warn!("failed pddb_key read: {:?}", e);
+                    None
+                }
+            }
+        }
+        Err(_) => None,
+    };
+    log::info!("get '{}' = '{:?}'", key, value);
+    Ok(value)
+}
+
+fn set(pddb: &Pddb, dict: &str, key: &str, value: Option<&str>) -> Result<(), Error> {
+    log::info!("set '{}' = '{:?}'", key, value);
+    // delete key first to ensure data in a prior longer key is gone
+    pddb.delete_key(dict, key, None).ok();
+    if let Some(value) = value {
+        match pddb.get(dict, key, None, true, true, None, None::<fn()>) {
+            Ok(mut pddb_key) => match pddb_key.write(&value.as_bytes()) {
+                Ok(len) => {
+                    pddb.sync().ok();
+                    log::trace!("Wrote {} bytes to {}:{}", len, dict, key);
+                }
+                Err(e) => {
+                    log::warn!("Error writing {}:{} {:?}", dict, key, e);
+                }
+            },
+            Err(e) => log::warn!("failed to set pddb {}:{}  {:?}", dict, key, e),
+        };
+    }
+    Ok(())
+}

--- a/apps/sigchat/src/account/service_environment.rs
+++ b/apps/sigchat/src/account/service_environment.rs
@@ -1,0 +1,28 @@
+use rkyv::{Archive, Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+// The server environment to use:
+#[derive(Archive, Serialize, Deserialize, Debug)]
+pub enum ServiceEnvironment {
+    Live,
+    Staging,
+}
+
+impl fmt::Display for ServiceEnvironment {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl FromStr for ServiceEnvironment {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<ServiceEnvironment, Self::Err> {
+        match input {
+            "Live" => Ok(ServiceEnvironment::Live),
+            "Staging" => Ok(ServiceEnvironment::Staging),
+            _ => Err(()),
+        }
+    }
+}

--- a/apps/sigchat/src/api.rs
+++ b/apps/sigchat/src/api.rs
@@ -1,0 +1,31 @@
+#[allow(dead_code)]
+pub(crate) const SERVER_NAME_SIGCHAT: &str = "_Signal chat_";
+
+#[derive(Debug, num_derive::FromPrimitive, num_derive::ToPrimitive)]
+pub enum SigchatOp {
+    /// chat ui event
+    Event = 0,
+    /// menu item click
+    Menu,
+    /// chat ui user post
+    Post,
+    /// chat ui keystroke
+    Rawkeys,
+    /// exit the application
+    Quit,
+}
+
+#[derive(Debug, num_derive::FromPrimitive, num_derive::ToPrimitive)]
+pub enum MenuOp {
+    Link,
+    Noop,
+    Register,
+}
+
+#[allow(dead_code)]
+pub struct Msg {
+    pub type_: String,
+    pub body: Option<String>,
+    pub sender: Option<String>,
+    pub ts: Option<u64>,
+}

--- a/apps/sigchat/src/lib.rs
+++ b/apps/sigchat/src/lib.rs
@@ -3,6 +3,7 @@ pub mod api;
 mod manager;
 
 use crate::account::Account;
+use crate::manager::{Manager, TrustMode};
 pub use api::*;
 use chat::Chat;
 use locales::t;
@@ -10,6 +11,7 @@ use modals::Modals;
 use std::io::{Error, ErrorKind};
 
 /// PDDB Dict for sigchat keys
+const SIGCHAT_ACCOUNT: &str = "sigchat.account";
 const SIGCHAT_DIALOGUE: &str = "sigchat.dialogue";
 
 const WIFI_TIMEOUT: u32 = 10; // seconds
@@ -21,6 +23,7 @@ pub const HOSTED_MODE: bool = false;
 
 //#[derive(Debug)]
 pub struct SigChat<'a> {
+    account: Option<Account>,
     chat: &'a Chat,
     netmgr: net::NetManager,
     modals: Modals,
@@ -32,6 +35,7 @@ impl<'a> SigChat<'a> {
         let pddb = pddb::Pddb::new();
         pddb.try_mount();
         SigChat {
+            account: Account::read(SIGCHAT_ACCOUNT).ok(),
             chat: chat,
             netmgr: net::NetManager::new(),
             modals: modals,
@@ -44,6 +48,21 @@ impl<'a> SigChat<'a> {
     pub fn connect(&mut self) -> bool {
         log::info!("Attempting connect to Signal server");
         if self.wifi() {
+            if self.account.is_none() {
+                self.account_modal();
+            }
+            if let Some(account) = &self.account {
+                log::info!(
+                    "Signal account OK: {}: {}",
+                    self.account.is_some(),
+                    self.account.as_ref().unwrap().number()
+                );
+                let _manager = Manager::new(&account, TrustMode::OnFirstUse);
+            } else {
+                self.modals
+                    .show_notification(t!("sigchat.account.failed", locales::LANG), None)
+                    .expect("notification failed");
+            };
         } else {
             self.modals
                 .show_notification(t!("sigchat.wifi.warning", locales::LANG), None)
@@ -51,6 +70,31 @@ impl<'a> SigChat<'a> {
         }
         self.dialogue_set(None);
         false
+    }
+
+    /// Attempts to obtain a phone number from the user and set self.account = a new Account.
+    ///
+    /// A Signal Account requires a phone number to receive SMS or incoming calls for registration & validation.
+    /// The phone number must include the country calling code, i.e. the number must start with a "+" sign.
+    ///
+    fn account_modal(&mut self) {
+        let mut builder = self
+            .modals
+            .alert_builder(t!("sigchat.number.title", locales::LANG));
+        let builder = builder.field(Some(t!("sigchat.number", locales::LANG).to_string()), None);
+        match builder.build() {
+            Ok(payloads) => match payloads.content()[0].content.as_str() {
+                Ok(number) => {
+                    log::info!("registration phone number = {:?}", number);
+                    match Account::new(SIGCHAT_ACCOUNT, &number.to_string()) {
+                        Ok(account) => self.account = Some(account),
+                        Err(e) => log::warn!("failed to create new Account: {e}"),
+                    }
+                }
+                Err(e) => log::warn!("failed to get payload from modal: {e}"),
+            },
+            Err(e) => log::warn!("failed to build modal: {:?}", e),
+        }
     }
 
     pub fn redraw(&self) {

--- a/apps/sigchat/src/lib.rs
+++ b/apps/sigchat/src/lib.rs
@@ -1,0 +1,123 @@
+mod account;
+pub mod api;
+mod manager;
+
+use crate::account::Account;
+pub use api::*;
+use chat::Chat;
+use locales::t;
+use modals::Modals;
+use std::io::{Error, ErrorKind};
+
+/// PDDB Dict for sigchat keys
+const SIGCHAT_DIALOGUE: &str = "sigchat.dialogue";
+
+const WIFI_TIMEOUT: u32 = 10; // seconds
+
+#[cfg(not(target_os = "xous"))]
+pub const HOSTED_MODE: bool = true;
+#[cfg(target_os = "xous")]
+pub const HOSTED_MODE: bool = false;
+
+//#[derive(Debug)]
+pub struct SigChat<'a> {
+    chat: &'a Chat,
+    netmgr: net::NetManager,
+    modals: Modals,
+}
+impl<'a> SigChat<'a> {
+    pub fn new(chat: &Chat) -> SigChat {
+        let xns = xous_names::XousNames::new().unwrap();
+        let modals = Modals::new(&xns).expect("can't connect to Modals server");
+        let pddb = pddb::Pddb::new();
+        pddb.try_mount();
+        SigChat {
+            chat: chat,
+            netmgr: net::NetManager::new(),
+            modals: modals,
+        }
+    }
+
+
+    /// Connect to the Signal servers
+    ///
+    pub fn connect(&mut self) -> bool {
+        log::info!("Attempting connect to Signal server");
+        if self.wifi() {
+        } else {
+            self.modals
+                .show_notification(t!("sigchat.wifi.warning", locales::LANG), None)
+                .expect("notification failed");
+        }
+        self.dialogue_set(None);
+        false
+    }
+
+    pub fn redraw(&self) {
+        self.chat.redraw();
+    }
+
+    pub fn dialogue_set(&self, room_alias: Option<&str>) {
+        self.chat
+            .dialogue_set(SIGCHAT_DIALOGUE, room_alias)
+            .expect("failed to set dialogue");
+    }
+
+    pub fn help(&self) {
+        self.chat.help();
+    }
+
+    /// Returns true if wifi is connected
+    ///
+    /// If wifi is not connected then a modal offers to "Connect to wifi?"
+    /// and tries for 10 seconds before representing.
+    ///
+    pub fn wifi(&self) -> bool {
+        if HOSTED_MODE {
+            return true;
+        }
+
+        if let Some(conf) = self.netmgr.get_ipv4_config() {
+            if conf.dhcp == com_rs::DhcpState::Bound {
+                return true;
+            }
+        }
+
+        while self.wifi_try_modal() {
+            self.netmgr.connection_manager_wifi_on_and_run().unwrap();
+            self.modals
+                .start_progress("Connecting ...", 0, 10, 0)
+                .expect("no progress bar");
+            let tt = ticktimer_server::Ticktimer::new().unwrap();
+            for wait in 0..WIFI_TIMEOUT {
+                tt.sleep_ms(1000).unwrap();
+                self.modals
+                    .update_progress(wait)
+                    .expect("no progress update");
+                if let Some(conf) = self.netmgr.get_ipv4_config() {
+                    if conf.dhcp == com_rs::DhcpState::Bound {
+                        self.modals
+                            .finish_progress()
+                            .expect("failed progress finish");
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Returns true if "Connect to WiFi?" yes option is chosen
+    ///
+    fn wifi_try_modal(&self) -> bool {
+        self.modals.add_list_item("yes").expect("failed radio yes");
+        self.modals.add_list_item("no").expect("failed radio no");
+        self.modals
+            .get_radiobutton("Connect to WiFi?")
+            .expect("failed radiobutton modal");
+        match self.modals.get_radio_index() {
+            Ok(button) => button == 0,
+            _ => false,
+        }
+    }
+}

--- a/apps/sigchat/src/lib.rs
+++ b/apps/sigchat/src/lib.rs
@@ -53,7 +53,7 @@ impl<'a> SigChat<'a> {
             if self.manager.is_none() {
                 self.account_setup();
             }
-            if let Some(manager) = &self.manager {
+            if let Some(_manager) = &self.manager {
                 log::info!("Signal manager OK" );
             } else {
                 self.modals
@@ -115,8 +115,15 @@ impl<'a> SigChat<'a> {
         match self.number_modal() {
             Ok(number) => {
                 log::info!("registration phone number = {:?}", number);
-                match Account::new(SIGCHAT_ACCOUNT, &number.to_string()) {
-                    Ok(account) => self.account = Some(account),
+                match Account::new(SIGCHAT_ACCOUNT) {
+                    Ok(mut account) => {
+                        match account.set_number(&number.to_string()) {
+                            Ok(_number) => {
+                                self.manager = Some(Manager::new(account, TrustMode::OnFirstUse));
+                            }
+                            Err(e) => log::warn!("failed to set Account number: {e}"),
+                        }
+                    }
                     Err(e) => log::warn!("failed to create new Account: {e}"),
                 }
             }

--- a/apps/sigchat/src/main.rs
+++ b/apps/sigchat/src/main.rs
@@ -1,0 +1,127 @@
+#![cfg_attr(target_os = "none", no_std)]
+#![cfg_attr(target_os = "none", no_main)]
+
+mod api;
+use api::*;
+use chat::{Chat, Event, POST_TEXT_MAX};
+use gam::{MenuItem, MenuPayload};
+use locales::t;
+use num_traits::*;
+use sigchat::SigChat;
+use xous_ipc::Buffer;
+
+fn main() -> ! {
+    let stack_size = 1024 * 1024;
+    std::thread::Builder::new()
+        .stack_size(stack_size)
+        .spawn(wrapped_main)
+        .unwrap()
+        .join()
+        .unwrap()
+}
+
+fn wrapped_main() -> ! {
+    log_server::init_wait().unwrap();
+    log::set_max_level(log::LevelFilter::Info);
+    log::info!("my PID is {}", xous::process::id());
+
+    const HEAP_LARGER_LIMIT: usize = 2048 * 1024;
+    let new_limit = HEAP_LARGER_LIMIT;
+    let result = xous::rsyscall(xous::SysCall::AdjustProcessLimit(
+        xous::Limits::HeapMaximum as usize,
+        0,
+        new_limit,
+    ));
+
+    if let Ok(xous::Result::Scalar2(1, current_limit)) = result {
+        xous::rsyscall(xous::SysCall::AdjustProcessLimit(
+            xous::Limits::HeapMaximum as usize,
+            current_limit,
+            new_limit,
+        ))
+        .unwrap();
+        log::info!("Heap limit increased to: {}", new_limit);
+    } else {
+        panic!("Unsupported syscall!");
+    }
+
+    let xns = xous_names::XousNames::new().unwrap();
+    let sid = xns
+        .register_name(SERVER_NAME_SIGCHAT, None)
+        .expect("can't register server");
+    log::trace!("registered with NS -- {:?}", sid);
+
+    let chat = Chat::new(
+        gam::APP_NAME_SIGCHAT,
+        gam::APP_MENU_0_SIGCHAT,
+        Some(xous::connect(sid).unwrap()),
+        Some(SigchatOp::Post as usize),
+        Some(SigchatOp::Event as usize),
+        Some(SigchatOp::Rawkeys as usize),
+    );
+
+    let cid = xous::connect(sid).unwrap();
+
+    let mut sigchat = SigChat::new(&chat);
+    let mut first_focus = true;
+    let mut user_post: Option<String> = None;
+    loop {
+        let msg = xous::receive_message(sid).unwrap();
+        log::debug!("got message {:?}", msg);
+        match FromPrimitive::from_usize(msg.body.id()) {
+            Some(SigchatOp::Event) => {
+                log::info!("got Chat UI Event");
+                xous::msg_scalar_unpack!(msg, event_code, _, _, _, {
+                    match FromPrimitive::from_usize(event_code) {
+                        Some(Event::Focus) => {
+                            if first_focus {
+                                first_focus = false;
+                                sigchat.connect();
+                            }
+                            sigchat.redraw();
+                        }
+                        _ => (),
+                    }
+                });
+            }
+            Some(SigchatOp::Menu) => {
+                log::info!("got Chat Menu Click");
+                xous::msg_scalar_unpack!(msg, menu_code, _, _, _, {
+                    match FromPrimitive::from_usize(menu_code) {
+                        Some(MenuOp::Link) => {}
+                        Some(MenuOp::Noop) => {}
+                        Some(MenuOp::Register) => {}
+                        _ => (),
+                    }
+                });
+            }
+            Some(SigchatOp::Post) => {
+                let buffer =
+                    unsafe { Buffer::from_memory_message(msg.body.memory_message().unwrap()) };
+                let s = buffer
+                    .to_original::<xous_ipc::String<{ POST_TEXT_MAX }>, _>()
+                    .unwrap();
+                if s.len() > 0 {
+                    // capture input instead of calling here, so message can drop and calling server is released
+                    user_post = Some(s.to_string());
+                }
+            }
+            Some(SigchatOp::Rawkeys) => log::info!("got sigchat rawkeys"),
+            Some(SigchatOp::Quit) => {
+                log::error!("got Quit");
+                break;
+            }
+            _ => (),
+        }
+        if let Some(_post) = user_post {
+            //sigchat.post(&post);
+            user_post = None;
+        }
+    }
+    // clean up our program
+    log::error!("main loop exit, destroying servers");
+    xns.unregister_server(sid).unwrap();
+    xous::destroy_server(sid).unwrap();
+    log::trace!("quitting");
+    xous::terminate_process(0)
+}

--- a/apps/sigchat/src/main.rs
+++ b/apps/sigchat/src/main.rs
@@ -61,6 +61,30 @@ fn wrapped_main() -> ! {
     );
 
     let cid = xous::connect(sid).unwrap();
+    chat.menu_add(MenuItem {
+        name: xous_ipc::String::from_str(t!("sigchat.register", locales::LANG)),
+        action_conn: Some(cid),
+        action_opcode: SigchatOp::Menu as u32,
+        action_payload: MenuPayload::Scalar([MenuOp::Register as u32, 0, 0, 0]),
+        close_on_select: true,
+    })
+    .expect("failed add menu");
+    chat.menu_add(MenuItem {
+        name: xous_ipc::String::from_str(t!("sigchat.link", locales::LANG)),
+        action_conn: Some(cid),
+        action_opcode: SigchatOp::Menu as u32,
+        action_payload: MenuPayload::Scalar([MenuOp::Link as u32, 0, 0, 0]),
+        close_on_select: true,
+    })
+    .expect("failed add menu");
+    chat.menu_add(MenuItem {
+        name: xous_ipc::String::from_str(t!("sigchat.menu.close", locales::LANG)),
+        action_conn: Some(cid),
+        action_opcode: SigchatOp::Menu as u32,
+        action_payload: MenuPayload::Scalar([MenuOp::Noop as u32, 0, 0, 0]),
+        close_on_select: true,
+    })
+    .expect("failed add menu");
 
     let mut sigchat = SigChat::new(&chat);
     let mut first_focus = true;
@@ -88,9 +112,9 @@ fn wrapped_main() -> ! {
                 log::info!("got Chat Menu Click");
                 xous::msg_scalar_unpack!(msg, menu_code, _, _, _, {
                     match FromPrimitive::from_usize(menu_code) {
-                        Some(MenuOp::Link) => {}
+                        Some(MenuOp::Link) => sigchat.account_link(),
                         Some(MenuOp::Noop) => {}
-                        Some(MenuOp::Register) => {}
+                        Some(MenuOp::Register) => sigchat.account_register(),
                         _ => (),
                     }
                 });

--- a/apps/sigchat/src/manager.rs
+++ b/apps/sigchat/src/manager.rs
@@ -13,22 +13,22 @@ pub use trust_mode::TrustMode;
 // see signal-cli Manual Page - https://github.com/AsamK/signal-cli/blob/master/man/signal-cli.1.adoc
 
 #[allow(dead_code)]
-pub struct Manager<'a> {
-    account: &'a Account,
+pub struct Manager {
+    account:Account,
     trust_mode: TrustMode,
     log_verbose: bool,
     log_scrub: bool,
     log_send: bool,
 }
 
-impl <'a> Manager<'a> {
+impl Manager {
     /// Create a new Signal account
     ///
     /// # Arguments
     /// * `live` - Specify the server environment
     /// * `account` - Specify your phone number, that will be your identifier. The phone number must include the country calling code, i.e. the number must start with a "+" sign.
     ///
-    pub fn new(account: &Account, trust_mode: TrustMode) -> Manager {
+    pub fn new(account: Account, trust_mode: TrustMode) -> Manager {
         Manager {
             account,
             trust_mode,

--- a/apps/sigchat/src/manager.rs
+++ b/apps/sigchat/src/manager.rs
@@ -1,0 +1,638 @@
+mod group_permission;
+mod link_state;
+mod trust_mode;
+
+use crate::Account;
+use group_permission::GroupPermission;
+use link_state::LinkState;
+use std::io::Error;
+pub use trust_mode::TrustMode;
+
+// Structure modeled on signal-cli by AsamK <asamk@gmx.de> and contributors - https://github.com/AsamK/signal-cli.
+// signal-cli is a commandline interface for libsignal-service-java. It supports registering, verifying, sending and receiving messages.
+// see signal-cli Manual Page - https://github.com/AsamK/signal-cli/blob/master/man/signal-cli.1.adoc
+
+#[allow(dead_code)]
+pub struct Manager<'a> {
+    account: &'a Account,
+    trust_mode: TrustMode,
+    log_verbose: bool,
+    log_scrub: bool,
+    log_send: bool,
+}
+
+impl <'a> Manager<'a> {
+    /// Create a new Signal account
+    ///
+    /// # Arguments
+    /// * `live` - Specify the server environment
+    /// * `account` - Specify your phone number, that will be your identifier. The phone number must include the country calling code, i.e. the number must start with a "+" sign.
+    ///
+    pub fn new(account: &Account, trust_mode: TrustMode) -> Manager {
+        Manager {
+            account,
+            trust_mode,
+            log_verbose: false,
+            log_scrub: false,
+            log_send: false,
+        }
+    }
+
+    /// Register a phone number with SMS or voice verification. Use the verify command to complete the verification.
+    ///
+    /// For registering you need a phone number where you can receive SMS or incoming calls.
+    ///
+    /// If the account is just deactivated, the register command will just reactivate account, without requiring an SMS verification. By default the unregister command just deactivates the account, in which case it can be reactivated without sms verification if the local data is still available. If the account was deleted (with --delete-account) it cannot be reactivated.
+    ///
+    /// # Arguments
+    /// * `voice` - The verification should be done over voice, not SMS.
+    /// * `captcha` - The captcha token, required if registration failed with a captcha required error. To get the token, go to https://signalcaptchas.org/registration/generate.html For the staging environment, use: https://signalcaptchas.org/staging/registration/generate.html Check the developer tools for a redirect starting with signalcaptcha:// Everything after signalcaptcha:// is the captcha token.
+    ///
+    #[allow(dead_code)]
+    pub fn register(&mut self, _voice: bool, _captcha: Option<&str>) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Verify the number using the code received via SMS or voice.
+    ///
+    /// * `verification_code` - The verification code.
+    /// * `pin` - The registration lock PIN, that was set by the user. Only required if a PIN was set.
+    ///
+    #[allow(dead_code)]
+    pub fn verify(_verification_code: &str, _pin: Option<&str>) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Disable push support for this device, i.e. this device won’t receive any more messages. If this is the primary device, other users can’t send messages to this number anymore. Use "updateAccount" to undo this. To remove a linked device, use "removeDevice" from the primary device.
+    ///
+    /// # Arguments
+    /// * `delete_account` - Delete account completely from server. Cannot be undone without loss. You will have to be readded to each group.
+    ///
+    /// Caution: Only delete your account if you won’t use this number again!
+    ///
+    #[allow(dead_code)]
+    pub fn unregister(_delete_account: bool) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Update the account attributes on the signal server. Can fix problems with receiving messages.
+    ///
+    /// # Arguments
+    /// * `name` - Set a new device name for the primary or linked device
+    ///
+    #[allow(dead_code)]
+    pub fn update_account(_name: &str) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Update signal configs and sync them to linked devices. This command only works on the primary devices.
+    ///
+    /// # Arguments
+    /// * `read_receipts` - Indicates if Signal should send read receipts.
+    /// * `unidentified_delivery_indicators` - Indicates if Signal should show unidentified delivery indicators.
+    /// * `typing_indicators` - Indicates if Signal should send/show typing indicators.
+    /// * `link_previews` - Indicates if Signal should generate link previews.
+    ///
+    #[allow(dead_code)]
+    pub fn update_configuration(
+        _read_receipts: bool,
+        _unidentified_delivery_indicators: bool,
+        _typing_indicators: bool,
+        _link_previews: bool,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Set a registration lock pin, to prevent others from registering this number.
+    ///
+    /// # Arguments
+    /// * `registration_lock_pin` - The registration lock PIN, that will be required for new registrations (resets after 7 days of inactivity)
+    ///
+    #[allow(dead_code)]
+    pub fn set_pin(_registration_lock_pin: &str) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Remove the registration lock pin.
+    ///
+    #[allow(dead_code)]
+    pub fn remove_pin() -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Link to an existing device, instead of registering a new number. This shows a "sgnl://linkdevice?uuid=…​" URI. If you want to connect to another signal-cli instance, you can just use this URI. If you want to link to an Android/iOS device, create a QR code with the URI (e.g. with qrencode) and scan that in the Signal app.
+    ///
+    /// # Arguments
+    /// * `name` - Optionally specify a name to describe this new device. By default "cli" will be used.
+    ///
+    #[allow(dead_code)]
+    pub fn link(_name: &str) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Link another device to this device. Only works, if this is the primary device.
+    ///
+    /// # Arguments
+    /// `uri` - Specify the uri contained in the QR code shown by the new device. You will need the full URI such as "sgnl://linkdevice?uuid=…​" (formerly "tsdevice:/?uuid=…​") Make sure to enclose it in quotation marks for shells.
+    ///
+    #[allow(dead_code)]
+    pub fn add_device(_uri: &str) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Show a list of linked devices.
+    ///
+    #[allow(dead_code)]
+    pub fn list_devices() -> Result<Vec<String>, Error> {
+        todo!();
+    }
+
+    /// Remove a linked device. Only works, if this is the primary device.
+    ///
+    /// # Arguments
+    /// * `device_id` - Specify the device you want to remove. Use listDevices to see the deviceIds.
+    ///
+    #[allow(dead_code)]
+    pub fn remove_device(_device_id: &str) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Uses a list of phone numbers to determine the statuses of those users. Shows if they are registered on the Signal Servers or not. In json mode this is outputted as a list of objects.
+    ///
+    /// # Arguments
+    /// * `recipient` - One or more numbers to check.
+    ///
+    #[allow(dead_code)]
+    pub fn get_user_status(_recipient: Vec<&str>) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Send a message to another user or group.
+    ///
+    /// # Arguments
+    /// * `recipient` - Specify the recipients’ phone number.
+    /// * `note_to_self` - Send the message to self without notification.
+    /// * `group_id` - Specify the recipient group ID in base64 encoding.
+    /// * `message` - Specify the message
+    /// * `attachments` -Add one or more files as attachment. Can be either a file path or a data URI. Data URI encoded attachments must follow the RFC 2397. Additionally a file name can be added: e.g.: data:<MIME-TYPE>;filename=<FILENAME>;base64,<BASE64 ENCODED DATA>
+    /// * `sticker` - Send a sticker of a locally known sticker pack (syntax: stickerPackId:stickerId). Shouldn’t be used together with -m as the official clients don’t support this. e.g.: --sticker 00abac3bc18d7f599bff2325dc306d43:2
+    /// * `mention` - Mention another group member (syntax: start:length:recipientNumber) In the apps the mention replaces part of the message text, which is specified by the start and length values. e.g.: -m "Hi X!" --mention "3:1:+123456789"
+    /// * `text_style` - Style parts of the message text (syntax: start:length:STYLE). Where STYLE is one of: BOLD, ITALIC, SPOILER, STRIKETHROUGH, MONOSPACE
+    /// * `quote_timestamp` - Specify the timestamp of a previous message with the recipient or group to add a quote to the new message.
+    /// * `quote_author` - Specify the number of the author of the original message.
+    /// * `quote_message` - Specify the message of the original message.
+    /// * `quote_mention` - Specify the mentions of the original message (same format as --mention).
+    /// * `quote_text_style` - Style parts of the original message text (same format as --text-style).
+    /// * `preview_url` - Specify the url for the link preview. The same url must also appear in the message body, otherwise the preview won’t be displayed by the apps.
+    /// * `preview_title` - Specify the title for the link preview (mandatory).
+    /// * `preview_description` - Specify the description for the link preview (optional).
+    /// * `preview_image` - Specify the image file for the link preview (optional).
+    /// * `story_timestamp` - Specify the timestamp of a story to reply to.
+    /// * `story_author` - Specify the number of the author of the story.
+    /// * `end_session` - Clear session state and send end session message.
+    /// * `edit_timestamp` - Specify the timestamp of a previous message with the recipient or group to send an edited message.
+    ///
+    #[allow(dead_code)]
+    pub fn send(
+        _recipient: Vec<&str>,
+        _note_to_self: bool,
+        _group_id: Vec<&str>,
+        _message: Option<&str>,
+        _attachments: Vec<&str>,
+        _sticker: Option<&str>,
+        _mention: Option<&str>,
+        _text_style: Option<&str>,
+        _quote_timestamp: Option<u64>,
+        _quote_author: Option<&str>,
+        _quote_message: Option<&str>,
+        _quote_mention: Vec<&str>,
+        _quote_text_style: Option<&str>,
+        _preview_url: Option<&str>,
+        _preview_title: Option<&str>,
+        _preview_description: Option<&str>,
+        _preview_image: Option<&str>,
+        _story_timestamp: Option<u64>,
+        _story_author: Option<&str>,
+        _end_session: bool,
+        _edit_timestamp: Option<u64>,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Send a payment notification.
+    ///
+    /// # Arguments
+    /// `recipient` - Specify the recipient’s phone number.
+    /// `receipt` - The base64 encoded receipt blob.
+    /// `note` - Specify a note for the payment notification.
+    ///
+    #[allow(dead_code)]
+    pub fn send_payment_notification(
+        _recipient: &str,
+        _receipt: &str,
+        _note: &str,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Send reaction to a previously received or sent message.
+    ///
+    /// # Arguments
+    /// * `recipient` - Specify the recipients’ phone number.
+    /// * `group_id` - Specify the recipient group ID in base64 encoding.
+    /// * `emoji` - Specify the emoji, should be a single unicode grapheme cluster.
+    /// * `target_author` - Specify the number of the author of the message to which to react.
+    /// * `target_timestamp` - Specify the timestamp of the message to which to react.
+    /// * `remove` - Remove a reaction.
+    /// * `story` - React to a story instead of a normal message
+    ///
+    #[allow(dead_code)]
+    pub fn send_reaction(
+        _recipient: Vec<&str>,
+        _group_id: Vec<&str>,
+        _emoji: &str,
+        _target_author: &str,
+        _target_timestamp: u64,
+        _remove: bool,
+        _story: bool,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Send a read or viewed receipt to a previously received message.
+    ///
+    /// # Arguments
+    /// * `recipient` - Specify the sender’s phone number.
+    /// * `target_timestamp - Specify the timestamp of the message to which to react.
+    /// * `reciept_type` - Specify the receipt type, either read (the default) or viewed.
+    ///
+    #[allow(dead_code)]
+    pub fn send_receipt(
+        _recipient: &str,
+        _target_timestamp: Vec<u64>,
+        _receipt_type: &str,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    // Send typing message to trigger a typing indicator for the recipient. Indicator will be shown for 15seconds unless a typing STOP message is sent first.
+    ///
+    /// # Arguments
+    /// * `recipient` - Specify the sender’s phone number.
+    /// * `group_id` - Specify the recipient group ID in base64 encoding.
+    /// * `stop` - Send a typing STOP message.
+    ///
+    #[allow(dead_code)]
+    pub fn send_typing(
+        _recipient: Vec<&str>,
+        _group_id: Vec<&str>,
+        _stop: bool,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Remotely delete a previously sent message.
+    ///
+    /// # Arguments
+    /// * `recipient` - Specify the sender’s phone number.
+    /// * `group_id` - Specify the recipient group ID in base64 encoding.
+    /// * `target_timestamp` - Specify the timestamp of the message to which to react.
+    ///
+    #[allow(dead_code)]
+    pub fn remote_delete(
+        _recipient: Vec<&str>,
+        _group_id: Vec<&str>,
+        _target_timestamp: u64,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Query the server for new messages. New messages are printed on standard output and attachments are downloaded to the config directory. In json mode this is outputted as one json object per line.
+    ///
+    /// # Arguments
+    /// * `timeout` - Number of seconds to wait for new messages (negative values disable timeout). Default is 5 seconds.
+    /// * `max-messages` - Maximum number of messages to receive, before returning.
+    /// * `ignore-attachments` - Don’t download attachments of received messages.
+    /// * `ignore-stories` - Don’t receive story messages from the server.
+    /// * `send-read-receipts` - Send read receipts for all incoming data messages (in addition to the default delivery receipts)
+    ///
+    #[allow(dead_code)]
+    pub fn receive(
+        _timeout: f64,
+        _max_messages: u16,
+        _ignore_attachments: bool,
+        _ignore_stories: bool,
+        _send_read_receipts: bool,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Join a group via an invitation link.
+    ///
+    /// # Arguments
+    /// * `uri` - The invitation link URI (starts with https://signal.group/#)
+    ///
+    #[allow(dead_code)]
+    pub fn join_group(_uri: &str) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Create or update a group. If the user is a pending member, this command will accept the group invitation.
+    ///
+    /// # Arguments
+    /// * `group_id' - Specify the recipient group ID in base64 encoding. If not specified, a new group with a new random ID is generated.
+    /// * `name' - Specify the new group name.
+    /// * `description' - Specify the new group description.
+    /// * `avatar' - Specify a new group avatar image file.
+    /// * `member' - Specify one or more members to add to the group.
+    /// * `remove_member' - Specify one or more members to remove from the group
+    /// * `admin ' - Specify one or more members to make a group admin
+    /// * `remove_admin' - Specify one or more members to remove group admin privileges
+    /// * `ban' - Specify one or more members to ban from joining the group. Banned members cannot join or request to join via a group link.
+    /// * `unban' - Specify one or more members to remove from the ban list
+    /// * `reset_link' - Reset group link and create new link password
+    /// * `link' - Set group link state: enabled, enabled-with-approval, disabled
+    /// * `set_permission_add_member' - Set permission to add new group members: every-member, only-admins
+    /// * `set_permission_edit_details' - Set permission to edit group details: every-member, only-admins
+    /// * `set_permission_send_messages' - Set permission to send messages in group: every-member, only-admins Groups where only admins can send messages are also called announcement groups
+    /// * `expiration' - Set expiration time of messages (seconds). To disable expiration set expiration time to 0.
+    ///
+    #[allow(dead_code)]
+    pub fn update_group(
+        _group_id: Option<&str>,
+        _name: Option<&str>,
+        _description: Option<&str>,
+        _avatar: Option<&str>,
+        _member: Vec<&str>,
+        _remove_member: Vec<&str>,
+        _admin: Vec<&str>,
+        _remove_admin: Vec<&str>,
+        _ban: Vec<&str>,
+        _unban: Vec<&str>,
+        _reset_link: bool,
+        _link: Option<LinkState>,
+        _set_permission_add_member: Option<GroupPermission>,
+        _set_permission_edit_details: Option<GroupPermission>,
+        _set_permission_send_messages: Option<GroupPermission>,
+        _expiration: Option<u32>,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Send a quit group message to all group members and remove self from member list. If the user is a pending member, this command will decline the group invitation.
+    ///
+    /// # Aurguments
+    /// * `group_id` - Specify the recipient group ID in base64 encoding.
+    /// * `delete` - Delete local group data completely after quitting group.
+    ///
+    #[allow(dead_code)]
+    pub fn quit_group(_group_id: &str, _delete: bool) -> Result<(), Error> {
+        todo!();
+    }
+
+    // Show a list of known groups and related information. In json mode this is outputted as an list of objects and is always in detailed mode.
+    ///
+    /// # Arguments
+    /// * `detailed` - Include the list of members of each group and the group invite link.
+    /// * `group_id` - Filter the group list by one or more group IDs.
+    ///
+    #[allow(dead_code)]
+    pub fn list_groups(_detailed: bool, _group_id: Vec<&str>) -> Result<(), Error> {
+        todo!();
+    }
+
+    // Show a list of known contacts with names and profiles. When a specific recipient is given, its profile will be refreshed.
+    ///
+    /// # Arguments
+    /// * `recipient` - Specify the recipients’ phone number.
+    /// * `all_recipients` - Include all known recipients, not only contacts.
+    /// * `blocked` - Specify if only blocked or unblocked contacts should be shown (default: all contacts)
+    /// * `name` - Find contacts with the given contact or profile name.
+    ///
+    #[allow(dead_code)]
+    pub fn list_contacts(
+        _recipient: &str,
+        _all_recipients: bool,
+        _blocked: bool,
+        _name: &str,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    // List all known identity keys and their trust status, fingerprint and safety number.
+    ///
+    /// # Arguments
+    /// * `number` - Only show identity keys for the given phone number.
+    ///
+    #[allow(dead_code)]
+    pub fn list_identities(_number: &str) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Set the trust level of a given number. The first time a key for a number is seen, it is trusted by default (TOFU). If the key changes, the new key must be trusted manually.
+    ///
+    /// # Arguments
+    /// * `number` - Specify the phone number, for which to set the trust.
+    /// * `trust_all_known_keys` - Trust all known keys of this user, only use this for testing.
+    /// * `verified_safety_number` - Specify the safety number of the key, only use this option if you have verified the safety number. Can be either the plain text numbers shown in the app or the bytes from the QR-code, encoded as base64.
+    ///
+    #[allow(dead_code)]
+    pub fn trust(
+        _recipient: &str,
+        _trust_all_known_keys: bool,
+        _verified_safety_number: Option<&str>,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    // Update the profile information shown to message recipients. The profile is stored encrypted on the Signal servers. The decryption key is sent with every outgoing messages to contacts and included in every group.
+    ///
+    /// # Arguments
+    /// * `given_name` - New (given) name.
+    /// * `family_name` - New family name.
+    /// * `about` - New profile status text.
+    /// * `about_emoji` - New profile status emoji.
+    /// * `avatar` - Path to the new avatar image file.
+    /// * `remove_avatar` - Remove the avatar
+    /// * `mobile_coin_address` - New MobileCoin address (Base64 encoded public address)
+    ///
+    #[allow(dead_code)]
+    pub fn update_profile(
+        _given_name: Option<&str>,
+        _family_name: Option<&str>,
+        _about: Option<&str>,
+        _about_emoji: Option<&str>,
+        _avatar: Option<&str>,
+        _remove_avatar: bool,
+        _mobile_coin_address: Option<&str>,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Update the info associated to a number on our contact list. This change is only local but can be synchronized to other devices by using sendContacts (see below). If the contact doesn’t exist yet, it will be added.
+    ///
+    /// # Arguments
+    /// * `number` - Specify the contact phone number.
+    /// * `given_name` - New (given) name.
+    /// * `family_name` - New family name.
+    /// * `expiration` - Set expiration time of messages (seconds). To disable expiration set expiration time to 0.
+    ///
+    #[allow(dead_code)]
+    pub fn update_contact(
+        _given_name: Option<&str>,
+        _family_name: Option<&str>,
+        _expiration: Option<u32>,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    // Remove the info of a given contact
+    ///
+    /// # Arguments
+    /// * `number` - Specify the contact phone number.
+    /// * `forget` - Delete all data associated with this contact, including identity keys and sessions.
+    /// * `block` - Block the given contacts or groups (no messages will be received). This change is only local but can be synchronized to other devices by using sendContacts (see below).
+    /// * `contacts` - Specify the phone numbers of contacts that should be blocked.
+    /// * `group_ids` - Specify the group IDs that should be blocked in base64 encoding.
+    ///
+    #[allow(dead_code)]
+    pub fn remove_contact(
+        _number: &str,
+        _forget: bool,
+        _block: bool,
+        _contacts: Vec<&str>,
+        _group_ids: Vec<&str>,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+
+    // Unblock the given contacts or groups (messages will be received again). This change is only local but can be synchronized to other devices by using sendContacts (see below).
+    ///
+    /// # Arguments
+    /// * `contacts` - Specify the phone numbers of contacts that should be unblocked.
+    /// * `group_ids` - Specify the group IDs that should be unblocked in base64 encoding.
+    ///
+    #[allow(dead_code)]
+    pub fn unblock(_contacts: Vec<&str>, _group_ids: Vec<&str>) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Send a synchronization message with the local contacts list to all linked devices. This command should only be used if this is the primary device.
+    #[allow(dead_code)]
+    pub fn send_contacts() -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Send a synchronization request message to the primary device (for group, contacts, …​). The primary device will respond with synchronization messages with full contact and group lists.
+    ///
+    #[allow(dead_code)]
+    pub fn send_sync_request() -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Upload a new sticker pack, consisting of a manifest file and the sticker images.
+    ///
+    /// Images must conform to the following specification: (see https:///support.signal.org/hc/en-us/articles/360031836512-Stickers#sticker_reqs )
+    /// * Static stickers in PNG or WebP format
+    /// * Animated stickers in APNG format,
+    /// * Maximum file size for a sticker file is 300KiB
+    /// * Image resolution of 512 x 512 px
+    ///
+    /// The required manifest.json has the following format:
+    ///
+    /// {
+    ///   "title": "<STICKER_PACK_TITLE>",
+    ///   "author": "<STICKER_PACK_AUTHOR>",
+    ///   "cover": { // Optional cover, by default the first sticker is used as cover
+    ///     "file": "<name of image file, mandatory>",
+    ///     "contentType": "<optional>",
+    ///     "emoji": "<optional>"
+    ///   },
+    ///   "stickers": [
+    ///     {
+    ///       "file": "<name of image file, mandatory>",
+    ///       "contentType": "<optional>",
+    ///       "emoji": "<optional>"
+    ///     }
+    ///     ...
+    ///   ]
+    /// }
+    ///
+    /// # Arguments
+    /// * `path` - The path of the manifest.json or a zip file containing the sticker pack you wish to upload.
+    ///
+    #[allow(dead_code)]
+    pub fn upload_sticker_pack(_path: &str) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Show a list of known sticker packs.
+    ///
+    #[allow(dead_code)]
+    pub fn list_sticker_packs() -> Result<Vec<String>, Error> {
+        todo!();
+    }
+
+    /// Install a sticker pack for this account.
+    ///
+    /// # Arguments
+    /// * `uri` - Specify the uri of the sticker pack. e.g. https://signal.art/addstickers/#pack_id=XXX&pack_key=XXX)"
+    ///
+    #[allow(dead_code)]
+    pub fn add_sticker_pack(_uri: &str) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Gets the raw data for a specified attachment. This is done using the ID of the attachment the recipient or group ID. The attachment data is returned as a Base64 String.
+    ///
+    /// # Arguments
+    /// * `id` - The ID of the attachment as given in the attachment list of the message.
+    /// * `recipient` - Specify the number which sent the attachment. Referred to generally as recipient.
+    /// * `group_id` - Alternatively, specify the group IDs for which to get the attachment.
+    ///
+    #[allow(dead_code)]
+    pub fn get_attachment(_recipient: Option<&str>, _group_id: Option<&str>) -> Result<(), Error> {
+        todo!();
+    }
+
+    // When running into rate limits, sometimes the limit can be lifted, by solving a CAPTCHA. To get the captcha token, go to https://signalcaptchas.org/challenge/generate.html For the staging environment, use: https://signalcaptchas.org/staging/registration/generate.html
+    ///
+    /// # Arguments
+    /// * `challenge` - The challenge token from the failed send attempt.
+    /// * `captcha` - The captcha result, starting with signalcaptcha://
+    ///
+    #[allow(dead_code)]
+    pub fn submit_rate_limit_challenge(_challenge: &str, _captcha: &str) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Configure logging.
+    ///
+    /// # Arguments
+    /// * `verbose` - Raise log level and include lib signal logs.
+    /// * `scrub` - Scrub possibly sensitive information from the log, like phone numbers and UUIDs.
+    /// * `send_log` - Enable message send log (for resending messages that recipient couldn’t decrypt).
+    ///
+    #[allow(dead_code)]
+    pub fn log_config(_verbose: bool, _scrub: bool, _send_log: bool) -> Result<(), Error> {
+        todo!();
+    }
+
+    /// Set the trust mode
+    ///
+    /// * `trust_mode` - Specify when to trust new identities
+    ///
+    #[allow(dead_code)]
+    pub fn trust_mode_set(&mut self, trust_mode: TrustMode) {
+        self.trust_mode = trust_mode;
+    }
+
+    /// Version
+    ///
+    /// Return the version.
+    ///
+    #[allow(dead_code)]
+    pub fn version() -> Result<String, Error> {
+        todo!();
+    }
+}

--- a/apps/sigchat/src/manager/group_permission.rs
+++ b/apps/sigchat/src/manager/group_permission.rs
@@ -1,0 +1,28 @@
+use rkyv::{Archive, Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+#[allow(dead_code)]
+#[derive(Archive, Serialize, Deserialize, Debug)]
+pub enum GroupPermission {
+    EveryMember,
+    OnlyAdmins,
+}
+
+impl fmt::Display for GroupPermission {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl FromStr for GroupPermission {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<GroupPermission, Self::Err> {
+        match input {
+            "EveryMember" => Ok(GroupPermission::EveryMember),
+            "OnlyAdmins" => Ok(GroupPermission::OnlyAdmins),
+            _ => Err(()),
+        }
+    }
+}

--- a/apps/sigchat/src/manager/link_state.rs
+++ b/apps/sigchat/src/manager/link_state.rs
@@ -1,0 +1,30 @@
+use rkyv::{Archive, Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+#[allow(dead_code)]
+#[derive(Archive, Serialize, Deserialize, Debug)]
+pub enum LinkState {
+    Enabled,
+    EnabledWithApproval,
+    Disabled,
+}
+
+impl fmt::Display for LinkState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl FromStr for LinkState {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<LinkState, Self::Err> {
+        match input {
+            "Enabled" => Ok(LinkState::Enabled),
+            "EnabledWithApproval" => Ok(LinkState::EnabledWithApproval),
+            "Disabled" => Ok(LinkState::Disabled),
+            _ => Err(()),
+        }
+    }
+}

--- a/apps/sigchat/src/manager/trust_mode.rs
+++ b/apps/sigchat/src/manager/trust_mode.rs
@@ -1,0 +1,34 @@
+use rkyv::{Archive, Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+// When to trust new identities:
+#[allow(dead_code)]
+#[derive(Archive, Serialize, Deserialize, Debug)]
+pub enum TrustMode {
+    ///  Trust the first seen identity key from new users, changed keys must be verified manually
+    OnFirstUse,
+    /// Trust any new identity key without verification
+    Always,
+    /// Don’t trust any unknown identity key, every key must be verified manually
+    Never,
+}
+
+impl fmt::Display for TrustMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl FromStr for TrustMode {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<TrustMode, Self::Err> {
+        match input {
+            "OnFirstUse" => Ok(TrustMode::OnFirstUse),
+            "Always" => Ok(TrustMode::Always),
+            "Never" => Ok(TrustMode::Never),
+            _ => Err(()),
+        }
+    }
+}


### PR DESCRIPTION
This is the skeleton of a Signal chat application - **sigchat**

The UI and local storage are provided by the xous chat library.

The structure of the Signal interface is modelled on [signal-cli](https://github.com/AsamK/signal-cli) by AsamK and contributors. `signal-cli` is a command-line interface for `libsignal-service-java`. It supports registering, verifying, sending and receiving messages. This development provides a welcome road-map of the various common transactions between a Signal client and server - see the `signal-cli` [Manual Page](https://github.com/AsamK/signal-cli/blob/master/man/signal-cli.1.adoc). This road-map is sketched out in `apps/sigchat/src/manager.rs`, but will be subject to refinement as sigchat development progresses.

The Rust implementation of each method stub in the `Manager` struct will ultimately make a call the official [libsignal](https://github.com/signalapp/libsignal#overview) library. 

> libsignal contains platform-agnostic APIs used by the official Signal clients and servers, exposed as a Java, Swift, or TypeScript library. The underlying implementations are written in Rust.

> This repository is used by the Signal client apps ([Android](https://github.com/signalapp/Signal-Android), [iOS](https://github.com/signalapp/Signal-iOS), and [Desktop](https://github.com/signalapp/Signal-Desktop)) as well as server-side. Use outside of Signal is unsupported.

libsignal is released under the AGPLv3 licence, so the plan is to wrap libsignal in a xous server (exposing a suitable API) under a compatible AGPLv3 licence - then to include this binary in a hardware image - making it available to sigchat.


