### PR TITLE
implement default behavior when no dialog is specified.

### DIFF
--- a/libs/chat/src/ui.rs
+++ b/libs/chat/src/ui.rs
@@ -391,12 +391,12 @@ impl Ui {
     ) -> Result<(), Error> {
         match (&self.pddb_key, &mut self.dialogue) {
             (Some(pddb_key), Some(ref mut dialogue)) => {
-                if pddb_key.eq(&dialogue_id) {
+                if dialogue_id.len() == 0 || pddb_key.eq(&dialogue_id) {
                     dialogue
                         .post_add(author, timestamp, text, attach_url)
                         .unwrap();
                 } else {
-                    log::warn!("dropping Post as dialogue_id does not match pddb_key");
+                    log::warn!("dropping Post as dialogue_id does not match pddb_key: '{}' vs '{}'", pddb_key, dialogue_id);
                 }
             }
             (None, _) => log::warn!("no pddb_key set to match dialogue_id"),


### PR DESCRIPTION
- the `post_add()` API on the 'lib' side of things says Add a new Post to the current `Dialogue`, and it passes an empty `dialogue_id` string.
- the `post_add()` handler on the server dutifully unpacks the `dialog_id` field with `post.dialogue_id.as_str().unwrap()`, and then passes on to the `post_add()` call inside the UI object
- the `post_add()` implementation in the UI object then checks the `dialog_id` with if `pddb_key.eq(&dialogue_id)`, expecting that the key should match the dialog id. But through this path, the dialogue ID is always the empty string, so the function can't work.

This patch causes the code to "fall through" and use the default `pddb_key` if the length of the `dialog_id` is zero. Not sure if this is the intended behavior, but in the test case at least I get posts appearing now once this patch is in.