### PR TITLE
RFQ: is it worth it to absorb the lates usbd-human-interface-device changes prior to forking?

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,28 +1309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "delegate"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c47a31748d9cfa641f6cccb3608385fafe261ba36054f3d40d5a3ca11eb1af"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.103",
-]
-
-[[package]]
-name = "delegate"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70a2d4995466955a415223acf3c9c934b9ff2339631cdf4ffc893da4bacd717"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.103",
-]
-
-[[package]]
 name = "der"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +1882,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fugit"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
+dependencies = [
+ "gcd",
+]
+
+[[package]]
 name = "funty"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2016,12 @@ dependencies = [
  "xous-api-ticktimer",
  "xous-ipc 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "gcd"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "gdbstub"
@@ -2158,14 +2151,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32-derive"
-version = "0.1.1"
+name = "hash32"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d2aba832b60be25c1b169146b27c64115470981b128ed84c8db18c1b03c6ff"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.103",
+ "byteorder",
 ]
 
 [[package]]
@@ -2181,9 +2172,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version 0.4.0",
  "spin 0.9.3",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -3065,7 +3066,16 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.7",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -3077,6 +3087,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.103",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3105,6 +3126,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "option-block"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f2c5d345596a14d7c8b032a68f437955f0059f2eb9a5972371c84f7eef3227"
 
 [[package]]
 name = "orbclient"
@@ -3394,7 +3421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e09694b50f89f302ed531c1f2a7569f0be5867aee4ab4f8f729bbeec0078e3"
 dependencies = [
  "arrayvec",
- "num_enum",
+ "num_enum 0.5.7",
  "paste",
 ]
 
@@ -4479,13 +4506,13 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 [[package]]
 name = "smoltcp"
 version = "0.10.0"
-source = "git+https://github.com/smoltcp-rs/smoltcp.git?branch=main#edfdb23243a973d458397a2b4e76f527bacb1fd6"
+source = "git+https://github.com/smoltcp-rs/smoltcp.git?branch=main#9b791ae3057e10f7afcb70c67deb5daf714293a9"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
  "defmt",
- "heapless",
+ "heapless 0.8.0",
  "libc",
  "log",
  "managed",
@@ -5184,14 +5211,14 @@ dependencies = [
  "modals",
  "num-derive",
  "num-traits",
- "num_enum",
+ "num_enum 0.5.7",
  "packed_struct",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rkyv",
  "trng",
  "usb-device",
- "usbd-human-interface-device 0.2.1",
+ "usbd-human-interface-device",
  "usbd-serial",
  "usbd_mass_storage 0.1.0",
  "usbd_scsi 0.1.1",
@@ -5219,7 +5246,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "usb-device",
- "usbd-human-interface-device 0.1.1",
+ "usbd-human-interface-device",
  "utralib",
  "vcell",
  "xous 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5231,34 +5258,15 @@ dependencies = [
 
 [[package]]
 name = "usbd-human-interface-device"
-version = "0.1.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262ce4294612a8fc830daeaded8b111e241dff8520965979d1754eb87fb33951"
+checksum = "809d98d59a6fccbdcf27026101e9a753c5a98d66898061eee7dd8bfd4eff1d03"
 dependencies = [
- "delegate 0.6.2",
- "embedded-time",
  "frunk",
- "hash32",
- "hash32-derive",
- "heapless",
- "log",
- "num_enum",
- "packed_struct",
- "usb-device",
-]
-
-[[package]]
-name = "usbd-human-interface-device"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f01ee9d05b01603f4d6ee43e7d0ebe140f16567d6ff99fde0dc1ea6e7564e65"
-dependencies = [
- "delegate 0.7.0",
- "embedded-time",
- "frunk",
- "heapless",
- "log",
- "num_enum",
+ "fugit",
+ "heapless 0.7.16",
+ "num_enum 0.6.1",
+ "option-block",
  "packed_struct",
  "usb-device",
 ]
@@ -5435,7 +5443,7 @@ dependencies = [
  "trng",
  "tts-frontend",
  "usb-device-xous",
- "usbd-human-interface-device 0.2.1",
+ "usbd-human-interface-device",
  "userprefs",
  "utralib",
  "xous 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/apps/vault/Cargo.toml
+++ b/apps/vault/Cargo.toml
@@ -17,7 +17,7 @@ graphics-server = {path = "../../services/graphics-server" }
 locales = {path = "../../locales"}
 tts-frontend = {path="../../services/tts"}
 usb-device-xous = {path="../../services/usb-device-xous"}
-usbd-human-interface-device = "0.2.1"
+usbd-human-interface-device = "0.4.3"
 pddb = {path = "../../services/pddb" }
 modals = {path = "../../services/modals" }
 trng = {path="../../services/trng"}

--- a/apps/vault/src/env/xous/mod.rs
+++ b/apps/vault/src/env/xous/mod.rs
@@ -48,10 +48,10 @@ impl XousHidConnection {
             }
         }
     }
-    pub fn u2f_wait_incoming(&self) -> Result<RawFidoMsg, xous::Error> {
+    pub fn u2f_wait_incoming(&self) -> Result<RawFidoReport, xous::Error> {
         self.endpoint.u2f_wait_incoming()
     }
-    pub fn u2f_send(&self, msg: RawFidoMsg) -> Result<(), xous::Error> {
+    pub fn u2f_send(&self, msg: RawFidoReport) -> Result<(), xous::Error> {
         self.endpoint.u2f_send(msg)
     }
 }
@@ -62,7 +62,7 @@ impl HidConnection for XousHidConnection {
         buf: &mut [u8; 64],
         _timeout: Duration,
     ) -> SendOrRecvResult {
-        let mut reply = RawFidoMsg::default();
+        let mut reply = RawFidoReport::default();
         reply.packet.copy_from_slice(buf);
         match self.endpoint.u2f_send(reply) {
             Ok(()) => Ok(SendOrRecvStatus::Sent),

--- a/apps/vault/src/main.rs
+++ b/apps/vault/src/main.rs
@@ -312,7 +312,7 @@ fn main() -> ! {
                             match typed_reply {
                                 HidIterType::Ctap(reply) => {
                                     for pkt_reply in reply {
-                                        let mut reply = RawFidoMsg::default();
+                                        let mut reply = RawFidoReport::default();
                                         reply.packet.copy_from_slice(&pkt_reply);
                                         let status = ctap.env().main_hid_connection().u2f_send(reply);
                                         match status {
@@ -372,7 +372,7 @@ fn main() -> ! {
                                         }
                                     };
                                     for pkt_reply in reply {
-                                        let mut reply = RawFidoMsg::default();
+                                        let mut reply = RawFidoReport::default();
                                         reply.packet.copy_from_slice(&pkt_reply);
                                         let status = ctap.env().main_hid_connection().u2f_send(reply);
                                         match status {

--- a/services/usb-device-xous/Cargo.toml
+++ b/services/usb-device-xous/Cargo.toml
@@ -26,7 +26,7 @@ xous-semver = "0.1.2"
 utralib = { version = "0.1.23", optional = true, default-features = false }
 trng = {path="../trng"}
 
-usbd-human-interface-device = "0.2.1"
+usbd-human-interface-device = "0.4.3"
 embedded-time = "0.12.1" # required by the keyboard interface
 packed_struct = { version = "0.10", default-features = false } # used by the usbd-human-interface-device crate
 num_enum = { version = "0.5", default-features = false } # used by the usbd-human-interface-device crate

--- a/services/usb-device-xous/src/lib.rs
+++ b/services/usb-device-xous/src/lib.rs
@@ -10,7 +10,7 @@ pub use usbd_human_interface_device::device::keyboard::KeyboardLedsReport;
 pub use usbd_human_interface_device::page::Keyboard as UsbKeyCode;
 use packed_struct::PackedStruct;
 use xous_ipc::Buffer;
-pub use usbd_human_interface_device::device::fido::RawFidoMsg;
+pub use usbd_human_interface_device::device::fido::RawFidoReport;
 
 #[derive(Debug)]
 pub struct UsbHid {
@@ -283,7 +283,7 @@ impl UsbHid {
             _ => panic!("Internal error: illegal return type"),
         }
     }
-    pub fn u2f_wait_incoming(&self) -> Result<RawFidoMsg, xous::Error> {
+    pub fn u2f_wait_incoming(&self) -> Result<RawFidoReport, xous::Error> {
         let req = U2fMsgIpc {
             data: [0; 64],
             code: U2fCode::RxWait,
@@ -294,7 +294,7 @@ impl UsbHid {
         let ack = buf.to_original::<U2fMsgIpc, _>().unwrap();
         match ack.code {
             U2fCode::RxAck => {
-                let mut u2fmsg = RawFidoMsg::default();
+                let mut u2fmsg = RawFidoReport::default();
                 u2fmsg.packet.copy_from_slice(&ack.data);
                 Ok(u2fmsg)
             },
@@ -308,7 +308,7 @@ impl UsbHid {
         }
     }
     /// Note: this variant is not tested.
-    pub fn u2f_wait_incoming_timeout(&self, timeout_ms: u64) -> Result<RawFidoMsg, xous::Error> {
+    pub fn u2f_wait_incoming_timeout(&self, timeout_ms: u64) -> Result<RawFidoReport, xous::Error> {
         let req = U2fMsgIpc {
             data: [0; 64],
             code: U2fCode::RxWait,
@@ -319,7 +319,7 @@ impl UsbHid {
         let ack = buf.to_original::<U2fMsgIpc, _>().unwrap();
         match ack.code {
             U2fCode::RxAck => {
-                let mut u2fmsg = RawFidoMsg::default();
+                let mut u2fmsg = RawFidoReport::default();
                 u2fmsg.packet.copy_from_slice(&ack.data);
                 Ok(u2fmsg)
             },
@@ -332,7 +332,7 @@ impl UsbHid {
             _ => Err(xous::Error::InternalError)
         }
     }
-    pub fn u2f_send(&self, msg: RawFidoMsg) -> Result<(), xous::Error> {
+    pub fn u2f_send(&self, msg: RawFidoReport) -> Result<(), xous::Error> {
         let mut req = U2fMsgIpc {
             data: [0; 64],
             code: U2fCode::Tx,

--- a/services/usb-device-xous/src/main_hosted.rs
+++ b/services/usb-device-xous/src/main_hosted.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 use num_traits::*;
-use usbd_human_interface_device::device::fido::RawFidoMsg;
+use usbd_human_interface_device::device::fido::RawFidoReport;
 use xous::{msg_scalar_unpack, msg_blocking_scalar_unpack};
 use xous_semver::SemVer;
 use core::num::NonZeroU8;
@@ -172,7 +172,7 @@ pub(crate) fn main_hosted() -> ! {
                 let mut buffer = unsafe { Buffer::from_memory_message_mut(msg.body.memory_message_mut().unwrap()) };
                 let mut u2f_ipc = buffer.to_original::<U2fMsgIpc, _>().unwrap();
                 if fido_listener_pid == msg.sender.pid() {
-                    let mut u2f_msg = RawFidoMsg::default();
+                    let mut u2f_msg = RawFidoReport::default();
                     assert_eq!(u2f_ipc.code, U2fCode::Tx, "Expected U2fCode::Tx in wrapper");
                     u2f_msg.packet.copy_from_slice(&u2f_ipc.data);
                     log::debug!("sent U2F packet {:x?}", u2f_ipc.data);

--- a/services/usb-device-xous/src/main_hw.rs
+++ b/services/usb-device-xous/src/main_hw.rs
@@ -3,8 +3,10 @@ use crate::*;
 use num_traits::*;
 use usb_device_xous::KeyboardLedsReport;
 use usb_device_xous::UsbDeviceType;
-use usbd_human_interface_device::device::fido::RawFidoMsg;
-use usbd_human_interface_device::device::fido::RawFidoInterface;
+use usbd_human_interface_device::device::fido::RawFidoReport;
+use usbd_human_interface_device::device::fido::RawFidoConfig;
+use usbd_human_interface_device::device::fido::RawFido;
+use usbd_human_interface_device::device::DeviceClass;
 use xous::{msg_scalar_unpack, msg_blocking_scalar_unpack};
 #[cfg(not(feature="minimal"))]
 use xous_semver::SemVer;
@@ -16,11 +18,9 @@ use utralib::generated::*;
 use usb_device::prelude::*;
 use usb_device::class_prelude::*;
 use usbd_human_interface_device::page::Keyboard;
-use usbd_human_interface_device::device::keyboard::NKROBootKeyboardInterface;
+use usbd_human_interface_device::device::keyboard::{NKROBootKeyboard, NKROBootKeyboardConfig};
 use usbd_human_interface_device::prelude::*;
-use num_enum::FromPrimitive as EnumFromPrimitive;
 
-use embedded_time::Clock;
 use std::convert::TryInto;
 #[cfg(not(feature="minimal"))]
 use keyboard::KeyMap;
@@ -28,24 +28,6 @@ use xous_ipc::Buffer;
 use std::collections::VecDeque;
 
 use usbd_serial::SerialPort;
-
-pub struct EmbeddedClock {
-    start: std::time::Instant,
-}
-impl EmbeddedClock {
-    pub fn new() -> EmbeddedClock {
-        EmbeddedClock { start: std::time::Instant::now() }
-    }
-}
-
-impl Clock for EmbeddedClock {
-    type T = u64;
-    const SCALING_FACTOR: embedded_time::fraction::Fraction = <embedded_time::fraction::Fraction>::new(1, 1_000);
-
-    fn try_now(&self) -> Result<embedded_time::Instant<Self>, embedded_time::clock::Error> {
-        Ok(embedded_time::Instant::new(self.start.elapsed().as_millis().try_into().unwrap()))
-    }
-}
 
 /// Time allowed for switchover between device core types. It's longer because some hosts
 /// get really confused when you have the same VID/PID show up with a different set of endpoints.
@@ -228,14 +210,13 @@ pub(crate) fn main_hw() -> ! {
 
     // FIDO + keyboard
     let usb_alloc = UsbBusAllocator::new(usb_fidokbd_dev);
-    let clock = EmbeddedClock::new();
 
     let mut composite = UsbHidClassBuilder::new()
-        .add_interface(
-            NKROBootKeyboardInterface::default_config(&clock),
+        .add_device(
+            NKROBootKeyboardConfig::default(),
         )
-        .add_interface(
-            RawFidoInterface::default_config()
+        .add_device(
+            RawFidoConfig::default()
         )
         .build(&usb_alloc);
 
@@ -248,8 +229,8 @@ pub(crate) fn main_hw() -> ! {
     // FIDO only
     let fido_alloc = UsbBusAllocator::new(usb_fido_dev);
     let mut fido_class = UsbHidClassBuilder::new()
-        .add_interface(
-            RawFidoInterface::default_config()
+        .add_device(
+            RawFidoConfig::default()
         )
         .build(&fido_alloc);
 
@@ -553,12 +534,12 @@ pub(crate) fn main_hw() -> ! {
                 let mut buffer = unsafe { Buffer::from_memory_message_mut(msg.body.memory_message_mut().unwrap()) };
                 let mut u2f_ipc = buffer.to_original::<U2fMsgIpc, _>().unwrap();
                 if fido_listener_pid == msg.sender.pid() {
-                    let mut u2f_msg = RawFidoMsg::default();
+                    let mut u2f_msg = RawFidoReport::default();
                     assert_eq!(u2f_ipc.code, U2fCode::Tx, "Expected U2fCode::Tx in wrapper");
                     u2f_msg.packet.copy_from_slice(&u2f_ipc.data);
                     let u2f = match view {
-                        Views::FidoWithKbd => composite.interface::<RawFidoInterface<'_, _>, _>(),
-                        Views::FidoOnly => fido_class.interface::<RawFidoInterface<'_, _>, _>(),
+                        Views::FidoWithKbd => composite.device::<RawFido<'_, _>, _>(),
+                        Views::FidoOnly => fido_class.device::<RawFido<'_, _>, _>(),
                         #[cfg(feature="mass-storage")]
                         Views::MassStorage => panic!("did not expect u2f tx when in mass storage mode!"),
                         Views::Serial => panic!("did not expect u2f tx while in serial mode!"),
@@ -575,22 +556,21 @@ pub(crate) fn main_hw() -> ! {
                 let maybe_u2f = match view {
                     Views::FidoWithKbd => {
                         if usb_dev.poll(&mut [&mut composite]) {
-                            let keyboard = composite.interface::<NKROBootKeyboardInterface<'_, _, _,>, _>();
-                            match keyboard.read_report() {
+                            match composite.device::<NKROBootKeyboard<_>, _>().read_report() {
                                 Ok(l) => {
                                     log::info!("keyboard LEDs: {:?}", l);
                                     led_state = l;
                                 }
                                 Err(e) => log::trace!("KEYB ERR: {:?}", e),
                             }
-                            Some(composite.interface::<RawFidoInterface<'_, _>, _>())
+                            Some(composite.device::<RawFido<'_, _>, _>())
                         } else {
                             None
                         }
                     }
                     Views::FidoOnly => {
                         if fido_dev.poll(&mut [&mut fido_class]) {
-                            Some(fido_class.interface::<RawFidoInterface<'_, _>, _>())
+                            Some(fido_class.device::<RawFido<'_, _>, _>())
                         } else {
                             None
                         }
@@ -796,8 +776,8 @@ pub(crate) fn main_hw() -> ! {
                                 usbmgmt.ll_reset(false);
                             }
                         }
-                        let keyboard = composite.interface::<NKROBootKeyboardInterface<'_, _, _,>, _>();
-                        keyboard.write_report(&[]).ok(); // queues an "all key-up" for the interface
+                        let keyboard = composite.device::<NKROBootKeyboard<'_, _,>, _>();
+                        keyboard.write_report([Keyboard::NoEventIndicated]).ok(); // queues an "all key-up" for the interface
                         keyboard.tick().ok();
                     }
                     UsbDeviceType::Fido => {
@@ -894,8 +874,8 @@ pub(crate) fn main_hw() -> ! {
                                 // type matches, do nothing
                             }
                         }
-                        let keyboard = composite.interface::<NKROBootKeyboardInterface<'_, _, _,>, _>();
-                        keyboard.write_report(&[]).ok(); // queues an "all key-up" for the interface
+                        let keyboard = composite.device::<NKROBootKeyboard<'_, _,>, _>();
+                        keyboard.write_report([Keyboard::NoEventIndicated]).ok(); // queues an "all key-up" for the interface
                         keyboard.tick().ok();
                     }
                     UsbDeviceType::Fido => {
@@ -1026,21 +1006,36 @@ pub(crate) fn main_hw() -> ! {
                         if usb_dev.state() == UsbDeviceState::Configured {
                             let mut codes = Vec::<Keyboard>::new();
                             if code0 != 0 {
-                                codes.push(Keyboard::from_primitive(code0 as u8));
+                                codes.push(
+                                    match native_map {
+                                        KeyMap::Dvorak => mappings::char_to_hid_code_dvorak(code0 as u8 as char)[0],
+                                        _ => mappings::char_to_hid_code_us101(code0 as u8 as char)[0],
+                                    }
+                                );
                             }
                             if code1 != 0 {
-                                codes.push(Keyboard::from_primitive(code1 as u8));
+                                codes.push(
+                                    match native_map {
+                                        KeyMap::Dvorak => mappings::char_to_hid_code_dvorak(code1 as u8 as char)[0],
+                                        _ => mappings::char_to_hid_code_us101(code1 as u8 as char)[0],
+                                    }
+                                );
                             }
                             if code2 != 0 {
-                                codes.push(Keyboard::from_primitive(code2 as u8));
+                                codes.push(
+                                    match native_map {
+                                        KeyMap::Dvorak => mappings::char_to_hid_code_dvorak(code2 as u8 as char)[0],
+                                        _ => mappings::char_to_hid_code_us101(code2 as u8 as char)[0],
+                                    }
+                                );
                             }
                             let auto_up = if autoup == 1 {true} else {false};
-                            let keyboard = composite.interface::<NKROBootKeyboardInterface<'_, _, _,>, _>();
-                            keyboard.write_report(&codes).ok();
+                            let keyboard = composite.device::<NKROBootKeyboard<'_, _,>, _>();
+                            keyboard.write_report(codes).ok();
                             keyboard.tick().ok();
                             tt.sleep_ms(autotype_delay_ms).ok();
                             if auto_up {
-                                keyboard.write_report(&[]).ok(); // this is the key-up
+                                keyboard.write_report([Keyboard::NoEventIndicated]).ok(); // this is the key-up
                                 keyboard.tick().ok();
                                 tt.sleep_ms(autotype_delay_ms).ok();
                             }
@@ -1111,11 +1106,11 @@ pub(crate) fn main_hw() -> ! {
                                 KeyMap::Dvorak => mappings::char_to_hid_code_dvorak(ch),
                                 _ => mappings::char_to_hid_code_us101(ch),
                             };
-                            let keyboard = composite.interface::<NKROBootKeyboardInterface<'_, _, _,>, _>();
-                            keyboard.write_report(&codes).ok();
+                            let keyboard = composite.device::<NKROBootKeyboard<'_, _>, _>();
+                            keyboard.write_report(codes).ok();
                             keyboard.tick().ok();
                             tt.sleep_ms(autotype_delay_ms).ok();
-                            keyboard.write_report(&[]).ok(); // this is the key-up
+                            keyboard.write_report([Keyboard::NoEventIndicated]).ok(); // this is the key-up
                             keyboard.tick().ok();
                             tt.sleep_ms(autotype_delay_ms).ok();
                             sent += 1;

--- a/services/usb-test/Cargo.toml
+++ b/services/usb-test/Cargo.toml
@@ -20,7 +20,7 @@ bitfield = "0.13.2"
 vcell = "0.1.3"
 utralib = { version = "0.1.23", optional = true, default-features = false }
 
-usbd-human-interface-device = "0.1.1"
+usbd-human-interface-device = "0.4.3"
 embedded-time = "0.12.1" # required by the keyboard interface
 
 [dependencies.usb-device]

--- a/services/usb-test/src/main.rs
+++ b/services/usb-test/src/main.rs
@@ -28,7 +28,7 @@ use std::collections::BTreeMap;
 use usb_device::prelude::*;
 use usb_device::class_prelude::*;
 use usbd_human_interface_device::page::Keyboard;
-use usbd_human_interface_device::device::keyboard::NKROBootKeyboardInterface;
+use usbd_human_interface_device::device::keyboard::NKROBootKeyboard;
 use usbd_human_interface_device::prelude::*;
 use embedded_time::Clock;
 use std::convert::TryInto;
@@ -95,8 +95,8 @@ fn main() -> ! {
     let usb_alloc = UsbBusAllocator::new(usbdev);
     let clock = EmbeddedClock::new();
     let mut keyboard = UsbHidClassBuilder::new()
-        .add_interface(
-            NKROBootKeyboardInterface::default_config(&clock),
+        .add_device(
+            NKROBootKeyboard::default(&clock),
         )
         .build(&usb_alloc);
     let mut usb_dev = UsbDeviceBuilder::new(&usb_alloc, UsbVidPid(0x1209, 0x3613))


### PR DESCRIPTION
This PR fixes the `main` branch to track the latest changes in usb-human-interface-device (we were at API rev 0.2.1, this brings it up to 0.4.3).

Note that ... as far as I can tell most of the changes are cosmetic -- method names seem to be renamed to be more "rusty".

Aside from the renamings, the timer requirement is removed from keyboard devices.

@gsora - I'm fine to fork the crate at 0.2.1, but wanted to see what you thought about these changes. If you want me to pull these in prior to forking usbd-human-interface-device, I'm happy to. But I am also equally happy to fork at the older API rev if you see no clear advantage to adopting the changes.

Aside from that, I don't see any earth-changing fixes -- a bunch of dependencies got bumped, maybe they were bumped because security problems were found, or maybe they were bumped just because they could be bumped. The release notes are not clear on this.
