### PR TITLE
chore: fix default clock rate for simulation framework

### DIFF
--- a/libs/xous-pio/src/pio_tests/units.rs
+++ b/libs/xous-pio/src/pio_tests/units.rs
@@ -1283,7 +1283,7 @@ pub fn fifo_join_test() -> bool {
     a_prog.setup_default_config(&mut sm_a);
     sm_a.config_set_out_pins(0, 32);
     #[cfg(not(feature = "rp2040"))]
-    sm_a.config_set_clkdiv(192.0); // slow down the machine so we can read out the values after writing them...
+    sm_a.config_set_clkdiv(2048.0); // slow down the machine so we can read out the values after writing them...
     #[cfg(feature = "rp2040")]
     sm_a.config_set_clkdiv(32768.0);
     sm_a.config_set_out_shift(false, true, 0);


### PR DESCRIPTION
have to slow down the defalut clock rate for the FIFO test in PIO unit test, so we can capture results in simulation