### PR TITLE
WIP: Cramium cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cram-hal-service"
+version = "0.1.0"
+dependencies = [
+ "cramium-hal",
+ "log",
+ "num-derive",
+ "num-traits",
+ "rkyv",
+ "utralib",
+ "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-api-log",
+ "xous-api-names",
+ "xous-api-ticktimer",
+]
+
+[[package]]
 name = "cram-mbox1"
 version = "0.1.0"
 dependencies = [
@@ -930,7 +946,9 @@ dependencies = [
 name = "cramium-hal"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.3.2",
  "utralib",
+ "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2724,6 +2742,8 @@ dependencies = [
  "lazy_static",
  "sha2-loader",
  "utralib",
+ "xous-pio",
+ "xous-pl230",
 ]
 
 [[package]]
@@ -6158,6 +6178,7 @@ dependencies = [
  "armv7",
  "atsama5d27",
  "bitflags 1.3.2",
+ "cramium-hal",
  "critical-section 1.1.1",
  "crossbeam-channel",
  "gdbstub",
@@ -6177,6 +6198,7 @@ name = "xous-log"
 version = "0.1.28"
 dependencies = [
  "atsama5d27",
+ "cramium-hal",
  "log",
  "num-derive",
  "num-traits",
@@ -6219,6 +6241,7 @@ name = "xous-pl230"
 version = "0.1.0"
 dependencies = [
  "bitfield",
+ "cramium-hal",
  "log",
  "pio",
  "pio-proc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "cramium-hal"
+version = "0.1.0"
+dependencies = [
+ "utralib",
+]
+
+[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2711,6 +2718,7 @@ dependencies = [
  "armv7",
  "atsama5d27",
  "com_rs 0.1.0 (git+https://github.com/betrusted-io/com_rs?branch=main)",
+ "cramium-hal",
  "curve25519-dalek-loader",
  "ed25519-dalek-loader",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ members = [
   "libs/tls",
   "libs/xous-pio",
   "libs/xous-pl230",
+  "libs/cramium-hal",
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ members = [
   "libs/xous-pio",
   "libs/xous-pl230",
   "libs/cramium-hal",
+  "services/cram-hal-service",
 ]
 resolver = "2"
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -16,6 +16,7 @@ xous-kernel = { package = "xous", version = "0.9.57", features = [
 ] }
 utralib = { version = "0.1.24", optional = true, default_features = false }
 rand_chacha = { version = "0.3.1", optional = true, default_features = false }
+cramium-hal = { path = "../libs/cramium-hal", optional = true }
 
 [target.'cfg(any(windows,unix))'.dev-dependencies]
 xous-kernel = { package = "xous", version = "0.9.57", features = [
@@ -37,7 +38,7 @@ xous-kernel = { package = "xous", version = "0.9.57", features = ["v2p"] }
 critical-section = "1.1.1"
 
 [features]
-cramium-soc = ["utralib/cramium-soc"]
+cramium-soc = ["utralib/cramium-soc", "cramium-hal", "rand_chacha"]
 cramium-fpga = ["utralib/cramium-fpga"]
 atsama5d27 = ["utralib/atsama5d27"]
 precursor = ["utralib/precursor"]
@@ -54,9 +55,6 @@ v2p = ["xous-kernel/v2p"]
 
 # patches for simulation targets ONLY. Applying these flags will result in totally broken security.
 hwsim = []
-fake-rng = [
-    "rand_chacha",
-] # works around lack of a real TRNG in the full-chip sim for now. This should go away for production.
 
 # default = ["print-panics", "debug-print", "wrap-print"]
 default = ["print-panics"]

--- a/kernel/src/arch/riscv/mem.rs
+++ b/kernel/src/arch/riscv/mem.rs
@@ -870,6 +870,10 @@ pub fn virt_to_phys(virt: usize) -> Result<usize, xous_kernel::Error> {
     Ok((l0_pt.entries[vpn0] >> 10) << 12)
 }
 
+pub fn virt_to_phys_pid(_pid: PID, _virt: usize) -> Result<usize, xous_kernel::Error> {
+    todo!("virt_to_phys_pid is not yet implemented for riscv");
+}
+
 pub fn ensure_page_exists_inner(address: usize) -> Result<usize, xous_kernel::Error> {
     // Disallow mapping memory outside of user land
     if !MemoryMapping::current().is_kernel() && address >= USER_AREA_END {

--- a/kernel/src/platform/cramium/rand.rs
+++ b/kernel/src/platform/cramium/rand.rs
@@ -2,88 +2,53 @@
 // SPDX-FileCopyrightText: 2022 Foundation Devices, Inc. <hello@foundationdevices.com>
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(not(feature = "fake-rng"))]
-use utralib::generated::*;
-#[cfg(not(feature = "fake-rng"))]
+use cramium_hal::sce;
+use rand_chacha::rand_core::RngCore;
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 use xous_kernel::{MemoryFlags, MemoryType, PID};
 
-#[cfg(not(feature = "fake-rng"))]
 use crate::mem::MemoryManager;
 
 /// The manually chosen virtual address has to be in the top 4MiB as it is the
 /// only page shared among all processes.
 ///
 /// See https://github.com/betrusted-io/xous-core/blob/master/docs/memory.md
-#[cfg(not(feature = "fake-rng"))]
 pub const TRNG_KERNEL_ADDR: usize = 0xffce_0000;
-#[cfg(not(feature = "fake-rng"))]
-pub static mut TRNG_KERNEL: Option<TrngKernel> = None;
-#[cfg(feature = "fake-rng")]
+pub static mut TRNG_KERNEL: Option<sce::trng::Trng> = None;
 use core::sync::atomic::{AtomicU32, Ordering};
-#[cfg(feature = "fake-rng")]
-static LOCAL_RNG_STATE: AtomicU32 = AtomicU32::new(2);
-
-#[cfg(not(feature = "fake-rng"))]
-pub struct TrngKernel {
-    pub trng_kernel_csr: CSR<u32>,
-}
-
-#[cfg(not(feature = "fake-rng"))]
-impl TrngKernel {
-    pub fn new(addr: usize) -> TrngKernel { TrngKernel { trng_kernel_csr: CSR::new(addr as *mut u32) } }
-
-    pub fn init(&mut self) {
-        if false {
-            // raw random path - left in for debugging urandom, can strip out later
-            while self.trng_kernel_csr.rf(utra::trng_kernel::STATUS_AVAIL) == 0 {}
-            // discard the first entry, as it is always 0x0000_0000
-            // this is because the read register is a pipeline stage behind the FIFO
-            // once the pipeline has been filled, there is no need to prime it again.
-            self.trng_kernel_csr.rf(utra::trng_kernel::DATA_DATA);
-        } else {
-            // urandom path (recommended)
-            // simulations show this isn't strictly necessary, but I prefer to have it
-            // just in case a subtle bug in the reset logic leaves something deterministic
-            // in the connecting logic: the simulation coverage stops at the edge of the TRNG block.
-            for _ in 0..4 {
-                // wait until the urandom port is initialized
-                while self.trng_kernel_csr.rf(utra::trng_kernel::URANDOM_VALID_URANDOM_VALID) == 0 {}
-                // pull a dummy piece of data
-                self.trng_kernel_csr.rf(utra::trng_kernel::URANDOM_URANDOM);
-            }
-        }
-    }
-
-    pub fn get_u32(&mut self) -> u32 {
-        if false {
-            // raw random path
-            while self.trng_kernel_csr.rf(utra::trng_kernel::STATUS_AVAIL) == 0 {}
-            self.trng_kernel_csr.rf(utra::trng_kernel::DATA_DATA)
-        } else {
-            // urandom path (recommended)
-            while self.trng_kernel_csr.rf(utra::trng_kernel::URANDOM_VALID_URANDOM_VALID) == 0 {}
-            self.trng_kernel_csr.rf(utra::trng_kernel::URANDOM_URANDOM)
-        }
-    }
-}
+// these values are overwritten on boot with something out of the TRNG.
+static LOCAL_RNG_STATE_LSB: AtomicU32 = AtomicU32::new(0);
+static LOCAL_RNG_STATE_MSB: AtomicU32 = AtomicU32::new(0);
 
 /// Initialize TRNG driver.
 ///
 /// Needed so that the kernel can allocate names.
-#[cfg(not(feature = "fake-rng"))]
+/// This driver "owns" the hardware TRNG on the chip. Because there aren't two
+/// TRNG ports on the Cramium implementation, it means that userspace applications
+/// have to extract random numbers from the kernel through the SID request mechanism.
+/// This is ostensibly harmless, if everything is implemented well, but if there is
+/// a problem it does mean that the state of the kernel TRNG is disclosed to userspace.
+/// What can you do though, this chip just has one TRNG.
+///
+/// The final implementation for user applications is recommended to have a supplementary
+/// noise source in addition to the on-chip noise source, so that user applications
+/// combine both the feed from the kernel and the supplementary source to seed a CSPRNG.
+///
+/// This particular application doesn't trust the on-chip TRNG so much: it takes
+/// values from the TRNG and folds them into a seed pool that is then groomed by
+/// a ChaCha8 RNG CSPRNG. Every request for a random number folds another 32 bits
+/// from the TRNG into the CSPRNG pool, so even if the TRNG is fairly poor, quite
+/// rapidly the pool of numbers should diverge. However, from the kernel's perspective,
+/// it will function correctly even if the CSPRNG is fully deterministic, it just isn't
+/// secure against attackers trying to guess a server address.
+
 pub fn init() {
     // Map the TRNG so that we can allocate names
-    // hardware guarantees that:
-    //   - TRNG will automatically power on
-    //   - Both TRNGs are enabled, with conservative defaults
-    //   - Kernel FIFO will fill with TRNGs such that at least the next 512 calls to get_u32() will succeed
-    //     without delay
-    //   - The kernel will start a TRNG server
-    //   - All further security decisions and policies are 100% delegated to this new server.
     MemoryManager::with_mut(|memory_manager| {
         memory_manager
             .map_range(
-                utra::trng_kernel::HW_TRNG_KERNEL_BASE as *mut u8,
+                utralib::generated::HW_TRNG_BASE as *mut u8,
                 (TRNG_KERNEL_ADDR & !4095) as *mut u8,
                 4096,
                 PID::new(1).unwrap(),
@@ -93,34 +58,46 @@ pub fn init() {
             .expect("unable to map TRNG_KERNEL")
     });
 
-    let mut trng_kernel = TrngKernel::new(TRNG_KERNEL_ADDR);
-    trng_kernel.init();
+    let mut trng_kernel = sce::trng::Trng::new(TRNG_KERNEL_ADDR);
+    trng_kernel.setup_raw_generation(256);
 
+    // setup the initial seeds with stuff out of the TRNG.
+    LOCAL_RNG_STATE_LSB.store(trng_kernel.get_u32().expect("TRNG error"), Ordering::SeqCst);
+    LOCAL_RNG_STATE_MSB.store(trng_kernel.get_u32().expect("TRNG error"), Ordering::SeqCst);
+
+    // move the trng_kernel object into the static mut state
     unsafe {
         TRNG_KERNEL = Some(trng_kernel);
+    }
+
+    // now run the CSPRNG a few cycles to fold more entropy into the pool before we start
+    // to use it for reals. 16 iterations will extract 512 bits out of the TRNG, so even
+    // if it is somewhat degraded, we'll be in good shape...
+    for _ in 0..16 {
+        let _ = get_u32();
     }
 }
 
 /// Retrieve random `u32`.
-#[cfg(not(feature = "fake-rng"))]
 pub fn get_u32() -> u32 {
-    unsafe { TRNG_KERNEL.as_mut().expect("TRNG_KERNEL driver not initialized").get_u32() }
-}
+    let mut state = LOCAL_RNG_STATE_LSB.load(Ordering::SeqCst) as u64
+        | (LOCAL_RNG_STATE_MSB.load(Ordering::SeqCst) as u64) << 32;
 
-/// Initialize TRNG driver.
-///
-/// Needed so that the kernel can allocate names.
-#[cfg(feature = "fake-rng")]
-pub fn init() {}
+    // XOR in 32 bits of entropy from the HW TRNG pool.
+    state ^= unsafe {
+        TRNG_KERNEL
+            .as_mut()
+            .expect("TRNG_KERNEL driver not initialized")
+            .get_u32()
+            .expect("Error in random number generation")
+    } as u64;
 
-#[cfg(feature = "fake-rng")]
-pub fn get_u32() -> u32 {
-    use rand_chacha::rand_core::RngCore;
-    use rand_chacha::rand_core::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
-
-    let mut rng = ChaCha8Rng::seed_from_u64(LOCAL_RNG_STATE.load(Ordering::SeqCst) as u64);
-    let r = rng.next_u32();
-    LOCAL_RNG_STATE.store(rng.next_u64() as u32, Ordering::SeqCst);
-    r
+    let mut rng = ChaCha8Rng::seed_from_u64(state);
+    let next_state = rng.next_u64();
+    // next state is extracted before the returned value, to reduce state
+    // leakage outside of the RNG.
+    let ret_val = rng.next_u32();
+    LOCAL_RNG_STATE_LSB.store(next_state as u32, Ordering::SeqCst);
+    LOCAL_RNG_STATE_MSB.store((next_state >> 32) as u32, Ordering::SeqCst);
+    ret_val
 }

--- a/libs/cramium-hal/Cargo.toml
+++ b/libs/cramium-hal/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cramium-hal"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+utralib = { version = "0.1.24", default-features = false, features = [
+    "cramium-soc",
+] }

--- a/libs/cramium-hal/Cargo.toml
+++ b/libs/cramium-hal/Cargo.toml
@@ -9,3 +9,10 @@ edition = "2021"
 utralib = { version = "0.1.24", default-features = false, features = [
     "cramium-soc",
 ] }
+
+[target.'cfg(target_os = "xous")'.dependencies]
+xous = { version = "0.9.57", features = ["v2p"] }
+
+[features]
+baremetal = []
+default = []

--- a/libs/cramium-hal/Cargo.toml
+++ b/libs/cramium-hal/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 utralib = { version = "0.1.24", default-features = false, features = [
     "cramium-soc",
 ] }
+bitflags = "1.2.1"
 
 [target.'cfg(target_os = "xous")'.dependencies]
 xous = { version = "0.9.57", features = ["v2p"] }

--- a/libs/cramium-hal/src/iox.rs
+++ b/libs/cramium-hal/src/iox.rs
@@ -1,0 +1,383 @@
+use utralib::generated::utra::iox;
+use utralib::generated::*;
+
+macro_rules! set_pin_in_bank {
+    ($self:expr, $register:expr, $port:expr, $pin:expr, $val:expr) => {{
+        assert!($pin < 16, "pin must be in range of 0-15");
+        // safety: it is safe to create this raw pointer and cast it because the
+        // code below does not add to the raw pointer outside of its approved range,
+        // thanks to the constraints placed by the enum type of IoxPort.
+        unsafe {
+            let oe_ptr = $self.csr.base();
+
+            oe_ptr.add($register.offset() + $port as usize).write_volatile(
+                (oe_ptr.add($register.offset() + $port as usize).read_volatile() & !(1u32 << ($pin as u32)))
+                    | (($val as u32) << ($pin as u32)),
+            )
+        }
+    }};
+}
+
+#[derive(Copy, Clone)]
+#[repr(u32)]
+pub enum IoxPort {
+    PA = 0,
+    PB = 1,
+    PC = 2,
+    PD = 3,
+    PE = 4,
+    PF = 5,
+}
+
+#[repr(u32)]
+pub enum IoxFunction {
+    Gpio = 0b00,
+    AF1 = 0b01,
+    AF2 = 0b10,
+    AF3 = 0b11,
+}
+
+#[repr(u32)]
+pub enum IoxDriveStrength {
+    Drive2mA = 0b00,
+    Drive4mA = 0b01,
+    Drive8mA = 0b10,
+    Drive12mA = 0b11,
+}
+
+#[repr(u32)]
+pub enum IoxDir {
+    Input = 0,
+    Output = 1,
+}
+
+#[repr(u32)]
+pub enum IoxEnable {
+    Disable = 0,
+    Enable = 1,
+}
+
+#[derive(Copy, Clone)]
+#[repr(u32)]
+pub enum IoxValue {
+    Low = 0,
+    High = 1,
+}
+/// The From trait for IoxValue takes any non-zero value and interprets it as "high".
+impl From<u32> for IoxValue {
+    fn from(value: u32) -> Self { if value == 0 { IoxValue::Low } else { IoxValue::High } }
+}
+
+pub struct Iox {
+    csr: CSR<u32>,
+}
+
+impl Iox {
+    pub fn new(base_address: *mut u32) -> Self { Iox { csr: CSR::new(base_address) } }
+
+    pub fn set_gpio_dir(&mut self, port: IoxPort, pin: u8, direction: IoxDir) {
+        set_pin_in_bank!(self, iox::SFR_GPIOOE_CRGOE0, port, pin, direction)
+    }
+
+    pub fn set_gpio_pullup(&mut self, port: IoxPort, pin: u8, enable: IoxEnable) {
+        set_pin_in_bank!(self, iox::SFR_GPIOPU_CRGPU0, port, pin, enable)
+    }
+
+    pub fn set_gpio_pin(&mut self, port: IoxPort, pin: u8, value: IoxValue) {
+        set_pin_in_bank!(self, iox::SFR_GPIOOUT_CRGO0, port, pin, value)
+    }
+
+    pub fn set_gpio_schmitt_trigger(&mut self, port: IoxPort, pin: u8, enable: IoxEnable) {
+        set_pin_in_bank!(self, iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL0, port, pin, enable)
+    }
+
+    pub fn set_slow_slew_rate(&mut self, port: IoxPort, pin: u8, enable: IoxEnable) {
+        set_pin_in_bank!(self, iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW0, port, pin, enable)
+    }
+
+    pub fn get_gpio_pin(&self, port: IoxPort, pin: u8) -> IoxValue {
+        assert!(pin < 16, "pin must be in range of 0-15");
+        // safety: it is safe to create this raw pointer and cast it because the
+        // code below does not add to the raw pointer outside of its approved range,
+        // thanks to the constraints placed by the enum type of IoxPort.
+        unsafe {
+            let oe_ptr = self.csr.base();
+            IoxValue::from(
+                oe_ptr.add(iox::SFR_GPIOIN_SRGI0.offset() + port as usize).read_volatile()
+                    & !(1u32 << (pin as u32)),
+            )
+        }
+    }
+
+    pub fn get_gpio_bank(&self, port: IoxPort) -> u16 {
+        // safety: it is safe to create this raw pointer and cast it because the
+        // code below does not add to the raw pointer outside of its approved range,
+        // thanks to the constraints placed by the enum type of IoxPort.
+        unsafe {
+            let oe_ptr = self.csr.base();
+            oe_ptr.add(iox::SFR_GPIOIN_SRGI0.offset() + port as usize).read_volatile() as u16
+        }
+    }
+
+    pub fn set_alternate_function(&mut self, port: IoxPort, pin: u8, function: IoxFunction) {
+        assert!(pin < 16, "pin must be in range of 0-15");
+        match port {
+            IoxPort::PA => {
+                if pin < 8 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL0,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL0) & !(0b11 << (pin * 2))
+                            | (function as u32) << (pin * 2),
+                    )
+                } else if pin >= 8 && pin < 16 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL1,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL1) & !(0b11 << ((pin - 8) * 2))
+                            | (function as u32) << ((pin - 8) * 2),
+                    )
+                }
+            }
+            IoxPort::PB => {
+                if pin < 8 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL2,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL2) & !(0b11 << (pin * 2))
+                            | (function as u32) << (pin * 2),
+                    )
+                } else if pin >= 8 && pin < 16 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL3,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL3) & !(0b11 << ((pin - 8) * 2))
+                            | (function as u32) << ((pin - 8) * 2),
+                    )
+                }
+            }
+            IoxPort::PC => {
+                if pin < 8 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL4,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL4) & !(0b11 << (pin * 2))
+                            | (function as u32) << (pin * 2),
+                    )
+                } else if pin >= 8 && pin < 16 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL5,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL5) & !(0b11 << ((pin - 8) * 2))
+                            | (function as u32) << ((pin - 8) * 2),
+                    )
+                }
+            }
+            IoxPort::PD => {
+                if pin < 8 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL6,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL6) & !(0b11 << (pin * 2))
+                            | (function as u32) << (pin * 2),
+                    )
+                } else if pin >= 8 && pin < 16 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL7,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL7) & !(0b11 << ((pin - 8) * 2))
+                            | (function as u32) << ((pin - 8) * 2),
+                    )
+                }
+            }
+            IoxPort::PE => {
+                if pin < 8 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL8,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL8) & !(0b11 << (pin * 2))
+                            | (function as u32) << (pin * 2),
+                    )
+                } else if pin >= 8 && pin < 16 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL9,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL9) & !(0b11 << ((pin - 8) * 2))
+                            | (function as u32) << ((pin - 8) * 2),
+                    )
+                }
+            }
+            IoxPort::PF => {
+                if pin < 8 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL10,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL10) & !(0b11 << (pin * 2))
+                            | (function as u32) << (pin * 2),
+                    )
+                } else if pin >= 8 && pin < 16 {
+                    self.csr.wo(
+                        iox::SFR_AFSEL_CRAFSEL11,
+                        self.csr.r(iox::SFR_AFSEL_CRAFSEL11) & !(0b11 << ((pin - 8) * 2))
+                            | (function as u32) << ((pin - 8) * 2),
+                    )
+                }
+            }
+        }
+    }
+
+    /// This function takes a 32-bit bitmask, corresponding to PIO 31 through 0, where
+    /// a `1` indicates to map that PIO to a GPIO.
+    ///
+    /// This function will automatically remap the AF and PIO settings for the PIO pins
+    /// specified in the bitmask, corresponding to the PIO GPIO pin number. If a `0` is
+    /// present in a bit position, it will turn off the PIO mux, but not change the AF setting.
+    ///
+    /// VERY IMPORTANT: Note that the PIO GPIO number is *not* consistent with the
+    /// numbering order of the GPIO ports: in fact, it is reverse-order for PORT B and in-order with skips for
+    /// PORT C. Also, bits 22, 27, 30 and 31 are not mappable for the PIO.
+    ///
+    /// Returns: a 32-entry array which records which GPIO bank and pin number was affected
+    /// by the mapping request. The index of the array corresponds to the bit position in
+    /// the bitmask. You may use this to pass as arguments to further functions
+    /// that do things like control slew rate or apply pull-ups.
+    pub fn set_ports_from_pio_bitmask(&mut self, enable_bitmask: u32) -> [Option<(IoxPort, u8)>; 32] {
+        let mut mapping: [Option<(IoxPort, u8)>; 32] = [None; 32];
+
+        for i in 0..32 {
+            let enable = ((enable_bitmask >> i) & 1) != 0;
+
+            if enable {
+                let map: Option<(IoxPort, u8)> = match i {
+                    // Port B: reversed
+                    0 => Some((IoxPort::PB, 15)),
+                    1 => Some((IoxPort::PB, 14)),
+                    2 => Some((IoxPort::PB, 13)),
+                    3 => Some((IoxPort::PB, 12)),
+                    4 => Some((IoxPort::PB, 11)),
+                    5 => Some((IoxPort::PB, 10)),
+                    6 => Some((IoxPort::PB, 9)),
+                    7 => Some((IoxPort::PB, 8)),
+                    8 => Some((IoxPort::PB, 7)),
+                    9 => Some((IoxPort::PB, 6)),
+                    10 => Some((IoxPort::PB, 5)),
+                    11 => Some((IoxPort::PB, 4)),
+                    12 => Some((IoxPort::PB, 3)),
+                    13 => Some((IoxPort::PB, 2)),
+                    14 => Some((IoxPort::PB, 1)),
+                    15 => Some((IoxPort::PB, 0)),
+                    // Port C
+                    16 => Some((IoxPort::PC, 0)),
+                    17 => Some((IoxPort::PC, 1)),
+                    18 => Some((IoxPort::PC, 2)),
+                    19 => Some((IoxPort::PC, 3)),
+                    20 => Some((IoxPort::PC, 4)),
+                    21 => Some((IoxPort::PC, 5)),
+                    // Skip 22
+                    23 => Some((IoxPort::PC, 7)),
+                    24 => Some((IoxPort::PC, 8)),
+                    25 => Some((IoxPort::PC, 9)),
+                    26 => Some((IoxPort::PC, 10)),
+                    // Skip 27
+                    28 => Some((IoxPort::PC, 12)),
+                    29 => Some((IoxPort::PC, 13)),
+                    _ => None,
+                };
+                if let Some((port, pin)) = map {
+                    // AF1 must be selected
+                    self.set_alternate_function(port, pin, IoxFunction::AF1);
+                    // then the PIO register must have its bit flipped to 1
+                    self.csr.wo(iox::SFR_PIOSEL, self.csr.r(iox::SFR_PIOSEL) | (1 << i));
+                    mapping[i] = Some((port, pin));
+                }
+            } else {
+                mapping[i] = None;
+                // ensure that the PIO register bit is not set
+                self.csr.wo(iox::SFR_PIOSEL, self.csr.r(iox::SFR_PIOSEL) & !(1 << i));
+            }
+        }
+        mapping
+    }
+
+    /// Returns the PIO bit that was enabled based on the port and pin specifier given;
+    /// returns `None` if the proposed mapping is invalid.
+    pub fn set_pio_bit_from_port_and_pin(&mut self, port: IoxPort, pin: u8) -> Option<u8> {
+        match port {
+            IoxPort::PA => None,
+            IoxPort::PB => {
+                if pin >= 16 {
+                    None
+                } else {
+                    self.set_alternate_function(port, pin, IoxFunction::AF1);
+                    let pio_bit = 15 - pin;
+                    self.csr.wo(iox::SFR_PIOSEL, self.csr.r(iox::SFR_PIOSEL) | (1 << pio_bit as u32));
+                    Some(pio_bit)
+                }
+            }
+            IoxPort::PC => {
+                if (pin != 6 && pin != 11 && pin != 14 && pin != 15) && pin < 16 {
+                    self.set_alternate_function(port, pin, IoxFunction::AF1);
+                    let pio_bit = pin + 16;
+                    self.csr.wo(iox::SFR_PIOSEL, self.csr.r(iox::SFR_PIOSEL) | (1 << pio_bit as u32));
+                    Some(pio_bit)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// Returns the PIO bit that was disabled based on the port and pin specifier given;
+    /// returns `None` if the proposed mapping is invalid. Does not change the AF mapping,
+    /// simply disables the bit in the PIO mux register.
+    pub fn unset_pio_bit_from_port_and_pin(&mut self, port: IoxPort, pin: u8) -> Option<u8> {
+        match port {
+            IoxPort::PA => None,
+            IoxPort::PB => {
+                if pin >= 16 {
+                    None
+                } else {
+                    let pio_bit = 15 - pin;
+                    self.csr.wo(iox::SFR_PIOSEL, self.csr.r(iox::SFR_PIOSEL) & !(1 << pio_bit as u32));
+                    Some(pio_bit)
+                }
+            }
+            IoxPort::PC => {
+                if (pin != 6 && pin != 11 && pin != 14 && pin != 15) && pin < 16 {
+                    let pio_bit = pin + 16;
+                    self.csr.wo(iox::SFR_PIOSEL, self.csr.r(iox::SFR_PIOSEL) & !(1 << pio_bit as u32));
+                    Some(pio_bit)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn set_drive_strength(&mut self, port: IoxPort, pin: u8, strength: IoxDriveStrength) {
+        assert!(pin < 16, "pin must be in range of 0-15");
+        match port {
+            IoxPort::PA => self.csr.wo(
+                iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL0,
+                self.csr.r(iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL0) & !(0b11 << (pin * 2))
+                    | (strength as u32) << (pin * 2),
+            ),
+            IoxPort::PB => self.csr.wo(
+                iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL1,
+                self.csr.r(iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL1) & !(0b11 << (pin * 2))
+                    | (strength as u32) << (pin * 2),
+            ),
+            IoxPort::PC => self.csr.wo(
+                iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL2,
+                self.csr.r(iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL2) & !(0b11 << (pin * 2))
+                    | (strength as u32) << (pin * 2),
+            ),
+            IoxPort::PD => self.csr.wo(
+                iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL3,
+                self.csr.r(iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL3) & !(0b11 << (pin * 2))
+                    | (strength as u32) << (pin * 2),
+            ),
+            IoxPort::PE => self.csr.wo(
+                iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4,
+                self.csr.r(iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4) & !(0b11 << (pin * 2))
+                    | (strength as u32) << (pin * 2),
+            ),
+            IoxPort::PF => self.csr.wo(
+                iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5,
+                self.csr.r(iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5) & !(0b11 << (pin * 2))
+                    | (strength as u32) << (pin * 2),
+            ),
+        }
+    }
+}

--- a/libs/cramium-hal/src/lib.rs
+++ b/libs/cramium-hal/src/lib.rs
@@ -1,0 +1,4 @@
+#![no_std]
+
+pub mod iox;
+pub mod udma;

--- a/libs/cramium-hal/src/lib.rs
+++ b/libs/cramium-hal/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
 
 pub mod iox;
+pub mod sce;
 pub mod udma;

--- a/libs/cramium-hal/src/sce.rs
+++ b/libs/cramium-hal/src/sce.rs
@@ -1,0 +1,1 @@
+pub mod trng;

--- a/libs/cramium-hal/src/sce/trng.rs
+++ b/libs/cramium-hal/src/sce/trng.rs
@@ -1,0 +1,188 @@
+use bitflags::*;
+use utralib::generated::*;
+
+const START_CODE: u32 = 0x5A;
+const STOP_CODE: u32 = 0xA5;
+
+bitflags! {
+    pub struct EntropySource: u32 {
+        const LOW_FREQ_EN        = 0b0000000_000_01;
+        const HIGH_FREQ_EN       = 0b0000000_000_10;
+        const LOW_FREQ_SRC_MASK  = 0b0000000_111_00;
+        const HIGH_FREQ_SRC_MASK = 0b1111111_000_00;
+    }
+}
+
+bitflags! {
+    pub struct Analog: u32 {
+        const VALID_MASK  = 0b00000000_11111111;
+        const ENABLE_MASK = 0b11111111_00000000;
+    }
+}
+
+bitflags! {
+    pub struct Options: u32 {
+        const GENERATION_COUNT_POS  = 0x0;
+        const GENERATION_COUNT_MASK = 0x0_FFFF;
+        const SEGMENT_A_SELECT      = 0x0_0000;
+        const SEGMENT_B_SELECT      = 0x1_0000;
+        const SEGMENT_SEL_MASK      = 0x1_0000;
+    }
+}
+
+bitflags! {
+    pub struct Config: u32 {
+        const GEN_EN               = 0b0_00_00_000000_00_0_0_0_1;
+        const PARITY_FILTER_EN     = 0b0_00_00_000000_00_0_0_1_0;
+        const HEALTHEST_EN         = 0b0_00_00_000000_00_0_1_0_0;
+        const DRNG_EN              = 0b0_00_00_000000_00_1_0_0_0;
+        const POSTPROC_OPT_MASK    = 0b0_00_00_000000_11_0_0_0_0;
+
+        const POSTPROC_OPT_LFSR    = 0b0_00_00_000000_00_0_0_0_0;
+        const POSTPROC_OPT_AES     = 0b0_00_00_000000_01_0_0_0_0;
+        const POSTPROC_OPT_RESEED_ALWAYS  = 0b0_00_00_000000_10_0_0_0_0;
+        const POSTPROC_OPT_RESEED_AUTO    = 0b0_00_00_000000_10_0_0_0_0;
+
+        const HEALTHTEST_LEN_POS   = 7;
+        const HEALTHTEST_LEN_MASK  = 0b0_00_00_111111_00_0_0_0_0;
+        const GEN_INTERVAL_MASK    = 0b0_00_11_000000_00_0_0_0_0;
+        const GEN_INTERVAL_1       = 0b0_00_00_000000_00_0_0_0_0;
+        const GEN_INTERVAL_2       = 0b0_00_01_000000_00_0_0_0_0;
+        const GEN_INTERVAL_4       = 0b0_00_10_000000_00_0_0_0_0;
+        const GEN_INTERVAL_8       = 0b0_00_11_000000_00_0_0_0_0;
+        const RESEED_INTERVAL_MASK = 0b0_11_00_000000_00_0_0_0_0;
+        const RESEED_INTERVAL_NEVER= 0b0_00_00_000000_00_0_0_0_0;
+        const RESEED_INTERVAL_1    = 0b0_01_00_000000_00_0_0_0_0;
+        const RESEED_INTERVAL_128  = 0b0_10_00_000000_00_0_0_0_0;
+        const RESEED_INTERVAL_1024 = 0b0_11_00_000000_00_0_0_0_0;
+        const RESEED_SEL           = 0b1_00_00_000000_00_0_0_0_0;
+    }
+}
+
+bitflags! {
+    pub struct Status: u32 {
+        const GEN_COUNT_MASK          = 0b0_0__0000_0000__1111_1111_1111_1111;
+        const HEALTHTEST_ERRCNT_MASK  = 0b0_0__1111_1111__0000_0000_0000_0000;
+        const BUFREADY                = 0b0_1__0000_0000__0000_0000_0000_0000;
+        const DRNG_REESED_REQ         = 0b1_0__0000_0000__0000_0000_0000_0000;
+    }
+}
+
+enum Mode {
+    Uninit,
+    Raw,
+    Lfsr,
+    Aes,
+}
+
+pub struct Trng {
+    csr: CSR<u32>,
+    count: u16,
+    mode: Mode,
+}
+
+impl Trng {
+    pub fn new(base_addr: usize) -> Self {
+        let csr = CSR::new(base_addr as *mut u32);
+        Trng { csr, count: 0, mode: Mode::Uninit }
+    }
+
+    pub fn setup_raw_generation(&mut self, count: u16) {
+        self.count = count;
+        self.mode = Mode::Raw;
+        // turn on all the entropy sources
+        self.csr.wo(
+            utra::trng::SFR_CRSRC,
+            (EntropySource::LOW_FREQ_EN
+                | EntropySource::HIGH_FREQ_EN
+                | EntropySource::LOW_FREQ_SRC_MASK
+                | EntropySource::HIGH_FREQ_SRC_MASK)
+                .bits(),
+        );
+        // turn on all the analog generators, and declare their outputs valid
+        self.csr.wo(utra::trng::SFR_AR_GEN, (Analog::ENABLE_MASK | Analog::VALID_MASK).bits());
+        // set options
+        self.csr.wo(
+            utra::trng::SFR_OPT,
+            (((count as u32) << Options::GENERATION_COUNT_POS.bits())
+                & Options::GENERATION_COUNT_MASK.bits())
+                | Options::SEGMENT_B_SELECT.bits(),
+        );
+        // set configuration options
+        let healthest_len =
+            if count as u32 > (Config::HEALTHTEST_LEN_MASK.bits() >> Config::HEALTHTEST_LEN_POS.bits()) {
+                Config::HEALTHTEST_LEN_MASK.bits()
+            } else {
+                count as u32
+            };
+        self.csr.wo(
+            utra::trng::SFR_PP,
+            (Config::GEN_EN | Config::GEN_INTERVAL_4 | Config::RESEED_INTERVAL_1).bits()
+                | (healthest_len << Config::HEALTHTEST_LEN_POS.bits()) & Config::HEALTHTEST_LEN_MASK.bits(),
+        );
+    }
+
+    pub fn get_u32(&mut self) -> Option<u32> {
+        match self.mode {
+            Mode::Uninit => None,
+            Mode::Raw => {
+                if self.count > 0 {
+                    self.count -= 1;
+                    while self.csr.r(utra::trng::SFR_SR) & Status::BUFREADY.bits() == 0 {}
+                    Some(self.csr.r(utra::trng::SFR_BUF))
+                } else {
+                    None
+                }
+            }
+            Mode::Lfsr => {
+                todo!("LFSR mode not yet implemented");
+            }
+            Mode::Aes => {
+                todo!("AES mode not yet implemented");
+            }
+        }
+    }
+
+    pub fn get_raw_count(&self) -> u16 {
+        (self.csr.r(utra::trng::SFR_SR) & Status::GEN_COUNT_MASK.bits()) as u16
+    }
+
+    pub fn get_count_remaining(&self) -> u16 { self.count }
+}
+
+// some old test code
+#[cfg(feature = "delete-me-when-done")]
+pub fn trng_test() {
+    let mut trng = sce::trng::Trng::new(HW_TRNG_BASE);
+    trng.setup_raw_generation(256);
+    for _ in 0..8 {
+        crate::println!("trng raw: {:x}", trng.get_u32().unwrap_or(0xDEAD_BEEF));
+    }
+    let trng_csr = CSR::new(HW_TRNG_BASE as *mut u32);
+    /*
+    let mut trng = CSR::new(HW_TRNG_BASE as *mut u32);
+    trng.wo(utra::trng::SFR_CRSRC, 0xFFFF);
+    trng.wo(utra::trng::SFR_CRANA, 0xFFFF);
+    trng.wo(utra::trng::SFR_OPT, 0x10020);
+    trng.wo(utra::trng::SFR_PP, 0x1 << 14 | 0x2 << 12 | 0x20 << 6 | 1);
+
+    while (trng.r(utra::trng::SFR_SR) & (1 << 24)) == 0 {}
+    for _ in 0..8 {
+        crate::println!("trng raw: {:x}", trng.r(utra::trng::SFR_BUF));
+    }
+    */
+    // used for auto DMA i think...
+    #[cfg(feature = "autodma")]
+    {
+        trng.wo(utra::trng::SFR_AR_GEN, 0x5A); // start
+        while trng.rf(utra::trng::SFR_FR_SFR_FR) == 0 {}
+        trng.wfo(utra::trng::SFR_FR_SFR_FR, 1);
+        trng.wo(utra::trng::SFR_AR_GEN, 0xA5); // stop
+        let seg_rngb = unsafe {
+            core::slice::from_raw_parts(utralib::HW_SEG_RNGB_MEM as *const u32, utralib::HW_SEG_RNGB_MEM_LEN)
+        };
+        for &w in seg_rngb[..16].iter() {
+            crate::println!("trng: {:x}", w)
+        }
+    }
+}

--- a/libs/cramium-hal/src/udma.rs
+++ b/libs/cramium-hal/src/udma.rs
@@ -1,0 +1,430 @@
+use core::mem::size_of;
+
+use utralib::generated::*;
+
+/// UDMA has a structure that Rust hates. The concept of UDMA is to take a bunch of
+/// different hardware functions, and access them with a template register pattern.
+/// But with small asterisks here and there depending upon the hardware block in question.
+///
+/// It is essentially polymorphism at the hardware level, but with special cases meant
+/// to be patched up with instance-specific peeks and pokes. It's probably possible
+/// to create a type system that can safe-ify this kind of structure, but just because
+/// something is possible does not mean it's a good idea to do it, nor would it be
+/// maintainable and/or ergonomic to use.
+///
+/// Anyways. Lots of unsafe code here. UDMA: specious concept, made entirely of footguns.
+
+// --------------------------- Global Shared State (!!🤌!!) --------------------------
+#[repr(usize)]
+enum GlobalReg {
+    ClockGate = 0,
+    EventIn = 1,
+}
+impl Into<usize> for GlobalReg {
+    fn into(self) -> usize { self as usize }
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum PeriphId {
+    Uart0 = 1 << 0,
+    Uart1 = 1 << 1,
+    Uart2 = 1 << 2,
+    Uart3 = 1 << 3,
+    Spim0 = 1 << 4,
+    Spim1 = 1 << 5,
+    Spim2 = 1 << 6,
+    Spim3 = 1 << 7,
+    I2c0 = 1 << 8,
+    I2c1 = 1 << 9,
+    I2c2 = 1 << 10,
+    I2c3 = 1 << 11,
+    Sdio = 1 << 12,
+    I2s = 1 << 13,
+    Cam = 1 << 14,
+    Filter = 1 << 15,
+    Scif = 1 << 16,
+    Spis0 = 1 << 17,
+    Spis1 = 1 << 18,
+    Adc = 1 << 19,
+}
+impl Into<u32> for PeriphId {
+    fn into(self) -> u32 { self as u32 }
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum PeriphEventId {
+    Uart0 = 0,
+    Uart1 = 4,
+    Uart2 = 8,
+    Uart3 = 12,
+    Spim0 = 16,
+    Spim1 = 20,
+    Spim2 = 24,
+    Spim3 = 28,
+    I2c0 = 32,
+    I2c1 = 36,
+    I2c2 = 40,
+    I2c3 = 44,
+    Sdio = 48,
+    I2s = 52,
+    Cam = 56,
+    Adc = 57, // note exception to ordering here
+    Filter = 60,
+    Scif = 64,
+    Spis0 = 68,
+    Spis1 = 72,
+}
+impl From<PeriphId> for PeriphEventId {
+    fn from(id: PeriphId) -> Self {
+        match id {
+            PeriphId::Uart0 => PeriphEventId::Uart0,
+            PeriphId::Uart1 => PeriphEventId::Uart1,
+            PeriphId::Uart2 => PeriphEventId::Uart2,
+            PeriphId::Uart3 => PeriphEventId::Uart3,
+            PeriphId::Spim0 => PeriphEventId::Spim0,
+            PeriphId::Spim1 => PeriphEventId::Spim1,
+            PeriphId::Spim2 => PeriphEventId::Spim2,
+            PeriphId::Spim3 => PeriphEventId::Spim3,
+            PeriphId::I2c0 => PeriphEventId::I2c0,
+            PeriphId::I2c1 => PeriphEventId::I2c1,
+            PeriphId::I2c2 => PeriphEventId::I2c2,
+            PeriphId::I2c3 => PeriphEventId::I2c3,
+            PeriphId::Sdio => PeriphEventId::Sdio,
+            PeriphId::I2s => PeriphEventId::I2s,
+            PeriphId::Cam => PeriphEventId::Cam,
+            PeriphId::Filter => PeriphEventId::Filter,
+            PeriphId::Scif => PeriphEventId::Scif,
+            PeriphId::Spis0 => PeriphEventId::Spis0,
+            PeriphId::Spis1 => PeriphEventId::Spis1,
+            PeriphId::Adc => PeriphEventId::Adc,
+        }
+    }
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum EventUartOffset {
+    Rx = 0,
+    Tx = 1,
+    RxChar = 2,
+    Err = 3,
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum EventSpimOffset {
+    Rx = 0,
+    Tx = 1,
+    Cmd = 2,
+    Eot = 3,
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum EventI2cOffset {
+    Rx = 0,
+    Tx = 1,
+    Cmd = 2,
+    Eot = 3,
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum EventSdioOffset {
+    Rx = 0,
+    Tx = 1,
+    Eot = 2,
+    Err = 3,
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum EventI2sOffset {
+    Rx = 0,
+    Tx = 1,
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum EventCamOffset {
+    Rx = 0,
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum EventAdcOffset {
+    Rx = 0,
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum EventFilterOffset {
+    Eot = 0,
+    Active = 1,
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+
+pub enum EventScifOffset {
+    Rx = 0,
+    Tx = 1,
+    RxChar = 2,
+    Err = 3,
+}
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum EventSpisOffset {
+    Rx = 0,
+    Tx = 1,
+    Eot = 2,
+}
+#[derive(Copy, Clone)]
+pub enum PeriphEventType {
+    Uart(EventUartOffset),
+    Spim(EventSpimOffset),
+    I2c(EventI2cOffset),
+    Sdio(EventSdioOffset),
+    I2s(EventI2sOffset),
+    Cam(EventCamOffset),
+    Adc(EventAdcOffset),
+    Filter(EventFilterOffset),
+    Scif(EventScifOffset),
+    Spis(EventSpisOffset),
+}
+impl Into<u32> for PeriphEventType {
+    fn into(self) -> u32 {
+        match self {
+            PeriphEventType::Uart(t) => t as u32,
+            PeriphEventType::Spim(t) => t as u32,
+            PeriphEventType::I2c(t) => t as u32,
+            PeriphEventType::Sdio(t) => t as u32,
+            PeriphEventType::I2s(t) => t as u32,
+            PeriphEventType::Cam(t) => t as u32,
+            PeriphEventType::Adc(t) => t as u32,
+            PeriphEventType::Filter(t) => t as u32,
+            PeriphEventType::Scif(t) => t as u32,
+            PeriphEventType::Spis(t) => t as u32,
+        }
+    }
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum EventChannel {
+    Channel0 = 0,
+    Channel1 = 8,
+    Channel2 = 16,
+    Channel3 = 24,
+}
+pub struct GlobalConfig {
+    csr: CSR<u32>,
+}
+impl GlobalConfig {
+    pub fn new(base_addr: *mut u32) -> Self { GlobalConfig { csr: CSR::new(base_addr) } }
+
+    pub fn clock_on(&mut self, peripheral: PeriphId) {
+        // Safety: only safe when used in the context of UDMA registers.
+        unsafe {
+            self.csr.base().add(GlobalReg::ClockGate.into()).write_volatile(
+                self.csr.base().add(GlobalReg::ClockGate.into()).read_volatile() | peripheral as u32,
+            );
+        }
+    }
+
+    pub fn clock_off(&mut self, peripheral: PeriphId) {
+        // Safety: only safe when used in the context of UDMA registers.
+        unsafe {
+            self.csr.base().add(GlobalReg::ClockGate.into()).write_volatile(
+                self.csr.base().add(GlobalReg::ClockGate.into()).read_volatile() & !(peripheral as u32),
+            );
+        }
+    }
+
+    pub fn raw_clock_map(&self) -> u32 {
+        // Safety: only safe when used in the context of UDMA registers.
+        unsafe { self.csr.base().add(GlobalReg::ClockGate.into()).read_volatile() }
+    }
+
+    pub fn is_clock_set(&self, peripheral: PeriphId) -> bool {
+        // Safety: only safe when used in the context of UDMA registers.
+        unsafe {
+            (self.csr.base().add(GlobalReg::ClockGate.into()).read_volatile() & (peripheral as u32)) != 0
+        }
+    }
+
+    pub fn map_event(&mut self, peripheral: PeriphId, event_type: PeriphEventType, to_channel: EventChannel) {
+        let event_type: u32 = event_type.into();
+        let id: u32 = PeriphEventId::from(peripheral) as u32 + event_type;
+        // Safety: only safe when used in the context of UDMA registers.
+        unsafe {
+            self.csr.base().add(GlobalReg::EventIn.into()).write_volatile(
+                self.csr.base().add(GlobalReg::EventIn.into()).read_volatile()
+                    & !(0xFF << (to_channel as u32))
+                    | id << (to_channel as u32),
+            )
+        }
+    }
+
+    pub fn raw_event_map(&self) -> u32 {
+        // Safety: only safe when used in the context of UDMA registers.
+        unsafe { self.csr.base().add(GlobalReg::EventIn.into()).read_volatile() }
+    }
+}
+
+// --------------------------------- DMA channel ------------------------------------
+const CFG_EN: u32 = 0b01_0000; // start a transfer
+#[allow(dead_code)]
+const CFG_CONT: u32 = 0b00_0001; // continuous mode
+#[allow(dead_code)]
+const CFG_SIZE_8: u32 = 0b00_0000; // 8-bit transfer
+#[allow(dead_code)]
+const CFG_SIZE_16: u32 = 0b00_0010; // 16-bit transfer
+#[allow(dead_code)]
+const CFG_SIZE_32: u32 = 0b00_0100; // 32-bit transfer
+#[allow(dead_code)]
+const CFG_CLEAR: u32 = 0b10_0000; // stop and clear all pending transfers
+const CFG_SHADOW: u32 = 0b10_0000; // indicates a shadow transfer
+
+#[repr(usize)]
+pub enum Bank {
+    Rx = 0,
+    Tx = 0x10 / size_of::<u32>(),
+    // woo dat special case...
+    Custom = 0x20 / size_of::<u32>(),
+}
+impl Into<usize> for Bank {
+    fn into(self) -> usize { self as usize }
+}
+
+/// Crate-local struct that defines the offset of registers in UDMA banks, as words.
+#[repr(usize)]
+enum DmaReg {
+    Saddr = 0,
+    Size = 1,
+    Cfg = 2,
+    #[allow(dead_code)]
+    IntCfg = 3,
+}
+impl Into<usize> for DmaReg {
+    fn into(self) -> usize { self as usize }
+}
+
+/// The common UDMA channel structure shared across all UDMA peripherals
+pub struct Channel {
+    /// This is assumed to point to the base of the peripheral's UDMA register set.
+    csr: CSR<u32>,
+}
+
+impl Channel {
+    pub fn new(udma_base_addr: *mut u32) -> Self { Channel { csr: CSR::new(udma_base_addr) } }
+
+    /// `bank` selects which UDMA bank is the target
+    /// `buf` is a slice that points to the memory that is the target of the UDMA. Needs to be accessible
+    ///    by the UDMA subsystem, e.g. in IFRAM0/IFRAM1 range, and is a *physical address* even in a
+    ///    system running on virtual memory (!!!)
+    /// `config` is a device-specific word that configures the DMA.
+    pub fn enqueue(&mut self, bank: Bank, buf: &[u8], config: u32) {
+        // Safety: only safe when used in the context of UDMA registers.
+        unsafe {
+            let bank_addr = self.csr.base().add(bank as usize);
+            let buf_addr = buf.as_ptr() as u32;
+            bank_addr.add(DmaReg::Saddr.into()).write_volatile(buf_addr);
+            bank_addr.add(DmaReg::Size.into()).write_volatile(buf.len() as u32);
+            bank_addr.add(DmaReg::Cfg.into()).write_volatile(config | CFG_EN)
+        }
+    }
+
+    pub fn can_enqueue(&self, bank: Bank) -> bool {
+        // Safety: only safe when used in the context of UDMA registers.
+        unsafe {
+            (self.csr.base().add(bank as usize).add(DmaReg::Cfg.into()).read_volatile() & CFG_SHADOW) == 0
+        }
+    }
+
+    pub fn busy(&self, bank: Bank) -> bool {
+        // Safety: only safe when used in the context of UDMA registers.
+        unsafe { (self.csr.base().add(bank as usize).add(DmaReg::Cfg.into()).read_volatile() & CFG_EN) != 0 }
+    }
+}
+
+// ----------------------------------- UART ------------------------------------
+#[repr(usize)]
+enum UartReg {
+    Status = 0,
+    Setup = 1,
+}
+impl Into<usize> for UartReg {
+    fn into(self) -> usize { self as usize }
+}
+
+/// UDMA UART wrapper. Contains all the warts on top of the Channel abstraction.
+pub struct Uart {
+    /// This is assumed to point to the base of the peripheral's UDMA register set.
+    csr: CSR<u32>,
+    udma: Channel,
+}
+
+impl Uart {
+    /// Configures for N81
+    ///
+    /// This function is `unsafe` because it can only be called after the
+    /// global shared UDMA state has been set up to un-gate clocks and set up
+    /// events.
+    ///
+    /// It is also `unsafe` on Drop because you have to remember to unmap
+    /// the clock manually as well once the object is dropped...
+    pub unsafe fn new(base_addr: usize, baud: u32, clk_freq: u32) -> Self {
+        // now setup the channel
+        let channel = Channel::new(base_addr as *mut u32);
+        let csr = CSR::new(base_addr as *mut u32);
+
+        let clk_counter: u32 = (clk_freq + baud / 2) / baud;
+        // safe only in the context of a UART UDMA address
+        unsafe {
+            // setup baud, bits, parity, etc.
+            csr.base()
+                .add(Bank::Custom.into())
+                .add(UartReg::Setup.into())
+                .write_volatile(0x0306 | (clk_counter << 16))
+        }
+        Uart { csr, udma: channel }
+    }
+
+    pub fn disable(&mut self) {
+        // safe only in the context of a UART UDMA address
+        unsafe {
+            self.csr.base().add(Bank::Custom.into()).add(UartReg::Setup.into()).write_volatile(0x0050_0006);
+        }
+    }
+
+    pub fn tx_busy(&self) -> bool {
+        // safe only in the context of a UART UDMA address
+        unsafe {
+            (self.csr.base().add(Bank::Custom.into()).add(UartReg::Status.into()).read_volatile() & 1) != 0
+        }
+    }
+
+    pub fn rx_busy(&self) -> bool {
+        // safe only in the context of a UART UDMA address
+        unsafe {
+            (self.csr.base().add(Bank::Custom.into()).add(UartReg::Status.into()).read_volatile() & 2) != 0
+        }
+    }
+
+    pub fn wait_tx_done(&self) {
+        while self.udma.busy(Bank::Tx) {}
+        while self.tx_busy() {}
+    }
+
+    pub fn wait_rx_done(&self) { while self.udma.busy(Bank::Rx) {} }
+
+    pub fn write(&mut self, buf: &[u8]) {
+        self.udma.enqueue(Bank::Tx, buf, CFG_EN | CFG_SIZE_8);
+        self.wait_tx_done();
+    }
+
+    pub fn read(&mut self, buf: &mut [u8]) {
+        self.udma.enqueue(Bank::Rx, buf, CFG_EN | CFG_SIZE_8);
+        self.wait_rx_done();
+    }
+}
+
+impl Drop for Uart {
+    fn drop(&mut self) {
+        self.wait_tx_done();
+        self.disable();
+        // NOTE: this does not unmap the clock on drop, because clocks are managed by global shared state.
+    }
+}

--- a/libs/xous-pio/Cargo.toml
+++ b/libs/xous-pio/Cargo.toml
@@ -22,6 +22,8 @@ rp2040 = ["defmt"]
 precursor = []
 hosted = []
 renode = []
+# may be activated in conjunction with "cramium-soc", "rp2040" targets when not running Xous
+baremetal = []
 
 tests = []
 default = ["tests", "cramium-soc"]

--- a/libs/xous-pl230/Cargo.toml
+++ b/libs/xous-pl230/Cargo.toml
@@ -12,6 +12,9 @@ bitfield = "0.13.2"
 xous-pio = { path = "../xous-pio", optional = true, default-features = false }
 pio-proc = "0.2.2"
 pio = "0.2.1"
+cramium-hal = { path = "../cramium-hal", optional = true, features = [
+    "baremetal",
+] }
 
 [target.'cfg(target_os = "xous")'.dependencies]
 xous = "0.9.57"
@@ -26,5 +29,5 @@ pio = ["xous-pio"]
 dma-mainram = []
 baremetal = []
 
-tests = ["pio"]
+tests = ["pio", "cramium-hal"]
 default = ["tests", "pio"]

--- a/libs/xous-pl230/Cargo.toml
+++ b/libs/xous-pl230/Cargo.toml
@@ -24,6 +24,7 @@ hosted = []
 renode = []
 pio = ["xous-pio"]
 dma-mainram = []
+baremetal = []
 
 tests = ["pio"]
 default = ["tests", "pio"]

--- a/libs/xous-pl230/src/lib.rs
+++ b/libs/xous-pl230/src/lib.rs
@@ -1,6 +1,6 @@
-#![cfg_attr(target_os = "none", no_std)]
+#![cfg_attr(feature = "baremetal", no_std)]
 
-#[cfg(not(any(target_os = "xous")))]
+#[cfg(feature = "baremetal")]
 mod debug;
 
 #[cfg(feature = "tests")]
@@ -30,7 +30,7 @@ pub struct Pl230 {
 }
 
 impl Pl230 {
-    #[cfg(not(any(target_os = "xous")))]
+    #[cfg(feature = "baremetal")]
     pub fn new() -> Self {
         Pl230 {
             csr: CSR::new(utralib::HW_PL230_BASE as *mut u32),
@@ -38,7 +38,7 @@ impl Pl230 {
         }
     }
 
-    #[cfg(target_os = "xous")]
+    #[cfg(not(feature = "baremetal"))]
     pub fn new() -> Self {
         let csr = xous::syscall::map_memory(
             xous::MemoryAddress::new(utralib::HW_PL230_BASE),

--- a/libs/xous-pl230/src/pl230_tests/mod.rs
+++ b/libs/xous-pl230/src/pl230_tests/mod.rs
@@ -1,13 +1,13 @@
 pub mod units;
 
 pub fn report_api(desc: &str, d: u32) {
-    #[cfg(not(any(target_os = "xous")))]
+    #[cfg(feature = "baremetal")]
     {
         use core::fmt::Write;
         let mut uart = crate::debug::Uart {};
         writeln!(uart, "pl230: [{}] 0x{:x}", desc, d).ok();
     }
-    #[cfg(target_os = "xous")]
+    #[cfg(not(feature = "baremetal"))]
     log::info!("pl230: [{}] 0x{:x}", desc, d);
 }
 

--- a/libs/xous-pl230/src/pl230_tests/units.rs
+++ b/libs/xous-pl230/src/pl230_tests/units.rs
@@ -136,6 +136,7 @@ pub fn pio_test(pl230: &mut Pl230) -> bool {
     report_api("id1", pl230.csr.r(utra::pl230::PERIPH_ID_1));
     report_api("id2", pl230.csr.r(utra::pl230::PERIPH_ID_2));
 
+    // Configure PB15 -> PIO0 for test (although the code is capable of toggling all pins, only map one).
     let mut iox = iox::Iox::new(utralib::generated::HW_IOX_BASE as *mut u32);
     let pin = iox.set_pio_bit_from_port_and_pin(iox::IoxPort::PB, 15).unwrap();
     report_api("Configured PIO pin: ", pin as u32);
@@ -156,6 +157,7 @@ pub fn pio_test(pl230: &mut Pl230) -> bool {
     sm_a.config_set_out_pins(0, 32);
     sm_a.config_set_clkdiv(133.0); // have it run slow so this test operates in the background
     sm_a.config_set_out_shift(false, true, 32);
+    // map the pin returned from set_pio_bit_from_port_and_pin
     sm_a.sm_set_pindirs_with_mask(1 << pin as usize, 1 << pin as usize);
     sm_a.sm_init(a_prog.entry());
     sm_a.sm_clear_fifos(); // ensure the fifos are cleared for this test

--- a/libs/xous-pl230/src/pl230_tests/units.rs
+++ b/libs/xous-pl230/src/pl230_tests/units.rs
@@ -12,9 +12,9 @@ pub fn lfsr_next(state: u32) -> u32 {
 
 pub fn basic_tests(pl230: &mut Pl230) -> bool {
     report_api("channels", pl230.csr.rf(utra::pl230::STATUS_CHNLS_MINUS1) + 1);
-    //report_api("id0", pl230.csr.r(utra::pl230::PERIPH_ID_0));
-    //report_api("id1", pl230.csr.r(utra::pl230::PERIPH_ID_1));
-    //report_api("id2", pl230.csr.r(utra::pl230::PERIPH_ID_2));
+    report_api("id0", pl230.csr.r(utra::pl230::PERIPH_ID_0));
+    report_api("id1", pl230.csr.r(utra::pl230::PERIPH_ID_1));
+    report_api("id2", pl230.csr.r(utra::pl230::PERIPH_ID_2));
 
     // conjure the DMA control structure in IFRAM0. In order to guarantee Rust
     // semantics, it must be initialized to 0: 4 word-sized entries * 8 channels * 2 banks = 4 * 8 * 2
@@ -27,9 +27,9 @@ pub fn basic_tests(pl230: &mut Pl230) -> bool {
         unsafe { (utralib::HW_IFRAM0_MEM as *mut ControlChannels).as_mut().unwrap() };
 
     // read the status register
-    // report_api("status", pl230.csr.r(utra::pl230::STATUS));
+    report_api("status", pl230.csr.r(utra::pl230::STATUS));
     pl230.csr.wfo(utra::pl230::CFG_MASTER_ENABLE, 1); // enable
-    // report_api("status after enable", pl230.csr.r(utra::pl230::STATUS));
+    report_api("status after enable", pl230.csr.r(utra::pl230::STATUS));
 
     const DMA_LEN: usize = 16;
     // setup the PL230 to do a simple transfer between two memory regions
@@ -128,16 +128,17 @@ pub fn basic_tests(pl230: &mut Pl230) -> bool {
 
 #[cfg(feature = "pio")]
 pub fn pio_test(pl230: &mut Pl230) -> bool {
+    use cramium_hal::iox;
     use xous_pio::*;
 
-    let iox_csr = utra::iox::HW_IOX_BASE as *mut u32;
-    unsafe {
-        iox_csr.add(0x8 / core::mem::size_of::<u32>()).write_volatile(0b0101_0101_0101_0101); // PBL
-        iox_csr.add(0xC / core::mem::size_of::<u32>()).write_volatile(0b0101_0101_0101_0101); // PBH
-        iox_csr.add(0x10 / core::mem::size_of::<u32>()).write_volatile(0b0101_0101_0101_0101); // PCL
-        iox_csr.add(0x14 / core::mem::size_of::<u32>()).write_volatile(0b0101_0101_0101_0101); // PCH
-        iox_csr.add(0x200 / core::mem::size_of::<u32>()).write_volatile(0xffffffff); // PIO sel port D31-0
-    }
+    report_api("channels", pl230.csr.rf(utra::pl230::STATUS_CHNLS_MINUS1) + 1);
+    report_api("id0", pl230.csr.r(utra::pl230::PERIPH_ID_0));
+    report_api("id1", pl230.csr.r(utra::pl230::PERIPH_ID_1));
+    report_api("id2", pl230.csr.r(utra::pl230::PERIPH_ID_2));
+
+    let mut iox = iox::Iox::new(utralib::generated::HW_IOX_BASE as *mut u32);
+    let pin = iox.set_pio_bit_from_port_and_pin(iox::IoxPort::PB, 15).unwrap();
+    report_api("Configured PIO pin: ", pin as u32);
 
     // setup PIO block as DMA target -- just take the data coming into the TX
     // FIFO and send it to the GPIO pins.
@@ -153,10 +154,9 @@ pub fn pio_test(pl230: &mut Pl230) -> bool {
     sm_a.sm_set_enabled(false);
     a_prog.setup_default_config(&mut sm_a);
     sm_a.config_set_out_pins(0, 32);
-    sm_a.sm_set_pindirs_with_mask(0xFFFF_FFFF, 0xFFFF_FFFF);
     sm_a.config_set_clkdiv(133.0); // have it run slow so this test operates in the background
     sm_a.config_set_out_shift(false, true, 32);
-    sm_a.sm_set_pindirs_with_mask(0x10, 0x10);
+    sm_a.sm_set_pindirs_with_mask(1 << pin as usize, 1 << pin as usize);
     sm_a.sm_init(a_prog.entry());
     sm_a.sm_clear_fifos(); // ensure the fifos are cleared for this test
 
@@ -185,14 +185,17 @@ pub fn pio_test(pl230: &mut Pl230) -> bool {
     // safety: we guarantee that the pointer is aligned and initialized
     let cc_struct: &mut ControlChannels =
         unsafe { (utralib::HW_IFRAM0_MEM as *mut ControlChannels).as_mut().unwrap() };
+    report_api("status", pl230.csr.r(utra::pl230::STATUS));
     pl230.csr.wfo(utra::pl230::CFG_MASTER_ENABLE, 1); // enable
+    report_api("status after enable", pl230.csr.r(utra::pl230::STATUS));
 
     const DMA_LEN: usize = 1024;
-    let mut region_a = [0u32; DMA_LEN];
+    // DMA can't happen from main RAM, only IFRAM.
+    let region_a = unsafe { core::slice::from_raw_parts_mut(utralib::HW_IFRAM0_MEM as *mut u32, DMA_LEN) };
     let mut state = 0x1111_0000;
     for d in region_a.iter_mut() {
         *d = state;
-        state += 0x0101_0101;
+        state = crate::pl230_tests::units::lfsr_next(state);
     }
 
     cc_struct.channels[0].dst_end_ptr =
@@ -234,6 +237,14 @@ pub fn pio_test(pl230: &mut Pl230) -> bool {
     // now enable the PIO block so that DMA reqs can run
     sm_a.sm_irq0_source_enabled(PioIntSource::TxNotFull, true);
     sm_a.sm_set_enabled(true);
+
+    let mut timeout = 0;
+    while (DmaChanControl(cc_struct.channels[0].control).cycle_ctrl() != 0) && timeout < 32 {
+        // report_api("dma progress ", cc_struct.channels[0].control);
+        report_api("progress as baseptr[2]", unsafe { cc_struct.channels.as_ptr().read() }.control);
+        timeout += 1;
+    }
+
     report_api("pio irq", if sm_a.sm_irq0_status(None) { 1 } else { 0 });
 
     // irq0 will now fire and cause the DMA data to clock into the PIO block until the length is exhausted.

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -20,6 +20,17 @@ sha2-loader = { path = "./sha2-loader", default-features = false, optional = tru
 cramium-hal = { path = "../libs/cramium-hal", optional = true, features = [
     "baremetal",
 ] }
+xous-pl230 = { path = "../libs/xous-pl230", optional = true, features = [
+    "tests",
+    "pio",
+    "cramium-soc",
+    "baremetal",
+] }
+xous-pio = { path = "../libs/xous-pio", optional = true, features = [
+    "tests",
+    "cramium-soc",
+    "baremetal",
+] }
 
 [dependencies.com_rs]
 git = "https://github.com/betrusted-io/com_rs"
@@ -50,6 +61,8 @@ cramium-soc = [
     "debug-print",
     "simulation-only",
     "cramium-hal",
+    "xous-pio",
+    "xous-pl230",
 ]
 cramium-fpga = [
     "utralib/cramium-fpga",
@@ -66,5 +79,5 @@ secboot = []
 simulation-only = []
 board-bringup = []
 #default = ["debug-print"]
-resume = []               # suspend/resume pathway code
-default = ["debug-print"]
+resume = []                                # suspend/resume pathway code
+default = ["debug-print", "board-bringup"]

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -17,7 +17,9 @@ utralib = { version = "0.1.24", optional = true, default-features = false }
 armv7 = { git = "https://github.com/Foundation-Devices/armv7.git", branch = "update", optional = true }
 atsama5d27 = { git = "https://github.com/Foundation-Devices/atsama5d27.git", branch = "master", optional = true }
 sha2-loader = { path = "./sha2-loader", default-features = false, optional = true }
-cramium-hal = { path = "../libs/cramium-hal", optional = true }
+cramium-hal = { path = "../libs/cramium-hal", optional = true, features = [
+    "baremetal",
+] }
 
 [dependencies.com_rs]
 git = "https://github.com/betrusted-io/com_rs"
@@ -64,5 +66,5 @@ secboot = []
 simulation-only = []
 board-bringup = []
 #default = ["debug-print"]
-resume = []  # suspend/resume pathway code
-default = []
+resume = []               # suspend/resume pathway code
+default = ["debug-print"]

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -17,6 +17,7 @@ utralib = { version = "0.1.24", optional = true, default-features = false }
 armv7 = { git = "https://github.com/Foundation-Devices/armv7.git", branch = "update", optional = true }
 atsama5d27 = { git = "https://github.com/Foundation-Devices/atsama5d27.git", branch = "master", optional = true }
 sha2-loader = { path = "./sha2-loader", default-features = false, optional = true }
+cramium-hal = { path = "../libs/cramium-hal", optional = true }
 
 [dependencies.com_rs]
 git = "https://github.com/betrusted-io/com_rs"
@@ -42,8 +43,18 @@ renode = [
     "secboot",
     "sha2-loader",
 ]
-cramium-soc = ["utralib/cramium-soc", "debug-print", "simulation-only"]
-cramium-fpga = ["utralib/cramium-fpga", "debug-print", "simulation-only"]
+cramium-soc = [
+    "utralib/cramium-soc",
+    "debug-print",
+    "simulation-only",
+    "cramium-hal",
+]
+cramium-fpga = [
+    "utralib/cramium-fpga",
+    "debug-print",
+    "simulation-only",
+    "cramium-hal",
+]
 atsama5d27 = ["utralib/atsama5d27", "armv7", "dep:atsama5d27"]
 platform-tests = []
 debug-print = []
@@ -51,6 +62,7 @@ earlyprintk = []
 renode-bypass = []
 secboot = []
 simulation-only = []
+board-bringup = []
 #default = ["debug-print"]
 resume = []  # suspend/resume pathway code
 default = []

--- a/loader/src/platform/cramium/cramium.rs
+++ b/loader/src/platform/cramium/cramium.rs
@@ -1,4 +1,5 @@
 use cramium_hal::iox::{Iox, IoxDir, IoxEnable, IoxFunction, IoxPort};
+use cramium_hal::sce;
 use cramium_hal::udma;
 use utralib::generated::*;
 
@@ -133,6 +134,13 @@ pub fn early_init() {
     // makes things a little bit cleaner for JTAG ops, it seems.
     #[cfg(feature = "board-bringup")]
     {
+        // do a quick TRNG test.
+        let mut trng = sce::trng::Trng::new(HW_TRNG_BASE);
+        trng.setup_raw_generation(256);
+        for _ in 0..8 {
+            crate::println!("trng raw: {:x}", trng.get_u32().unwrap_or(0xDEAD_BEEF));
+        }
+
         let rx_buf = unsafe {
             // safety: it's safe only because we are manually tracking the allocations in IFRAM0. Yuck!
             core::slice::from_raw_parts_mut(

--- a/loader/src/platform/cramium/cramium.rs
+++ b/loader/src/platform/cramium/cramium.rs
@@ -143,6 +143,12 @@ pub fn early_init() {
         let trng_csr = CSR::new(HW_TRNG_BASE as *mut u32);
         crate::println!("trng status: {:x}", trng_csr.r(utra::trng::SFR_SR));
 
+        // do a PL230/PIO test. Toggles PB15 (PIO0) with an LFSR sequence.
+        let mut pl230 = xous_pl230::Pl230::new();
+        xous_pl230::pl230_tests::units::basic_tests(&mut pl230);
+        xous_pl230::pl230_tests::units::pio_test(&mut pl230);
+
+        // Confirm that Rx can work while also adding a boot wait point.
         let rx_buf = unsafe {
             // safety: it's safe only because we are manually tracking the allocations in IFRAM0. Yuck!
             core::slice::from_raw_parts_mut(

--- a/loader/src/platform/cramium/cramium.rs
+++ b/loader/src/platform/cramium/cramium.rs
@@ -140,6 +140,8 @@ pub fn early_init() {
         for _ in 0..8 {
             crate::println!("trng raw: {:x}", trng.get_u32().unwrap_or(0xDEAD_BEEF));
         }
+        let trng_csr = CSR::new(HW_TRNG_BASE as *mut u32);
+        crate::println!("trng status: {:x}", trng_csr.r(utra::trng::SFR_SR));
 
         let rx_buf = unsafe {
             // safety: it's safe only because we are manually tracking the allocations in IFRAM0. Yuck!

--- a/loader/src/platform/cramium/cramium.rs
+++ b/loader/src/platform/cramium/cramium.rs
@@ -100,6 +100,10 @@ pub fn early_init() {
     // tx as output
     iox.set_gpio_dir(IoxPort::PA, 4, IoxDir::Output);
 
+    // This is necessary because an input has to be "high" on an alternate mux for it to work... :-/
+    iox.set_gpio_dir(IoxPort::PD, 13, IoxDir::Input);
+    iox.set_gpio_pullup(IoxPort::PD, 13, IoxEnable::Enable);
+
     // Set up the UDMA_UART block to the correct baud rate and enable status
     let mut udma_global = udma::GlobalConfig::new(utra::udma_ctrl::HW_UDMA_CTRL_BASE as *mut u32);
     udma_global.clock_on(udma::PeriphId::Uart0);
@@ -122,7 +126,9 @@ pub fn early_init() {
         udma::Uart::new(utra::udma_uart_0::HW_UDMA_UART_0_BASE, baudrate, freq)
     };
 
-    // Board bringup: send characters to confirm the UART is configured & ready to go for the logging crate!
+    // Board bring-up: send characters to confirm the UART is configured & ready to go for the logging crate!
+    // The "boot gutter" also has a role to pause the system in "real mode" before VM is mapped in Xous
+    // makes things a little bit cleaner for JTAG ops, it seems.
     #[cfg(feature = "board-bringup")]
     {
         let tx_buf = unsafe {
@@ -133,17 +139,17 @@ pub fn early_init() {
             // safety: it's safe only because we are manually tracking the allocations in IFRAM0. Yuck!
             core::slice::from_raw_parts_mut((utralib::HW_IFRAM0_MEM + 256) as *mut u8, 1)
         };
-        const BANNER: &'static str = "\n\rHit any key to continue boot...\r";
+        const BANNER: &'static str = "\n\rHit any key to continue boot...\r\n";
         tx_buf[..BANNER.len()].copy_from_slice(BANNER.as_bytes());
         udma_uart.write(&tx_buf[0..BANNER.len()]);
 
-        // receive characters
-        for _ in 0..16 {
+        // receive characters -- print them back. just to prove that this works.
+        for _ in 0..4 {
             udma_uart.read(rx_buf);
-            tx_buf[0] = rx_buf[0];
             const DBG_MSG: &'static str = "Got: ";
             tx_buf[..DBG_MSG.len()].copy_from_slice(DBG_MSG.as_bytes());
             udma_uart.write(&tx_buf[0..DBG_MSG.len()]);
+            tx_buf[0] = rx_buf[0];
             udma_uart.write(&tx_buf[0..1]);
             tx_buf[0] = '\n' as u32 as u8;
             tx_buf[1] = '\r' as u32 as u8;

--- a/services/cram-hal-service/Cargo.toml
+++ b/services/cram-hal-service/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "cram-hal-service"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+utralib = { version = "0.1.24", optional = true, default-features = false, features = [
+    "cramium-soc",
+] }
+xous-api-names = "0.9.55"
+xous-api-ticktimer = "0.9.53"
+xous = "0.9.57"
+log-server = { package = "xous-api-log", version = "0.1.53" }
+log = "0.4.14"
+cramium-hal = { path = "../../libs/cramium-hal" }
+
+num-derive = { version = "0.3.3", default-features = false }
+num-traits = { version = "0.2.14", default-features = false }
+rkyv = { version = "0.4.3", default-features = false, features = [
+    "const_generics",
+] }

--- a/services/cram-hal-service/src/api.rs
+++ b/services/cram-hal-service/src/api.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, num_derive::FromPrimitive, num_derive::ToPrimitive)]
+pub enum Opcode {
+    /// Allocate an IFRAM block
+    MapIfram,
+    /// Deallocate an IFRAM block
+    UnmapIfram,
+
+    /// Gutter for Invalid Calls
+    InvalidCall,
+
+    /// Exit server
+    Quit,
+}

--- a/services/cram-hal-service/src/lib.rs
+++ b/services/cram-hal-service/src/lib.rs
@@ -1,0 +1,148 @@
+pub mod api;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+pub use api::*;
+use num_traits::*;
+use xous::{send_message, MemoryAddress, MemoryRange, MemorySize, Message, Result};
+
+static REFCOUNT: AtomicU32 = AtomicU32::new(0);
+
+pub const SERVER_NAME_CRAM_HAL: &str = "_Cramium-SoC HAL_";
+
+pub enum IframBank {
+    Bank0,
+    Bank1,
+}
+
+/// `IframRange` is a range of memory that is suitable for use as a DMA target.
+pub struct IframRange {
+    pub(crate) phys_addr: MemoryAddress,
+    pub(crate) memory: MemoryRange,
+    pub(crate) size: MemorySize,
+    pub(crate) conn: xous::CID,
+}
+
+impl IframRange {
+    /// Request `length` bytes of memory in an optional Bank
+    ///
+    /// Safety: the caller must ensure that the `IframRange` object lives for the
+    /// entire lifetime of the *hardware* operation.
+    ///
+    /// Example of how things can go wrong: `IframRange` is used to allocate
+    /// a buffer for data that takes a long time to send via a slow UART.
+    /// The DMA is initiated, and the function exits, dropping `IframRange`.
+    /// At this point, the range could be re-allocated for another purpose.
+    ///
+    /// An `IframRange` would naturally live as long as a DMA request
+    /// if a sender synchronizes on the completion of the DMA request. Thus,
+    /// the `unsafe` bit happens in "fire-and-forget" contexts, and the
+    /// caller has to explicitly manage the lifetime of this object to
+    /// match the maximum duration of the call.
+    ///
+    /// A simple way to do this is to simply bind the structure to a long-lived
+    /// scope, but the trade-off is that IFRAM is very limited in capacity
+    /// and hanging on to chunks much longer than necessary can lead to memory
+    /// exhaustion.
+    pub unsafe fn request(length: usize, bank: Option<IframBank>) -> Option<Self> {
+        REFCOUNT.fetch_add(1, Ordering::Relaxed);
+        let xns = xous_api_names::XousNames::new().unwrap();
+        let conn =
+            xns.request_connection(SERVER_NAME_CRAM_HAL).expect("Couldn't connect to Cramium HAL server");
+        let bank_code = match bank {
+            Some(IframBank::Bank0) => 0,
+            Some(IframBank::Bank1) => 1,
+            _ => 2,
+        };
+        match send_message(
+            conn,
+            Message::new_blocking_scalar(Opcode::MapIfram.to_usize().unwrap(), length, bank_code, 0, 0),
+        ) {
+            Ok(Result::Scalar5(maybe_size, maybe_phys_address, _, _, _)) => {
+                if maybe_size != 0 && maybe_phys_address != 0 {
+                    let mut page_aligned_size = maybe_size / 4096;
+                    if maybe_size % 4096 != 0 {
+                        page_aligned_size += 1;
+                    }
+                    let virtual_pages = xous::map_memory(
+                        core::num::NonZeroUsize::new(maybe_phys_address),
+                        None,
+                        page_aligned_size,
+                        xous::MemoryFlags::R | xous::MemoryFlags::W,
+                    )
+                    .unwrap();
+                    Some(IframRange {
+                        phys_addr: MemoryAddress::new(maybe_phys_address).unwrap(),
+                        memory: virtual_pages,
+                        size: MemorySize::new(maybe_size).unwrap(),
+                        conn,
+                    })
+                } else {
+                    if REFCOUNT.fetch_sub(1, Ordering::Relaxed) == 1 {
+                        // "almost" safe because we checked our reference count before disconnecting
+                        // there is a race condition possibly if someone allocates a connection between
+                        // the check above, and the disconnect below.
+                        unsafe { xous::disconnect(conn).unwrap() }
+                    };
+                    None
+                }
+            }
+            _ => {
+                if REFCOUNT.fetch_sub(1, Ordering::Relaxed) == 1 {
+                    // "almost" safe because we checked our reference count before disconnecting
+                    // there is a race condition possibly if someone allocates a connection between
+                    // the check above, and the disconnect below.
+                    unsafe { xous::disconnect(conn).unwrap() }
+                };
+                None
+            }
+        }
+    }
+
+    /// Returns the IframRange as a slice, useful for passing to the UDMA API calls.
+    /// This is `unsafe` because the slice is actually not accessible in virtual memory mode:
+    /// any attempt to reference the returned slice will result in a panic. The returned
+    /// slice is *only* useful as a range-checked base/bounds for UDMA API calls.
+    pub unsafe fn as_phys_slice(&self) -> &[u8] {
+        core::slice::from_raw_parts(self.phys_addr.get() as *const u8, self.size.get())
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        // safe because `u8` is always representable on our system
+        unsafe { self.memory.as_slice() }
+    }
+
+    pub fn as_slice_mut(&mut self) -> &mut [u8] {
+        // safe because `u8` is always representable on our system
+        unsafe { self.memory.as_slice_mut() }
+    }
+}
+
+impl Drop for IframRange {
+    fn drop(&mut self) {
+        match send_message(
+            self.conn,
+            Message::new_blocking_scalar(
+                Opcode::UnmapIfram.to_usize().unwrap(),
+                self.size.get(),
+                self.phys_addr.get(),
+                0,
+                0,
+            ),
+        ) {
+            Ok(_) => (),
+            Err(e) => {
+                // This probably never happens, but also probably doesn't need to be a hard-panic
+                // if it does happen because it simply degrades performance; it does not impact
+                // correctness.
+                log::error!("Couldn't de-allocate IframRange: {:?}, IFRAM memory is leaking!", e)
+            }
+        }
+        // de-allocate myself. It's unsafe because we are responsible to make sure nobody else is using the
+        // connection.
+        if REFCOUNT.fetch_sub(1, Ordering::Relaxed) == 1 {
+            unsafe {
+                xous::disconnect(self.conn).unwrap();
+            }
+        }
+    }
+}

--- a/services/cram-hal-service/src/main.rs
+++ b/services/cram-hal-service/src/main.rs
@@ -1,0 +1,168 @@
+mod api;
+use api::*;
+use xous::sender::Sender;
+
+fn try_alloc(ifram_allocs: &mut Vec<Option<Sender>>, size: usize, sender: Sender) -> Option<usize> {
+    let mut size_pages = size / 4096;
+    if size % 4096 != 0 {
+        size_pages += 1;
+    }
+    let mut free_start = None;
+    let mut found_len = 0;
+    for (index, page) in ifram_allocs.iter().enumerate() {
+        if page.is_some() {
+            free_start = None;
+            found_len = 0;
+            continue;
+        } else {
+            if free_start.is_some() {
+                found_len += 1;
+                if found_len >= size_pages {
+                    break;
+                }
+            } else {
+                free_start = Some(index);
+                found_len = 1;
+            }
+        }
+    }
+    if let Some(start) = free_start {
+        if found_len >= size_pages {
+            // starting point found, and enough pages
+            assert!(
+                found_len == size_pages,
+                "Found pages should be exactly equal to size_pages at this point"
+            );
+            for i in ifram_allocs[start..start + found_len].iter_mut() {
+                *i = Some(sender);
+            }
+            // offset relative to start of IFRAM bank
+            Some(start * 4096)
+        } else {
+            // starting point found, but not enough pages
+            None
+        }
+    } else {
+        // no starting point found
+        None
+    }
+}
+fn main() {
+    log_server::init_wait().unwrap();
+    log::set_max_level(log::LevelFilter::Debug);
+
+    let xns = xous_api_names::XousNames::new().unwrap();
+    let sid = xns.register_name(cram_hal_service::SERVER_NAME_CRAM_HAL, None).expect("can't register server");
+
+    let mut ifram_allocs = [Vec::new(), Vec::new()];
+    // code is written assuming the IFRAM blocks have the same size. Since this is fixed in
+    // hardware, it's a good assumption; but the assert is put here in case we port this to
+    // a new system where for some reason they have different sizes.
+    assert!(utralib::generated::HW_IFRAM0_MEM_LEN == utralib::generated::HW_IFRAM1_MEM_LEN);
+    let pages = utralib::generated::HW_IFRAM0_MEM_LEN / 4096;
+    for _ in 0..pages {
+        ifram_allocs[0].push(None);
+        ifram_allocs[1].push(None);
+    }
+    // Top page of IFRAM0 is occupied by the log server's Tx buffer. We can't know the
+    // `Sender` of it, so fill it with a value for `Some` that can't map to any PID.
+    ifram_allocs[0][31] = Some(Sender::from_usize(usize::MAX));
+
+    let mut msg_opt = None;
+    log::debug!("Starting main loop");
+    loop {
+        xous::reply_and_receive_next(sid, &mut msg_opt).unwrap();
+        let msg = msg_opt.as_mut().unwrap();
+        let opcode = num_traits::FromPrimitive::from_usize(msg.body.id()).unwrap_or(api::Opcode::InvalidCall);
+        log::debug!("{:?}", opcode);
+        match opcode {
+            Opcode::MapIfram => {
+                if let Some(scalar) = msg.body.scalar_message_mut() {
+                    let requested_size = scalar.arg1; // requested size
+                    let requested_bank = scalar.arg2; // Specifies bank 0, 1, or don't care (any number but 0 or 1)
+
+                    let mut allocated_address = None;
+                    for (bank, table) in ifram_allocs.iter_mut().enumerate() {
+                        if bank == requested_bank || bank > 1 {
+                            match try_alloc(table, requested_size, msg.sender) {
+                                Some(offset) => {
+                                    let base = if bank == 0 {
+                                        utralib::generated::HW_IFRAM0_MEM
+                                    } else {
+                                        utralib::generated::HW_IFRAM1_MEM
+                                    };
+                                    allocated_address = Some(base + offset);
+                                    break;
+                                }
+                                None => {}
+                            }
+                        }
+                    }
+                    // responds with size in arg1 (0 means could not be allocated/OOM)
+                    // and address of allocation in arg2
+                    if let Some(addr) = allocated_address {
+                        log::debug!(
+                            "Allocated IFRAM at 0x{:x} to hold at least 0x{:x} bytes",
+                            addr,
+                            requested_size
+                        );
+                        log::debug!("Alloc[0]: {:x?}", ifram_allocs[0]);
+                        log::debug!("Alloc[1]: {:x?}", ifram_allocs[1]);
+                        scalar.arg1 = requested_size;
+                        scalar.arg2 = addr;
+                    } else {
+                        log::debug!(
+                            "Could not allocate IFRAM request of 0x{:x} bytes in bank {}",
+                            requested_size,
+                            requested_bank
+                        );
+                        scalar.arg1 = 0;
+                        scalar.arg2 = 0;
+                    }
+                }
+            }
+            Opcode::UnmapIfram => {
+                if let Some(scalar) = msg.body.scalar_message() {
+                    let mapped_size = scalar.arg1;
+                    let phys_addr = scalar.arg2;
+
+                    let bank: usize;
+                    let offset = if utralib::generated::HW_IFRAM0_MEM <= phys_addr
+                        && phys_addr
+                            < utralib::generated::HW_IFRAM0_MEM + utralib::generated::HW_IFRAM0_MEM_LEN
+                    {
+                        bank = 0;
+                        phys_addr - utralib::generated::HW_IFRAM0_MEM
+                    } else if utralib::generated::HW_IFRAM1_MEM <= phys_addr
+                        && phys_addr
+                            < utralib::generated::HW_IFRAM1_MEM + utralib::generated::HW_IFRAM1_MEM_LEN
+                    {
+                        bank = 1;
+                        phys_addr - utralib::generated::HW_IFRAM1_MEM
+                    } else {
+                        log::error!("Mapped IFRAM address 0x{:x} is invalid", phys_addr);
+                        panic!("Mapped IFRAM address is invalid");
+                    };
+                    let mut mapped_pages = mapped_size / 4096;
+                    if mapped_size % 4096 != 0 {
+                        mapped_pages += 1;
+                    }
+                    for record in ifram_allocs[bank][offset..offset + mapped_pages].iter_mut() {
+                        *record = None;
+                    }
+                }
+            }
+            Opcode::InvalidCall => {
+                log::error!("Invalid opcode received: {:?}", msg);
+            }
+            Opcode::Quit => {
+                log::info!("Received quit opcode, exiting.");
+                break;
+            }
+        }
+    }
+    xns.unregister_server(sid).unwrap();
+    xous::destroy_server(sid).unwrap();
+    log::trace!("quitting");
+    xous::terminate_process(0)
+}

--- a/services/cram-mbox1/src/main.rs
+++ b/services/cram-mbox1/src/main.rs
@@ -143,6 +143,7 @@ fn main() {
     let xns = xous_api_names::XousNames::new().unwrap();
     let mbox_sid = xns.register_name("_mbox_", None).expect("can't register server");
     let mbox_cid = xous::connect(mbox_sid).unwrap();
+    log::info!("mbox SID: {:x?}", mbox_sid);
 
     #[cfg(feature = "cramium-fpga")]
     let csr = xous::syscall::map_memory(

--- a/services/cram-mbox2/src/main.rs
+++ b/services/cram-mbox2/src/main.rs
@@ -154,6 +154,7 @@ fn main() {
     let xns = xous_api_names::XousNames::new().unwrap();
     let client_sid = xns.register_name("_mbox_client_", None).expect("can't register server");
     let client_cid = xous::connect(client_sid).unwrap();
+    log::info!("mbox client SID: {:x?}", client_sid);
 
     let mb_client_csr = xous::syscall::map_memory(
         #[cfg(not(feature = "ext"))]

--- a/services/xous-log/Cargo.toml
+++ b/services/xous-log/Cargo.toml
@@ -24,6 +24,8 @@ rkyv = { version = "0.4.3", default-features = false, features = [
     "const_generics",
 ], optional = true }
 
+cramium-hal = { path = "../../libs/cramium-hal", optional = true }
+
 [target.'cfg(target_arch = "arm")'.dependencies]
 atsama5d27 = { git = "https://github.com/Foundation-Devices/atsama5d27.git", branch = "master", features = [
     "lcd-console",
@@ -33,7 +35,7 @@ xous = { version = "0.9.57", features = [
 ] } # v2p feature is used when lcd-console feature is turned on
 
 [features]
-cramium-soc = ["utralib/cramium-soc"]
+cramium-soc = ["utralib/cramium-soc", "cramium-hal"]
 cramium-fpga = ["utralib/cramium-fpga"]
 precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]

--- a/services/xous-log/src/platform/cramium/implementation.rs
+++ b/services/xous-log/src/platform/cramium/implementation.rs
@@ -1,11 +1,15 @@
 use core::fmt::{Error, Write};
 
+use cramium_hal::udma;
 use utralib::generated::*;
 
 pub struct Output {}
 
 #[cfg(feature = "cramium-soc")]
-pub static mut UART_DMA_BUF: *mut u8 = 0x0000_0000 as *mut u8;
+pub static mut UART_DMA_TX_BUF_VIRT: *mut u8 = 0x0000_0000 as *mut u8;
+
+#[cfg(feature = "cramium-soc")]
+pub const UART_DMA_TX_BUF_PHYS: usize = utralib::HW_IFRAM0_MEM + utralib::HW_IFRAM0_MEM_LEN - 4096;
 
 pub fn init() -> Output {
     #[cfg(feature = "cramium-fpga")]
@@ -27,100 +31,26 @@ pub fn init() -> Output {
     )
     .expect("couldn't map serial port");
     unsafe { crate::platform::debug::DEFAULT_UART_ADDR = uart.as_mut_ptr() as _ };
-    println!("Mapped UART @ {:08x}", uart.as_ptr() as usize);
-    println!("Process: map success!");
-
     #[cfg(feature = "cramium-soc")]
     {
-        // TODO: need to write an allocator for the UDMA memory region as well
+        // Note: for the TX buf, we allocate a pre-reserved portion of IFRAM as our
+        // DMA buffer. We do *not* use the IFRAM allocator in `cram-hal-service` because
+        // we want to avoid a circular dependency between the logging crate and
+        // the HAL service. Instead, we simply note that this region of memory is
+        // always reserved by the logging crate in its allocator.
         let tx_buf_region = xous::syscall::map_memory(
-            xous::MemoryAddress::new(utralib::HW_IFRAM0_MEM),
+            // we take the last page of IFRAM0 for the Tx buffer.
+            xous::MemoryAddress::new(UART_DMA_TX_BUF_PHYS),
             None,
             4096,
             xous::MemoryFlags::R | xous::MemoryFlags::W,
         )
         .expect("couldn't map UDMA buffer");
-        unsafe { UART_DMA_BUF = tx_buf_region.as_mut_ptr() as *mut u8 };
-
-        /*
-        // TODO: migrate this to an allocator that can handle all IOs
-        let iox_buf = xous::syscall::map_memory(
-            xous::MemoryAddress::new(utra::iox::HW_IOX_BASE),
-            None,
-            4096,
-            xous::MemoryFlags::R | xous::MemoryFlags::W,
-        )
-        .expect("couldn't map iox buffer");
-
-        let udma_ctrl = xous::syscall::map_memory(
-            xous::MemoryAddress::new(utra::udma_ctrl::HW_UDMA_CTRL_BASE),
-            None,
-            4096,
-            xous::MemoryFlags::R | xous::MemoryFlags::W,
-        )
-        .expect("couldn't map UDMA control");
-
-        let iox_csr = iox_buf.as_mut_ptr() as *mut u32;
-        unsafe {
-            iox_csr.add(0).write_volatile(0b00_00_00_01_01_00_00_00);  // PAL AF1 on PA3/PA4
-            iox_csr.add(0x1c / core::mem::size_of::<u32>()).write_volatile(0x1400); // PDH
-            iox_csr.add(0x148 / core::mem::size_of::<u32>()).write_volatile(0x10); // PA4 output
-            iox_csr.add(0x148 / core::mem::size_of::<u32>() + 3).write_volatile(0xffff); // PD
-            iox_csr.add(0x160 / core::mem::size_of::<u32>()).write_volatile(0x8); // PA3 pullup
-        }
-
-        let mut udma_ctrl = CSR::new(udma_ctrl.as_mut_ptr() as _);
-        // ungate the clock for the UART. TODO: send this to a power management common server...
-        // probably should be in the same server that allocates UDMA buffers.
-        udma_ctrl.wo(utra::udma_ctrl::REG_CG, 1);
-
-        // setup the baud rate
-        let mut uart_csr = CSR::new(uart.as_mut_ptr() as *mut u32);
-        let baudrate: u32 = 115200;
-        let freq: u32 = 100_000_000;
-        let clk_counter: u32 = (freq + baudrate / 2) / baudrate;
-        uart_csr.wo(utra::udma_uart_0::REG_UART_SETUP,
-            0x0306 | (clk_counter << 16)
-        ); */
-
-        // rely on the bootloader to set up all the above params
-        /* //  for debug: send a test string to confirm everything is configured correctly
-        let tx_buf = tx_buf_region.as_mut_ptr() as *mut u8;
-        for i in 0..16 {
-            unsafe { tx_buf.add(i).write_volatile('M' as u32 as u8 + i as u8) };
-        }
-        let mut udma_uart = CSR::new(uart.as_mut_ptr() as *mut u32);
-        udma_uart.wo(utra::udma_uart_0::REG_TX_SADDR, tx_buf as u32);
-        udma_uart.wo(utra::udma_uart_0::REG_TX_SIZE, 16);
-        // send it
-        udma_uart.wo(utra::udma_uart_0::REG_TX_CFG, 0x10); // EN
-        // wait for it all to be done
-        while udma_uart.rf(utra::udma_uart_0::REG_TX_CFG_R_TX_EN) != 0 {   }
-        while (udma_uart.r(utra::udma_uart_0::REG_STATUS) & 1) != 0 {  }
-        */
+        unsafe { UART_DMA_TX_BUF_VIRT = tx_buf_region.as_mut_ptr() as *mut u8 };
     }
+    println!("Mapped UART @ {:08x}", uart.as_ptr() as usize);
+    println!("Process: map success!");
 
-    #[cfg(feature = "inject")]
-    {
-        let inject_mem = xous::syscall::map_memory(
-            xous::MemoryAddress::new(utra::keyinject::HW_KEYINJECT_BASE),
-            None,
-            4096,
-            xous::MemoryFlags::R | xous::MemoryFlags::W,
-        )
-        .expect("couldn't map keyinjection CSR range");
-        println!("Note: character injection via console UART is enabled.");
-
-        println!("Allocating IRQ...");
-        xous::syscall::claim_interrupt(
-            utra::console::CONSOLE_IRQ,
-            handle_console_irq,
-            inject_mem.as_mut_ptr() as *mut usize,
-        )
-        .expect("couldn't claim interrupt");
-        println!("Claimed IRQ {}", utra::console::CONSOLE_IRQ);
-        uart_csr.rmwf(utra::uart::EV_ENABLE_RX, 1);
-    }
     Output {}
 }
 
@@ -131,40 +61,6 @@ impl Output {
         loop {
             xous::wait_event();
         }
-    }
-}
-
-#[cfg(feature = "inject")]
-fn handle_console_irq(_irq_no: usize, arg: *mut usize) {
-    if cfg!(feature = "logging") {
-        let mut inject_csr = CSR::new(arg as *mut u32);
-        let mut uart_csr = CSR::new(unsafe { crate::platform::debug::DEFAULT_UART_ADDR as *mut u32 });
-        // println!("rxe {}", uart_csr.rf(utra::uart::RXEMPTY_RXEMPTY));
-        while uart_csr.rf(utra::uart::RXEMPTY_RXEMPTY) == 0 {
-            // I really rather think this is more readable, than the "Rusty" version below.
-            inject_csr.wfo(utra::keyinject::UART_CHAR_CHAR, uart_csr.rf(utra::uart::RXTX_RXTX));
-            uart_csr.wfo(utra::uart::EV_PENDING_RX, 1);
-
-            // I guess this is how you would do it if you were "really doing Rust"
-            // (except this is checking pending not fifo status for loop termination)
-            // (which was really hard to figure out just looking at this loop)
-            /*
-            let maybe_c = match uart_csr.rf(utra::uart::EV_PENDING_RX) {
-                0 => None,
-                ack => {
-                    let c = Some(uart_csr.rf(utra::uart::RXTX_RXTX) as u8);
-                    uart_csr.wfo(utra::uart::EV_PENDING_RX, ack);
-                    c
-                }
-            };
-            if let Some(c) = maybe_c {
-                inject_csr.wfo(utra::keyinject::UART_CHAR_CHAR, (c & 0xff) as u32);
-            } else {
-                break;
-            }*/
-        }
-        // println!("rxe {}", uart_csr.rf(utra::uart::RXEMPTY_RXEMPTY));
-        // println!("pnd {}", uart_csr.rf(utra::uart::EV_PENDING_RX));
     }
 }
 
@@ -187,21 +83,29 @@ impl OutputWriter {
         }
         #[cfg(feature = "cramium-soc")]
         {
-            let mut uart_csr = CSR::new(unsafe { crate::platform::debug::DEFAULT_UART_ADDR as *mut u32 });
+            // safety: safe to call as long as DEFAULT_UART_ADDR is initialized and we exclusively
+            // own it; and the UART has been initialized. For this peripheral, initialization
+            // is handled by the loader and tossed to us.
+            let mut uart =
+                unsafe { udma::Uart::get_handle(crate::platform::debug::DEFAULT_UART_ADDR as usize) };
+
             // enqueue our character to send via DMA
+            let tx_buf_virt = unsafe {
+                // safety: it's safe only because we are manually tracking the allocations in IFRAM0.
+                core::slice::from_raw_parts_mut(UART_DMA_TX_BUF_VIRT as *mut u8, 1)
+            };
+            let tx_buf_phys = unsafe {
+                // safety: it's safe only because we know that the UART TX buffer is expressly reserved at
+                // this location
+                core::slice::from_raw_parts_mut(UART_DMA_TX_BUF_PHYS as *mut u8, 1)
+            };
+            tx_buf_virt[0] = c;
+            // note that write_phys takes the *physical* address. We use `write_phys` because benchmarks
+            // show significant performance improvements skipping the V2P step inherent `write` (an extra
+            // 2 milliseconds for 15 print statements that are 90 chars in length).
             unsafe {
-                if UART_DMA_BUF as usize != 0 {
-                    UART_DMA_BUF.write_volatile(c); // write to the virtual memory address
-                }
+                uart.write_phys(tx_buf_phys);
             }
-            // configure the DMA
-            uart_csr.wo(utra::udma_uart_0::REG_TX_SADDR, utralib::HW_IFRAM0_MEM as u32); // source is the physical address
-            uart_csr.wo(utra::udma_uart_0::REG_TX_SIZE, 1);
-            // send it
-            uart_csr.wo(utra::udma_uart_0::REG_TX_CFG, 0x10); // EN
-            // wait for it all to be done
-            while uart_csr.rf(utra::udma_uart_0::REG_TX_CFG_R_TX_EN) != 0 {}
-            while (uart_csr.r(utra::udma_uart_0::REG_STATUS) & 1) != 0 {}
         }
     }
 
@@ -211,36 +115,31 @@ impl OutputWriter {
     pub fn write(&mut self, buf: &[u8]) -> usize {
         #[cfg(feature = "cramium-soc")]
         {
-            // write the whole buffer via DMA, and then idle with yield_slice() for better
-            // concurrency (as opposed to character-by-character polling).
+            // safety: safe to call as long as DEFAULT_UART_ADDR is initialized and we exclusively
+            // own it; and the UART has been initialized. For this peripheral, initialization
+            // is handled by the loader and tossed to us.
+            let mut uart =
+                unsafe { udma::Uart::get_handle(crate::platform::debug::DEFAULT_UART_ADDR as usize) };
 
-            let mut uart_csr = CSR::new(unsafe { crate::platform::debug::DEFAULT_UART_ADDR as *mut u32 });
             // enqueue our character to send via DMA
-            unsafe {
-                if UART_DMA_BUF as usize != 0 {
-                    // convert the raw pointer to a 4k buffer region. This is "by fiat", we don't
-                    // have a formal allocator for this region yet
-                    let dest_buf = core::slice::from_raw_parts_mut(UART_DMA_BUF as *mut u8, 4096);
-                    // copy the whole buf to the destination
-                    for (&s, d) in buf.iter().zip(dest_buf.iter_mut()) {
-                        *d = s;
-                    }
+            let tx_buf_virt = unsafe {
+                // safety: it's safe only because we are manually tracking the allocations in IFRAM0.
+                core::slice::from_raw_parts_mut(UART_DMA_TX_BUF_VIRT as *mut u8, 4096)
+            };
+            // create a "fictional" physical slice at the physical address where our buffer is mapped.
+            let tx_buf_phys = unsafe {
+                // safety: it's safe only because we know that the UART TX buffer is expressly reserved at
+                // this location
+                core::slice::from_raw_parts_mut(UART_DMA_TX_BUF_PHYS as *mut u8, 4096)
+            };
+            let mut writelen = 0;
+            for page in buf.chunks(4096) {
+                tx_buf_virt[..page.len()].copy_from_slice(page);
+                // note that the write_phys uses the *physical address* slice
+                unsafe {
+                    uart.write_phys(&tx_buf_phys[..page.len()]);
                 }
-            }
-            // configure the DMA
-            uart_csr.wo(utra::udma_uart_0::REG_TX_SADDR, utralib::HW_IFRAM0_MEM as u32); // source is the physical address
-            let writelen = buf.len().min(4096); // we will send the smaller of the buffer length or the maximum size of the DMA page
-            uart_csr.wo(utra::udma_uart_0::REG_TX_SIZE, writelen as u32);
-            // send it
-            uart_csr.wo(utra::udma_uart_0::REG_TX_CFG, 0x10); // EN
-            // wait for it all to be done
-            while uart_csr.rf(utra::udma_uart_0::REG_TX_CFG_R_TX_EN) != 0 {
-                // this should complete quickly because we're just ensuring nothing is already in progress
-            }
-            while (uart_csr.r(utra::udma_uart_0::REG_STATUS) & 1) != 0 {
-                // this takes a bit longer; yield the time because we expect the average
-                // time to send to be around 0.25ms or so, so this is worth it.
-                xous::yield_slice();
+                writelen += page.len();
             }
 
             writelen
@@ -258,11 +157,47 @@ impl OutputWriter {
 }
 
 impl Write for OutputWriter {
+    /// Optimizes performance for the typical case of strings < 210 chars long.
+    /// We have to insert `\r` after every `\n`, leading to a potential 2x growth in
+    /// string size for a reference string that is all `\n`. The downside of
+    /// over-initializing stack space is has to have 0's written to it, which costs
+    /// CPU time and blows out the cache. We're going to go out on a limb and guess
+    /// that there are few cases where we'd pack a huge number of newlines with
+    /// short strings. In the case that we do, we'll end up truncating the output
+    /// because we ran out of space to insert the newlines.
     fn write_str(&mut self, s: &str) -> Result<(), Error> {
-        for c in s.bytes() {
-            self.putc(c);
-            if c == '\n' as u8 {
-                self.putc('\r' as u8);
+        const OPTIMIZATION_BREAKPOINT: usize = 210;
+        const STACKBUF_LEN: usize = 256;
+        if s.len() < OPTIMIZATION_BREAKPOINT {
+            let mut crlf_buf = [0u8; STACKBUF_LEN];
+            let mut ptr = 0;
+            for c in s.bytes() {
+                crlf_buf[ptr] = c;
+                ptr += 1;
+                if ptr >= STACKBUF_LEN {
+                    break;
+                }
+                if c == '\n' as u8 {
+                    crlf_buf[ptr] = '\r' as u8;
+                    ptr += 1;
+                    if ptr >= STACKBUF_LEN {
+                        break;
+                    }
+                }
+            }
+            // now emit the buffer in one efficient, DMA-powered write operation
+            self.write(&crlf_buf[..ptr]);
+        } else {
+            // in case of long strings, the print will be less efficient because
+            // we go character-by-character to convert CRLF; the trade-off is the storage
+            // could be unbounded. Could also fall back to using a `Vec`, but alloc's
+            // are actually extremely expensive and we'd like to avoid them in the logging
+            // crate.
+            for c in s.bytes() {
+                self.putc(c);
+                if c == '\n' as u8 {
+                    self.putc('\r' as u8);
+                }
             }
         }
         Ok(())

--- a/utralib/cramium/core.svd
+++ b/utralib/cramium/core.svd
@@ -3,7 +3,7 @@
 <device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd" >
     <vendor>litex</vendor>
     <name>SOC</name>
-    <description><![CDATA[Litex SoC 2023-09-15 20:42:25]]></description>
+    <description><![CDATA[Litex SoC 2024-01-16 14:55:52]]></description>
 
     <addressUnitBits>8</addressUnitBits>
     <width>32</width>

--- a/utralib/cramium/daric.svd
+++ b/utralib/cramium/daric.svd
@@ -452,6 +452,7 @@
             <registers>
                 <register>
                     <name>REG_CG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_core/rtl/common/udma_ctrl.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -467,6 +468,7 @@
                 </register>
                 <register>
                     <name>REG_CFG_EVT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_core/rtl/common/udma_ctrl.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -503,6 +505,7 @@
                 </register>
                 <register>
                     <name>REG_RST</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_core/rtl/common/udma_ctrl.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -530,6 +533,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -545,6 +549,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -560,6 +565,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -589,6 +595,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -604,6 +611,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -619,6 +627,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -648,6 +657,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -663,6 +673,7 @@
                 </register>
                 <register>
                     <name>REG_UART_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -727,6 +738,7 @@
                 </register>
                 <register>
                     <name>REG_ERROR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -749,6 +761,7 @@
                 </register>
                 <register>
                     <name>REG_IRQ_EN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -771,6 +784,7 @@
                 </register>
                 <register>
                     <name>REG_VALID</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -786,6 +800,7 @@
                 </register>
                 <register>
                     <name>REG_DATA</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -813,6 +828,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -828,6 +844,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -843,6 +860,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -872,6 +890,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -887,6 +906,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -902,6 +922,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -931,6 +952,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -946,6 +968,7 @@
                 </register>
                 <register>
                     <name>REG_UART_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1010,6 +1033,7 @@
                 </register>
                 <register>
                     <name>REG_ERROR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1032,6 +1056,7 @@
                 </register>
                 <register>
                     <name>REG_IRQ_EN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1054,6 +1079,7 @@
                 </register>
                 <register>
                     <name>REG_VALID</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1069,6 +1095,7 @@
                 </register>
                 <register>
                     <name>REG_DATA</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1096,6 +1123,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1111,6 +1139,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1126,6 +1155,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1155,6 +1185,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1170,6 +1201,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1185,6 +1217,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1214,6 +1247,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1229,6 +1263,7 @@
                 </register>
                 <register>
                     <name>REG_UART_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1293,6 +1328,7 @@
                 </register>
                 <register>
                     <name>REG_ERROR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1315,6 +1351,7 @@
                 </register>
                 <register>
                     <name>REG_IRQ_EN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1337,6 +1374,7 @@
                 </register>
                 <register>
                     <name>REG_VALID</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1352,6 +1390,7 @@
                 </register>
                 <register>
                     <name>REG_DATA</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1379,6 +1418,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1394,6 +1434,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1409,6 +1450,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1438,6 +1480,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1453,6 +1496,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1468,6 +1512,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1497,6 +1542,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1512,6 +1558,7 @@
                 </register>
                 <register>
                     <name>REG_UART_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1576,6 +1623,7 @@
                 </register>
                 <register>
                     <name>REG_ERROR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1598,6 +1646,7 @@
                 </register>
                 <register>
                     <name>REG_IRQ_EN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1620,6 +1669,7 @@
                 </register>
                 <register>
                     <name>REG_VALID</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1635,6 +1685,7 @@
                 </register>
                 <register>
                     <name>REG_DATA</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_uart/rtl/udma_uart_reg_if.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1662,6 +1713,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1677,6 +1729,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1692,6 +1745,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1728,6 +1782,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1743,6 +1798,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1758,6 +1814,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1794,6 +1851,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1809,6 +1867,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1824,6 +1883,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1853,6 +1913,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1880,6 +1941,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1895,6 +1957,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1910,6 +1973,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1946,6 +2010,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1961,6 +2026,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -1976,6 +2042,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2012,6 +2079,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2027,6 +2095,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2042,6 +2111,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2071,6 +2141,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2098,6 +2169,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2113,6 +2185,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2128,6 +2201,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2164,6 +2238,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2179,6 +2254,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2194,6 +2270,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2230,6 +2307,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2245,6 +2323,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2260,6 +2339,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2289,6 +2369,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2316,6 +2397,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2331,6 +2413,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2346,6 +2429,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2382,6 +2466,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2397,6 +2482,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2412,6 +2498,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2448,6 +2535,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2463,6 +2551,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2478,6 +2567,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2507,6 +2597,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_qspi/rtl/udma_spim_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2534,6 +2625,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2549,6 +2641,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2564,6 +2657,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2593,6 +2687,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2608,6 +2703,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2623,6 +2719,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2652,6 +2749,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2667,6 +2765,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2682,6 +2781,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2711,6 +2811,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2733,6 +2834,7 @@
                 </register>
                 <register>
                     <name>REG_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2748,6 +2850,7 @@
                 </register>
                 <register>
                     <name>REG_ACK</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2775,6 +2878,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2790,6 +2894,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2805,6 +2910,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2834,6 +2940,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2849,6 +2956,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2864,6 +2972,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2893,6 +3002,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2908,6 +3018,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2923,6 +3034,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2952,6 +3064,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2974,6 +3087,7 @@
                 </register>
                 <register>
                     <name>REG_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -2989,6 +3103,7 @@
                 </register>
                 <register>
                     <name>REG_ACK</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3016,6 +3131,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3031,6 +3147,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3046,6 +3163,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3075,6 +3193,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3090,6 +3209,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3105,6 +3225,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3134,6 +3255,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3149,6 +3271,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3164,6 +3287,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3193,6 +3317,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3215,6 +3340,7 @@
                 </register>
                 <register>
                     <name>REG_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3230,6 +3356,7 @@
                 </register>
                 <register>
                     <name>REG_ACK</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3257,6 +3384,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3272,6 +3400,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3287,6 +3416,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3316,6 +3446,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3331,6 +3462,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3346,6 +3478,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3375,6 +3508,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3390,6 +3524,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3405,6 +3540,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3434,6 +3570,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3456,6 +3593,7 @@
                 </register>
                 <register>
                     <name>REG_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3471,6 +3609,7 @@
                 </register>
                 <register>
                     <name>REG_ACK</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2c/rtl/udma_i2c_reg_if.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3498,6 +3637,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3513,6 +3653,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3528,6 +3669,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3557,6 +3699,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3572,6 +3715,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3587,6 +3731,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3616,6 +3761,7 @@
                 </register>
                 <register>
                     <name>REG_CMD_OP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3634,10 +3780,18 @@
                             <lsb>8</lsb>
                             <description><![CDATA[r_cmd_op]]></description>
                         </field>
+                        <field>
+                            <name>r_cmd_stopopt</name>
+                            <msb>17</msb>
+                            <bitRange>[17:16]</bitRange>
+                            <lsb>16</lsb>
+                            <description><![CDATA[r_cmd_stopopt]]></description>
+                        </field>
                     </fields>
                 </register>
                 <register>
                     <name>REG_DATA_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3681,6 +3835,7 @@
                 </register>
                 <register>
                     <name>REG_START</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3696,6 +3851,7 @@
                 </register>
                 <register>
                     <name>REG_RSP0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3711,6 +3867,7 @@
                 </register>
                 <register>
                     <name>REG_RSP1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3726,6 +3883,7 @@
                 </register>
                 <register>
                     <name>REG_RSP2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3741,6 +3899,7 @@
                 </register>
                 <register>
                     <name>REG_RSP3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x003c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3756,6 +3915,7 @@
                 </register>
                 <register>
                     <name>REG_CLK_DIV</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3778,6 +3938,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_sdio/rtl/udma_sdio_reg_if.sv]]></description>
                     <addressOffset>0x0044</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3812,6 +3973,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2s/rtl/udma_i2s_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3827,6 +3989,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2s/rtl/udma_i2s_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3842,6 +4005,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2s/rtl/udma_i2s_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3878,6 +4042,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2s/rtl/udma_i2s_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3893,6 +4058,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2s/rtl/udma_i2s_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3908,6 +4074,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2s/rtl/udma_i2s_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -3944,6 +4111,7 @@
                 </register>
                 <register>
                     <name>REG_I2S_CLKCFG_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2s/rtl/udma_i2s_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4022,6 +4190,7 @@
                 </register>
                 <register>
                     <name>REG_I2S_SLV_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2s/rtl/udma_i2s_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4065,6 +4234,7 @@
                 </register>
                 <register>
                     <name>REG_I2S_MST_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2s/rtl/udma_i2s_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4108,6 +4278,7 @@
                 </register>
                 <register>
                     <name>REG_I2S_PDM_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_i2s/rtl/udma_i2s_reg_if.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4156,6 +4327,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_camera/rtl/camera_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4171,6 +4343,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_camera/rtl/camera_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4186,6 +4359,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_camera/rtl/camera_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4222,6 +4396,7 @@
                 </register>
                 <register>
                     <name>REG_CAM_CFG_GLOB</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_camera/rtl/camera_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4244,6 +4419,7 @@
                 </register>
                 <register>
                     <name>REG_CAM_CFG_LL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_camera/rtl/camera_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4259,6 +4435,7 @@
                 </register>
                 <register>
                     <name>REG_CAM_CFG_UR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_camera/rtl/camera_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4274,6 +4451,7 @@
                 </register>
                 <register>
                     <name>REG_CAM_CFG_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_camera/rtl/camera_reg_if.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4289,6 +4467,7 @@
                 </register>
                 <register>
                     <name>REG_CAM_CFG_FILTER</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_camera/rtl/camera_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4304,6 +4483,7 @@
                 </register>
                 <register>
                     <name>REG_CAM_VSYNC_POLARITY</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/udma/udma_camera/rtl/camera_reg_if.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4338,6 +4518,8 @@
             <registers>
                 <register>
                     <name>REG_TX_CH0_ADD</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4353,6 +4535,8 @@
                 </register>
                 <register>
                     <name>REG_TX_CH0_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4375,6 +4559,8 @@
                 </register>
                 <register>
                     <name>REG_TX_CH0_LEN0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4390,6 +4576,8 @@
                 </register>
                 <register>
                     <name>REG_TX_CH0_LEN1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4405,6 +4593,8 @@
                 </register>
                 <register>
                     <name>REG_TX_CH0_LEN2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4420,6 +4610,8 @@
                 </register>
                 <register>
                     <name>REG_TX_CH1_ADD</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4435,6 +4627,8 @@
                 </register>
                 <register>
                     <name>REG_TX_CH1_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4457,6 +4651,8 @@
                 </register>
                 <register>
                     <name>REG_TX_CH1_LEN0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4472,6 +4668,8 @@
                 </register>
                 <register>
                     <name>REG_TX_CH1_LEN1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4487,6 +4685,8 @@
                 </register>
                 <register>
                     <name>REG_TX_CH1_LEN2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4502,6 +4702,8 @@
                 </register>
                 <register>
                     <name>REG_RX_CH_ADD</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4517,6 +4719,8 @@
                 </register>
                 <register>
                     <name>REG_RX_CH_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4539,6 +4743,8 @@
                 </register>
                 <register>
                     <name>REG_RX_CH_LEN0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4554,6 +4760,8 @@
                 </register>
                 <register>
                     <name>REG_RX_CH_LEN1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4569,6 +4777,8 @@
                 </register>
                 <register>
                     <name>REG_RX_CH_LEN2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4584,6 +4794,8 @@
                 </register>
                 <register>
                     <name>REG_AU_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x003c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4620,6 +4832,8 @@
                 </register>
                 <register>
                     <name>REG_AU_REG0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4635,6 +4849,8 @@
                 </register>
                 <register>
                     <name>REG_AU_REG1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0044</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4650,6 +4866,8 @@
                 </register>
                 <register>
                     <name>REG_BINCU_TH</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0048</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4665,6 +4883,8 @@
                 </register>
                 <register>
                     <name>REG_BINCU_CNT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x004c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4687,6 +4907,8 @@
                 </register>
                 <register>
                     <name>REG_BINCU_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0050</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4702,6 +4924,8 @@
                 </register>
                 <register>
                     <name>REG_BINCU_VAL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0054</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4717,6 +4941,8 @@
                 </register>
                 <register>
                     <name>REG_FILT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0058</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4732,6 +4958,8 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-
+oss/ips/udma/udma_filter/rtl/udma_filter_reg_if.sv]]></description>
                     <addressOffset>0x0060</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4759,6 +4987,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4774,6 +5003,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4789,6 +5019,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4804,6 +5035,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4819,6 +5051,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4834,6 +5067,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4849,6 +5083,7 @@
                 </register>
                 <register>
                     <name>REG_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4864,6 +5099,7 @@
                 </register>
                 <register>
                     <name>REG_SCIF_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4935,6 +5171,7 @@
                 </register>
                 <register>
                     <name>REG_ERROR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4957,6 +5194,7 @@
                 </register>
                 <register>
                     <name>REG_IRQ_EN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4979,6 +5217,7 @@
                 </register>
                 <register>
                     <name>REG_VALID</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -4994,6 +5233,7 @@
                 </register>
                 <register>
                     <name>REG_DATA</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5009,6 +5249,7 @@
                 </register>
                 <register>
                     <name>REG_SCIF_ETU</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_scif_reg_v0.1.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5036,6 +5277,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5051,6 +5293,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5066,6 +5309,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5095,6 +5339,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5110,6 +5355,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5125,6 +5371,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5154,6 +5401,7 @@
                 </register>
                 <register>
                     <name>REG_SPIS_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5176,6 +5424,7 @@
                 </register>
                 <register>
                     <name>REG_SEOT_CNT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5191,6 +5440,7 @@
                 </register>
                 <register>
                     <name>REG_SPIS_IRQ_EN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5206,6 +5456,7 @@
                 </register>
                 <register>
                     <name>REG_SPIS_RXCNT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5221,6 +5472,7 @@
                 </register>
                 <register>
                     <name>REG_SPIS_TXCNT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5236,6 +5488,7 @@
                 </register>
                 <register>
                     <name>REG_SPIS_DMCNT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5263,6 +5516,7 @@
             <registers>
                 <register>
                     <name>REG_RX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5278,6 +5532,7 @@
                 </register>
                 <register>
                     <name>REG_RX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5293,6 +5548,7 @@
                 </register>
                 <register>
                     <name>REG_RX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5322,6 +5578,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5337,6 +5594,7 @@
                 </register>
                 <register>
                     <name>REG_TX_SIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5352,6 +5610,7 @@
                 </register>
                 <register>
                     <name>REG_TX_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5381,6 +5640,7 @@
                 </register>
                 <register>
                     <name>REG_SPIS_SETUP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5403,6 +5663,7 @@
                 </register>
                 <register>
                     <name>REG_SEOT_CNT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5418,6 +5679,7 @@
                 </register>
                 <register>
                     <name>REG_SPIS_IRQ_EN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5433,6 +5695,7 @@
                 </register>
                 <register>
                     <name>REG_SPIS_RXCNT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5448,6 +5711,7 @@
                 </register>
                 <register>
                     <name>REG_SPIS_TXCNT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5463,6 +5727,7 @@
                 </register>
                 <register>
                     <name>REG_SPIS_DMCNT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/udma_spis_reg_v0.2.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5502,6 +5767,7 @@
             <registers>
                 <register>
                     <name>SFR_CRFUNC</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5517,6 +5783,7 @@
                 </register>
                 <register>
                     <name>SFR_AR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5532,6 +5799,7 @@
                 </register>
                 <register>
                     <name>SFR_SRMFSM</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5547,6 +5815,7 @@
                 </register>
                 <register>
                     <name>SFR_FR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5587,6 +5856,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5616,6 +5886,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPT1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5631,21 +5902,55 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPTLTX</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
                         <field>
                             <name>sfr_optltx</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
+                            <msb>5</msb>
+                            <bitRange>[5:0]</bitRange>
                             <lsb>0</lsb>
                             <description><![CDATA[sfr_optltx read/write control register]]></description>
                         </field>
                     </fields>
                 </register>
                 <register>
+                    <name>SFR_MASKSEED</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
+                    <addressOffset>0x0020</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>sfr_maskseed</name>
+                            <msb>31</msb>
+                            <bitRange>[31:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[sfr_maskseed read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_MASKSEEDAR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
+                    <addressOffset>0x0024</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>sfr_maskseedar</name>
+                            <msb>31</msb>
+                            <bitRange>[31:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[sfr_maskseedar performs action on write of value: 0x5a]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
                     <name>SFR_SEGPTR_PTRID_IV</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5661,6 +5966,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_PTRID_AKEY</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5676,6 +5982,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_PTRID_AIB</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5691,6 +5998,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_PTRID_AOB</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/aes_v0.4.sv]]></description>
                     <addressOffset>0x003c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5718,6 +6026,7 @@ bit position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_CRFUNC</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5733,6 +6042,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5748,6 +6058,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SRMFSM</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5763,6 +6074,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5819,6 +6131,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPT1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5834,6 +6147,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPT2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5863,6 +6177,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPT3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5878,6 +6193,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_BLKT0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5893,6 +6209,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_SEGID_LKEY</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5908,6 +6225,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_SEGID_KEY</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5923,6 +6241,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_SEGID_SCRT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5938,6 +6257,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_SEGID_MSG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5953,6 +6273,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_SEGID_HOUT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5968,6 +6289,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_SEGID_HOUT2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/combohash_v0.3.sv]]></description>
                     <addressOffset>0x003c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -5995,6 +6317,7 @@ bit position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_CRFUNC</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6017,6 +6340,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6032,6 +6356,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SRMFSM</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6054,6 +6379,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6102,6 +6428,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPTNW</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6117,6 +6444,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPTEW</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6132,6 +6460,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPTRW</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6147,6 +6476,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPTLTX</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6162,6 +6492,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPTMASK</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6177,6 +6508,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_PTRID_PCON</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6192,6 +6524,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_PTRID_PIB0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6207,6 +6540,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_PTRID_PIB1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6222,6 +6556,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_PTRID_PKB</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x003c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6237,6 +6572,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SEGPTR_PTRID_POB</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/pke_v0.3tmp.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6264,6 +6600,7 @@ bit position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_SCHSTART_AR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6279,6 +6616,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_XCH_FUNC</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6294,6 +6632,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_XCH_OPT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6309,6 +6648,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_XCH_AXSTART</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6324,6 +6664,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_XCH_SEGID</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6339,6 +6680,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_XCH_SEGSTART</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6354,6 +6696,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_XCH_TRANSIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6369,6 +6712,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SCH_FUNC</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6384,6 +6728,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SCH_OPT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6399,6 +6744,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SCH_AXSTART</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6414,6 +6760,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SCH_SEGID</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x003c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6429,6 +6776,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SCH_SEGSTART</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6444,6 +6792,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SCH_TRANSIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0044</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6459,6 +6808,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ICH_OPT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0050</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6474,6 +6824,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ICH_SEGID</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0054</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6489,6 +6840,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ICH_RPSTART</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0058</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6504,6 +6856,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ICH_WPSTART</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x005c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6519,6 +6872,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ICH_TRANSIZE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/scedma_v0.1.sv]]></description>
                     <addressOffset>0x0060</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6546,6 +6900,7 @@ bit position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_SCEMODE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6561,6 +6916,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SUBEN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6576,6 +6932,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AHBS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6591,6 +6948,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SRBUSY</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6606,6 +6964,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FRDONE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6622,6 +6981,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FRERR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6638,6 +6998,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ARCLR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6653,6 +7014,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FRACERR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6669,6 +7031,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_TICKCNT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6684,6 +7047,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FFEN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6699,6 +7063,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FFCLR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6714,6 +7079,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FFCNT_SR_FF0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6729,6 +7095,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FFCNT_SR_FF1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0044</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6744,6 +7111,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FFCNT_SR_FF2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0048</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6759,6 +7127,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FFCNT_SR_FF3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x004c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6774,6 +7143,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FFCNT_SR_FF4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0050</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6789,6 +7159,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FFCNT_SR_FF5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x0054</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6804,6 +7175,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_TS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/sce_glbsfr_v0.1.sv]]></description>
                     <addressOffset>0x00fc</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6831,6 +7203,7 @@ bit position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_CRSRC</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6846,6 +7219,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CRANA</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6861,6 +7235,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_PP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6876,6 +7251,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_OPT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6891,6 +7267,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6906,6 +7283,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AR_GEN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6921,6 +7299,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6936,7 +7315,72 @@ position to clear the flag]]></description>
                     </fields>
                 </register>
                 <register>
+                    <name>SFR_DRPSZ</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
+                    <addressOffset>0x0020</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>sfr_drpsz</name>
+                            <msb>31</msb>
+                            <bitRange>[31:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[sfr_drpsz read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_DRGEN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
+                    <addressOffset>0x0024</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>sfr_drgen</name>
+                            <msb>31</msb>
+                            <bitRange>[31:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[sfr_drgen read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_DRRESEED</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
+                    <addressOffset>0x0028</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>sfr_drreseed</name>
+                            <msb>31</msb>
+                            <bitRange>[31:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[sfr_drreseed read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_BUF</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
+                    <addressOffset>0x0030</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>sfr_buf</name>
+                            <msb>31</msb>
+                            <bitRange>[31:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[sfr_buf read only status register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
                     <name>SFR_CHAIN_RNGCHAINEN0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6952,6 +7396,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CHAIN_RNGCHAINEN1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/crypto/trng_v0.2.sv]]></description>
                     <addressOffset>0x0044</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -6991,6 +7436,7 @@ position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_TXD</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/duart_v0.1.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7006,6 +7452,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/duart_v0.1.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7021,6 +7468,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/duart_v0.1.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7036,6 +7484,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ETUC</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/duart_v0.1.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7087,6 +7536,7 @@ position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_CM7EVSEL_CM7EVSEL0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7102,6 +7552,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CM7EVSEL_CM7EVSEL1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7117,6 +7568,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CM7EVSEL_CM7EVSEL2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7132,6 +7584,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CM7EVSEL_CM7EVSEL3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7147,6 +7600,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CM7EVSEL_CM7EVSEL4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7162,6 +7616,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CM7EVSEL_CM7EVSEL5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7177,6 +7632,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CM7EVSEL_CM7EVSEL6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7192,6 +7648,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CM7EVSEL_CM7EVSEL7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7207,6 +7664,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CM7EVEN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7222,6 +7680,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CM7EVFR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7238,6 +7697,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_TMREVSEL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7253,6 +7713,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_PWMEVSEL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7268,6 +7729,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IFEVEN_IFEVEN0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7283,6 +7745,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IFEVEN_IFEVEN1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0044</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7298,6 +7761,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IFEVEN_IFEVEN2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0048</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7313,6 +7777,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IFEVEN_IFEVEN3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x004c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7328,6 +7793,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IFEVEN_IFEVEN4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0050</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7343,6 +7809,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IFEVEN_IFEVEN5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0054</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7358,6 +7825,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IFEVEN_IFEVEN6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0058</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7373,6 +7841,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IFEVEN_IFEVEN7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x005c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7388,6 +7857,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IFEVERRFR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0060</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7404,6 +7874,7 @@ bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CM7ERRFR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/evc_v0.1.sv]]></description>
                     <addressOffset>0x0080</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7432,6 +7903,7 @@ position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_CGUSEC</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7447,6 +7919,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGULP</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7461,7 +7934,40 @@ position to clear the flag]]></description>
                     </fields>
                 </register>
                 <register>
+                    <name>SFR_SEED</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
+                    <addressOffset>0x0008</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>sfr_seed</name>
+                            <msb>31</msb>
+                            <bitRange>[31:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[sfr_seed read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_SEEDAR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
+                    <addressOffset>0x000c</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>sfr_seedar</name>
+                            <msb>31</msb>
+                            <bitRange>[31:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[sfr_seedar performs action on write of value: 0x5a]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
                     <name>SFR_CGUSEL0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7477,6 +7983,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFD_CFGFDCR_0_4_0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7492,6 +7999,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFD_CFGFDCR_0_4_1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7507,6 +8015,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFD_CFGFDCR_0_4_2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7522,6 +8031,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFD_CFGFDCR_0_4_3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7537,6 +8047,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFD_CFGFDCR_0_4_4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7552,6 +8063,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFDAO</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7567,6 +8079,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUSET</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7582,6 +8095,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUSEL1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7597,6 +8111,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFDPKE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7612,6 +8127,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFSSR_FSFREQ0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7627,6 +8143,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFSSR_FSFREQ1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0044</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7642,6 +8159,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFSSR_FSFREQ2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0048</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7657,6 +8175,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFSSR_FSFREQ3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x004c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7672,6 +8191,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFSVLD</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0050</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7687,6 +8207,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CGUFSCR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0054</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7702,6 +8223,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ACLKGR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0060</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7717,6 +8239,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_HCLKGR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0064</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7732,6 +8255,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ICLKGR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0068</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7747,6 +8271,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_PCLKGR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x006c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7762,6 +8287,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_RCURST0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0080</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7777,6 +8303,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_RCURST1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0084</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7792,6 +8319,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_RCUSRCFR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0088</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7808,6 +8336,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IPCARIPFLOW</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0090</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7823,6 +8352,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IPCEN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0094</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7838,6 +8368,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IPCLPEN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x0098</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7853,6 +8384,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IPCOSC</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x009c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7862,12 +8394,13 @@ respective bit position to clear the flag]]></description>
                             <msb>6</msb>
                             <bitRange>[6:0]</bitRange>
                             <lsb>0</lsb>
-                            <description><![CDATA[sfr_ipcosc read/write control register]]></description>
+                            <description><![CDATA[sfr_ipcosc read only status register]]></description>
                         </field>
                     </fields>
                 </register>
                 <register>
                     <name>SFR_IPCPLLMN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x00a0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7883,6 +8416,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IPCPLLF</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x00a4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7898,6 +8432,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IPCPLLQ</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x00a8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7913,6 +8448,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IPCCR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sysctrl/sysctrl_v0.2.sv]]></description>
                     <addressOffset>0x00ac</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7952,6 +8488,7 @@ respective bit position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_AFSEL_CRAFSEL0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7967,6 +8504,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AFSEL_CRAFSEL1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7982,6 +8520,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AFSEL_CRAFSEL2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -7997,6 +8536,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AFSEL_CRAFSEL3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8012,6 +8552,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AFSEL_CRAFSEL4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8027,6 +8568,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AFSEL_CRAFSEL5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8042,6 +8584,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AFSEL_CRAFSEL6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8057,6 +8600,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AFSEL_CRAFSEL7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8071,7 +8615,72 @@ respective bit position to clear the flag]]></description>
                     </fields>
                 </register>
                 <register>
+                    <name>SFR_AFSEL_CRAFSEL8</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0020</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>crafsel8</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[crafsel read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_AFSEL_CRAFSEL9</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0024</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>crafsel9</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[crafsel read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_AFSEL_CRAFSEL10</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0028</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>crafsel10</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[crafsel read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_AFSEL_CRAFSEL11</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x002c</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>crafsel11</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[crafsel read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
                     <name>SFR_INTCR_CRINT0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0100</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8087,6 +8696,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INTCR_CRINT1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0104</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8102,6 +8712,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INTCR_CRINT2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0108</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8117,6 +8728,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INTCR_CRINT3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x010c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8132,6 +8744,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INTCR_CRINT4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0110</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8147,6 +8760,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INTCR_CRINT5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0114</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8162,6 +8776,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INTCR_CRINT6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0118</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8177,6 +8792,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INTCR_CRINT7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x011c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8192,6 +8808,7 @@ respective bit position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INTFR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0120</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8208,6 +8825,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOOUT_CRGO0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0130</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8223,6 +8841,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOOUT_CRGO1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0134</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8238,6 +8857,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOOUT_CRGO2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0138</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8253,6 +8873,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOOUT_CRGO3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x013c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8267,8 +8888,41 @@ position to clear the flag]]></description>
                     </fields>
                 </register>
                 <register>
-                    <name>SFR_GPIOOE_CRGOE0</name>
+                    <name>SFR_GPIOOUT_CRGO4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0140</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>crgo4</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[crgo read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_GPIOOUT_CRGO5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0144</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>crgo5</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[crgo read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_GPIOOE_CRGOE0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0148</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8283,7 +8937,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOOE_CRGOE1</name>
-                    <addressOffset>0x0144</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x014c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8298,7 +8953,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOOE_CRGOE2</name>
-                    <addressOffset>0x0148</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0150</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8313,7 +8969,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOOE_CRGOE3</name>
-                    <addressOffset>0x014c</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0154</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8327,8 +8984,41 @@ position to clear the flag]]></description>
                     </fields>
                 </register>
                 <register>
+                    <name>SFR_GPIOOE_CRGOE4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0158</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>crgoe4</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[crgoe read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_GPIOOE_CRGOE5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x015c</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>crgoe5</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[crgoe read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
                     <name>SFR_GPIOPU_CRGPU0</name>
-                    <addressOffset>0x0150</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0160</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8343,7 +9033,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOPU_CRGPU1</name>
-                    <addressOffset>0x0154</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0164</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8358,7 +9049,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOPU_CRGPU2</name>
-                    <addressOffset>0x0158</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0168</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8373,7 +9065,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOPU_CRGPU3</name>
-                    <addressOffset>0x015c</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x016c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8387,8 +9080,41 @@ position to clear the flag]]></description>
                     </fields>
                 </register>
                 <register>
+                    <name>SFR_GPIOPU_CRGPU4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0170</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>crgpu4</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[crgpu read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_GPIOPU_CRGPU5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0174</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>crgpu5</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[crgpu read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
                     <name>SFR_GPIOIN_SRGI0</name>
-                    <addressOffset>0x0160</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0178</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8403,7 +9129,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOIN_SRGI1</name>
-                    <addressOffset>0x0164</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x017c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8418,7 +9145,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOIN_SRGI2</name>
-                    <addressOffset>0x0168</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0180</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8433,7 +9161,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GPIOIN_SRGI3</name>
-                    <addressOffset>0x016c</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0184</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8447,7 +9176,40 @@ position to clear the flag]]></description>
                     </fields>
                 </register>
                 <register>
+                    <name>SFR_GPIOIN_SRGI4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0188</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>srgi4</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[srgi read only status register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_GPIOIN_SRGI5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x018c</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>srgi5</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[srgi read only status register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
                     <name>SFR_PIOSEL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0200</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8463,6 +9225,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CFG_SCHM_CR_CFG_SCHMSEL0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0230</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8478,6 +9241,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CFG_SCHM_CR_CFG_SCHMSEL1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0234</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8493,6 +9257,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CFG_SCHM_CR_CFG_SCHMSEL2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0238</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8508,6 +9273,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CFG_SCHM_CR_CFG_SCHMSEL3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x023c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8522,8 +9288,41 @@ position to clear the flag]]></description>
                     </fields>
                 </register>
                 <register>
-                    <name>SFR_CFG_SLEW_CR_CFG_SLEWSLOW0</name>
+                    <name>SFR_CFG_SCHM_CR_CFG_SCHMSEL4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
                     <addressOffset>0x0240</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>cr_cfg_schmsel4</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[cr_cfg_schmsel read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_CFG_SCHM_CR_CFG_SCHMSEL5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0244</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>cr_cfg_schmsel5</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[cr_cfg_schmsel read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_CFG_SLEW_CR_CFG_SLEWSLOW0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0248</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8538,7 +9337,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CFG_SLEW_CR_CFG_SLEWSLOW1</name>
-                    <addressOffset>0x0244</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x024c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8553,7 +9353,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CFG_SLEW_CR_CFG_SLEWSLOW2</name>
-                    <addressOffset>0x0248</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0250</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8568,7 +9369,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CFG_SLEW_CR_CFG_SLEWSLOW3</name>
-                    <addressOffset>0x024c</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0254</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8582,8 +9384,41 @@ position to clear the flag]]></description>
                     </fields>
                 </register>
                 <register>
+                    <name>SFR_CFG_SLEW_CR_CFG_SLEWSLOW4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0258</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>cr_cfg_slewslow4</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[cr_cfg_slewslow read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_CFG_SLEW_CR_CFG_SLEWSLOW5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x025c</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>cr_cfg_slewslow5</name>
+                            <msb>15</msb>
+                            <bitRange>[15:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[cr_cfg_slewslow read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
                     <name>SFR_CFG_DRVSEL_CR_CFG_DRVSEL0</name>
-                    <addressOffset>0x0250</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0260</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8598,7 +9433,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CFG_DRVSEL_CR_CFG_DRVSEL1</name>
-                    <addressOffset>0x0254</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0264</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8613,7 +9449,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CFG_DRVSEL_CR_CFG_DRVSEL2</name>
-                    <addressOffset>0x0258</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0268</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8628,7 +9465,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CFG_DRVSEL_CR_CFG_DRVSEL3</name>
-                    <addressOffset>0x025c</addressOffset>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x026c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
                     <fields>
@@ -8641,10 +9479,42 @@ position to clear the flag]]></description>
                         </field>
                     </fields>
                 </register>
+                <register>
+                    <name>SFR_CFG_DRVSEL_CR_CFG_DRVSEL4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0270</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>cr_cfg_drvsel4</name>
+                            <msb>31</msb>
+                            <bitRange>[31:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[cr_cfg_drvsel read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SFR_CFG_DRVSEL_CR_CFG_DRVSEL5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/iox_v0.3.sv]]></description>
+                    <addressOffset>0x0274</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>cr_cfg_drvsel5</name>
+                            <msb>31</msb>
+                            <bitRange>[31:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[cr_cfg_drvsel read/write control register]]></description>
+                        </field>
+                    </fields>
+                </register>
             </registers>
             <addressBlock>
                 <offset>0</offset>
-                <size>0x260</size>
+                <size>0x278</size>
                 <usage>registers</usage>
             </addressBlock>
         </peripheral>
@@ -8667,6 +9537,7 @@ position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_IO</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8682,6 +9553,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8697,6 +9569,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_OCR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8712,6 +9585,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_RDFFTHRES</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8727,6 +9601,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REV</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8749,6 +9624,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BACSA</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8764,6 +9640,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BAIOFN_CFG_BASE_ADDR_IO_FUNC0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8779,6 +9656,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BAIOFN_CFG_BASE_ADDR_IO_FUNC1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8794,6 +9672,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BAIOFN_CFG_BASE_ADDR_IO_FUNC2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8809,6 +9688,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BAIOFN_CFG_BASE_ADDR_IO_FUNC3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8824,6 +9704,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BAIOFN_CFG_BASE_ADDR_IO_FUNC4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8839,6 +9720,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BAIOFN_CFG_BASE_ADDR_IO_FUNC5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8854,6 +9736,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BAIOFN_CFG_BASE_ADDR_IO_FUNC6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8869,6 +9752,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BAIOFN_CFG_BASE_ADDR_IO_FUNC7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x003c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8884,6 +9768,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNCISPTR_CFG_REG_FUNC_CIS_PTR0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8899,6 +9784,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNCISPTR_CFG_REG_FUNC_CIS_PTR1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0044</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8914,6 +9800,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNCISPTR_CFG_REG_FUNC_CIS_PTR2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0048</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8929,6 +9816,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNCISPTR_CFG_REG_FUNC_CIS_PTR3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x004c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8944,6 +9832,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNCISPTR_CFG_REG_FUNC_CIS_PTR4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0050</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8959,6 +9848,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNCISPTR_CFG_REG_FUNC_CIS_PTR5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0054</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8974,6 +9864,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNCISPTR_CFG_REG_FUNC_CIS_PTR6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0058</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -8989,6 +9880,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNCISPTR_CFG_REG_FUNC_CIS_PTR7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x005c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9004,6 +9896,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNEXTSTDCODE_CFG_REG_FUNC_EXT_STD_CODE0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0060</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9019,6 +9912,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNEXTSTDCODE_CFG_REG_FUNC_EXT_STD_CODE1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0064</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9034,6 +9928,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNEXTSTDCODE_CFG_REG_FUNC_EXT_STD_CODE2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0068</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9049,6 +9944,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNEXTSTDCODE_CFG_REG_FUNC_EXT_STD_CODE3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x006c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9064,6 +9960,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNEXTSTDCODE_CFG_REG_FUNC_EXT_STD_CODE4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0070</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9079,6 +9976,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNEXTSTDCODE_CFG_REG_FUNC_EXT_STD_CODE5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0074</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9094,6 +9992,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNEXTSTDCODE_CFG_REG_FUNC_EXT_STD_CODE6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0078</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9109,6 +10008,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_FNEXTSTDCODE_CFG_REG_FUNC_EXT_STD_CODE7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x007c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9124,6 +10024,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_WRITE_PROTECT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0080</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9139,6 +10040,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_DSR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0084</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9154,6 +10056,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_CID_CFG_REG_CID0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0088</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9169,6 +10072,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_CID_CFG_REG_CID1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x008c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9184,6 +10088,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_CID_CFG_REG_CID2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0090</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9199,6 +10104,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_CID_CFG_REG_CID3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0094</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9214,6 +10120,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_CSD_CFG_REG_CSD0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0098</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9229,6 +10136,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_CSD_CFG_REG_CSD1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x009c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9244,6 +10152,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_CSD_CFG_REG_CSD2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00a0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9259,6 +10168,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_CSD_CFG_REG_CSD3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00a4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9274,6 +10184,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SCR_CFG_REG_SCR0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00a8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9289,6 +10200,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SCR_CFG_REG_SCR1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00ac</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9304,6 +10216,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00b0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9319,6 +10232,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00b4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9334,6 +10248,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00b8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9349,6 +10264,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00bc</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9364,6 +10280,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00c0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9379,6 +10296,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00c4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9394,6 +10312,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00c8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9409,6 +10328,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00cc</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9424,6 +10344,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS8</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00d0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9439,6 +10360,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS9</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00d4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9454,6 +10376,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS10</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00d8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9469,6 +10392,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS11</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00dc</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9484,6 +10408,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS12</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00e0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9499,6 +10424,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS13</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00e4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9514,6 +10440,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS14</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00e8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9529,6 +10456,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_SD_STATUS_CFG_REG_SD_STATUS15</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x00ec</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9544,6 +10472,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0100</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9559,6 +10488,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0104</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9574,6 +10504,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0108</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9589,6 +10520,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x010c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9604,6 +10536,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0110</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9619,6 +10552,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0114</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9634,6 +10568,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0118</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9649,6 +10584,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x011c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9664,6 +10600,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC8</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0120</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9679,6 +10616,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC9</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0124</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9694,6 +10632,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC10</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0128</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9709,6 +10648,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC11</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x012c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9724,6 +10664,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC12</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0130</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9739,6 +10680,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC13</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0134</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9754,6 +10696,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC14</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0138</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9769,6 +10712,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC15</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x013c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9784,6 +10728,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC16</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0140</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9799,6 +10744,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_BASE_ADDR_MEM_FUNC_CFG_BASE_ADDR_MEM_FUNC17</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0144</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9814,6 +10760,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_INTERFACE_CODE_CFG_REG_FUNC_ISDIO_INTERFACE_CODE0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0148</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9829,6 +10776,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_INTERFACE_CODE_CFG_REG_FUNC_ISDIO_INTERFACE_CODE1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x014c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9844,6 +10792,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_INTERFACE_CODE_CFG_REG_FUNC_ISDIO_INTERFACE_CODE2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0150</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9859,6 +10808,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_INTERFACE_CODE_CFG_REG_FUNC_ISDIO_INTERFACE_CODE3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0154</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9874,6 +10824,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_INTERFACE_CODE_CFG_REG_FUNC_ISDIO_INTERFACE_CODE4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0158</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9889,6 +10840,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_INTERFACE_CODE_CFG_REG_FUNC_ISDIO_INTERFACE_CODE5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x015c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9904,6 +10856,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_INTERFACE_CODE_CFG_REG_FUNC_ISDIO_INTERFACE_CODE6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0160</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9919,6 +10872,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_CODE_CFG_REG_FUNC_MANUFACT_CODE0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0168</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9934,6 +10888,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_CODE_CFG_REG_FUNC_MANUFACT_CODE1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x016c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9949,6 +10904,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_CODE_CFG_REG_FUNC_MANUFACT_CODE2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0170</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9964,6 +10920,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_CODE_CFG_REG_FUNC_MANUFACT_CODE3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0174</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9979,6 +10936,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_CODE_CFG_REG_FUNC_MANUFACT_CODE4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0178</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -9994,6 +10952,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_CODE_CFG_REG_FUNC_MANUFACT_CODE5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x017c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10009,6 +10968,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_CODE_CFG_REG_FUNC_MANUFACT_CODE6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0180</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10024,6 +10984,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_INFO_CFG_REG_FUNC_MANUFACT_INFO0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0188</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10039,6 +11000,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_INFO_CFG_REG_FUNC_MANUFACT_INFO1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x018c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10054,6 +11016,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_INFO_CFG_REG_FUNC_MANUFACT_INFO2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0190</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10069,6 +11032,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_INFO_CFG_REG_FUNC_MANUFACT_INFO3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0194</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10084,6 +11048,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_INFO_CFG_REG_FUNC_MANUFACT_INFO4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x0198</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10099,6 +11064,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_INFO_CFG_REG_FUNC_MANUFACT_INFO5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x019c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10114,6 +11080,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_MANUFACT_INFO_CFG_REG_FUNC_MANUFACT_INFO6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01a0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10129,6 +11096,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_TYPE_SUP_CODE_CFG_REG_FUNC_ISDIO_TYPE_SUP_CODE0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01a8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10144,6 +11112,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_TYPE_SUP_CODE_CFG_REG_FUNC_ISDIO_TYPE_SUP_CODE1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01ac</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10159,6 +11128,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_TYPE_SUP_CODE_CFG_REG_FUNC_ISDIO_TYPE_SUP_CODE2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01b0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10174,6 +11144,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_TYPE_SUP_CODE_CFG_REG_FUNC_ISDIO_TYPE_SUP_CODE3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01b4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10189,6 +11160,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_TYPE_SUP_CODE_CFG_REG_FUNC_ISDIO_TYPE_SUP_CODE4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01b8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10204,6 +11176,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_TYPE_SUP_CODE_CFG_REG_FUNC_ISDIO_TYPE_SUP_CODE5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01bc</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10219,6 +11192,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_ISDIO_TYPE_SUP_CODE_CFG_REG_FUNC_ISDIO_TYPE_SUP_CODE6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01c0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10234,6 +11208,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_INFO_CFG_REG_FUNC_INFO0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01c8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10249,6 +11224,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_INFO_CFG_REG_FUNC_INFO1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01cc</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10264,6 +11240,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_INFO_CFG_REG_FUNC_INFO2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01d0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10279,6 +11256,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_INFO_CFG_REG_FUNC_INFO3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01d4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10294,6 +11272,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_INFO_CFG_REG_FUNC_INFO4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01d8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10309,6 +11288,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_INFO_CFG_REG_FUNC_INFO5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01dc</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10324,6 +11304,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_FUNC_INFO_CFG_REG_FUNC_INFO6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01e0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10339,6 +11320,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_REG_UHS_1_SUPPORT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/ifsub/sddc_v0.2.sv]]></description>
                     <addressOffset>0x01f0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10380,6 +11362,8 @@ position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_CTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10409,6 +11393,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FSTAT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10473,6 +11459,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FDEBUG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10537,6 +11525,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FLEVEL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10657,6 +11647,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_TXF0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10672,6 +11664,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_TXF1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10687,6 +11681,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_TXF2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10702,6 +11698,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_TXF3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10717,6 +11715,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_RXF0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10732,6 +11732,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_RXF1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10747,6 +11749,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_RXF2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10762,6 +11766,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_RXF3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10777,6 +11783,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IRQ</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10792,6 +11800,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IRQ_FORCE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10807,6 +11817,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SYNC_BYPASS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10822,6 +11834,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_DBG_PADOUT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x003c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10837,6 +11851,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_DBG_PADOE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10852,6 +11868,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_DBG_CFGINFO</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0044</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10881,6 +11899,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0048</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10896,6 +11916,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x004c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10911,6 +11933,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0050</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10926,6 +11950,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0054</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10941,6 +11967,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0058</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10956,6 +11984,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x005c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10971,6 +12001,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0060</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -10986,6 +12018,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0064</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11001,6 +12035,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM8</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0068</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11016,6 +12052,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM9</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x006c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11031,6 +12069,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM10</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0070</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11046,6 +12086,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM11</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0074</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11061,6 +12103,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM12</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0078</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11076,6 +12120,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM13</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x007c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11091,6 +12137,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM14</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0080</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11106,6 +12154,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM15</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0084</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11121,6 +12171,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM16</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0088</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11136,6 +12188,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM17</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x008c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11151,6 +12205,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM18</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0090</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11166,6 +12222,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM19</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0094</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11181,6 +12239,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM20</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0098</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11196,6 +12256,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM21</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x009c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11211,6 +12273,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM22</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00a0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11226,6 +12290,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM23</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00a4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11241,6 +12307,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM24</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00a8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11256,6 +12324,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM25</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00ac</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11271,6 +12341,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM26</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00b0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11286,6 +12358,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM27</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00b4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11301,6 +12375,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM28</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00b8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11316,6 +12392,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM29</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00bc</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11331,6 +12409,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM30</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00c0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11346,6 +12426,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INSTR_MEM31</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00c4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11361,6 +12443,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM0_CLKDIV</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00c8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11390,6 +12474,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM0_EXECCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00cc</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11482,6 +12568,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM0_SHIFTCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00d0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11553,6 +12641,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM0_ADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00d4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11568,6 +12658,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM0_INSTR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00d8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11583,6 +12675,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM0_PINCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00dc</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11640,6 +12734,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM1_CLKDIV</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00e0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11669,6 +12765,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM1_EXECCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00e4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11761,6 +12859,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM1_SHIFTCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00e8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11832,6 +12932,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM1_ADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00ec</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11847,6 +12949,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM1_INSTR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00f0</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11862,6 +12966,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM1_PINCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00f4</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11919,6 +13025,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM2_CLKDIV</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00f8</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -11948,6 +13056,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM2_EXECCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x00fc</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12040,6 +13150,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM2_SHIFTCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0100</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12111,6 +13223,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM2_ADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0104</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12126,6 +13240,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM2_INSTR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0108</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12141,6 +13257,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM2_PINCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x010c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12198,6 +13316,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM3_CLKDIV</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0110</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12227,6 +13347,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM3_EXECCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0114</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12319,6 +13441,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM3_SHIFTCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0118</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12390,6 +13514,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM3_ADDR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x011c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12405,6 +13531,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM3_INSTR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0120</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12420,6 +13548,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SM3_PINCTRL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0124</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12477,6 +13607,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_INTR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0128</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12506,6 +13638,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IRQ0_INTE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x012c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12535,6 +13669,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IRQ0_INTF</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0130</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12564,6 +13700,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IRQ0_INTS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0134</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12593,6 +13731,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IRQ1_INTE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0138</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12622,6 +13762,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IRQ1_INTF</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x013c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12651,6 +13793,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IRQ1_INTS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0140</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12680,6 +13824,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IO_OE_INV</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0180</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12695,6 +13841,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IO_O_INV</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0184</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12710,6 +13858,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IO_I_INV</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0188</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12725,6 +13875,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_FIFO_MARGIN</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x018c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12789,6 +13941,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ZERO0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0190</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12804,6 +13958,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ZERO1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0194</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12819,6 +13975,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ZERO2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x0198</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12834,6 +13992,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ZERO3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/pio/rp_pio.sv]]></description>
                     <addressOffset>0x019c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12861,6 +14021,7 @@ position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_CACHE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/coresub_sramtrm_v0.1.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12876,6 +14037,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ITCM</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/coresub_sramtrm_v0.1.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12891,6 +14053,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_DTCM</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/coresub_sramtrm_v0.1.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12906,6 +14069,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SRAM0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/coresub_sramtrm_v0.1.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12921,6 +14085,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SRAM1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/coresub_sramtrm_v0.1.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12936,6 +14101,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_VEXRAM</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/coresub_sramtrm_v0.1.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12949,10 +14115,27 @@ position to clear the flag]]></description>
                         </field>
                     </fields>
                 </register>
+                <register>
+                    <name>SFR_SRAMERR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/coresub_sramtrm_v0.1.sv]]></description>
+                    <addressOffset>0x0020</addressOffset>
+                    <resetValue>0x00</resetValue>
+                    <size>32</size>
+                    <fields>
+                        <field>
+                            <name>srambankerr</name>
+                            <msb>3</msb>
+                            <bitRange>[3:0]</bitRange>
+                            <lsb>0</lsb>
+                            <description><![CDATA[srambankerr flag register. `1` means event happened, write back `1` in
+respective bit position to clear the flag]]></description>
+                        </field>
+                    </fields>
+                </register>
             </registers>
             <addressBlock>
                 <offset>0</offset>
-                <size>0x18</size>
+                <size>0x24</size>
                 <usage>registers</usage>
             </addressBlock>
         </peripheral>
@@ -12963,6 +14146,7 @@ position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_EVSEL_CR_EVSEL0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12978,6 +14162,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_EVSEL_CR_EVSEL1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -12993,6 +14178,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_EVSEL_CR_EVSEL2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13008,6 +14194,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_EVSEL_CR_EVSEL3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13023,6 +14210,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_EVSEL_CR_EVSEL4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13038,6 +14226,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_EVSEL_CR_EVSEL5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13053,6 +14242,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_EVSEL_CR_EVSEL6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13068,6 +14258,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_EVSEL_CR_EVSEL7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13083,6 +14274,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CR_CR_MDMAREQ0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13098,6 +14290,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CR_CR_MDMAREQ1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13113,6 +14306,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CR_CR_MDMAREQ2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0028</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13128,6 +14322,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CR_CR_MDMAREQ3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x002c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13143,6 +14338,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CR_CR_MDMAREQ4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0030</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13158,6 +14354,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CR_CR_MDMAREQ5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0034</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13173,6 +14370,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CR_CR_MDMAREQ6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0038</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13188,6 +14386,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_CR_CR_MDMAREQ7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x003c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13203,6 +14402,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SR_SR_MDMAREQ0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13218,6 +14418,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SR_SR_MDMAREQ1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0044</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13233,6 +14434,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SR_SR_MDMAREQ2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0048</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13248,6 +14450,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SR_SR_MDMAREQ3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x004c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13263,6 +14466,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SR_SR_MDMAREQ4</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0050</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13278,6 +14482,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SR_SR_MDMAREQ5</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0054</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13293,6 +14498,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SR_SR_MDMAREQ6</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x0058</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13308,6 +14514,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_SR_SR_MDMAREQ7</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/mdma_v0.1.sv]]></description>
                     <addressOffset>0x005c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13335,6 +14542,7 @@ position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_IO</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13350,6 +14558,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_AR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13365,6 +14574,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_IODRV</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13380,6 +14590,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_XIP_ADDRMODE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0010</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13395,6 +14606,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_XIP_OPCODE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0014</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13410,6 +14622,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_XIP_WIDTH</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13425,6 +14638,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_XIP_SSEL</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13440,6 +14654,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_XIP_DUMCYC</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0020</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13455,6 +14670,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_XIP_CFG</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0024</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13470,6 +14686,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_AESKEY_AESKEYIN0</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0040</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13485,6 +14702,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_AESKEY_AESKEYIN1</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0044</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13500,6 +14718,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_AESKEY_AESKEYIN2</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0048</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13515,6 +14734,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_AESKEY_AESKEYIN3</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x004c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13530,6 +14750,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>CR_AESENA</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/core/qfc_v0.2.sv]]></description>
                     <addressOffset>0x0050</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13557,6 +14778,8 @@ position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_WDATA</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/mbox_v0.1.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13572,6 +14795,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_RDATA</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/mbox_v0.1.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13587,6 +14812,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_STATUS</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/mbox_v0.1.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13637,6 +14864,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_ABORT</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/mbox_v0.1.sv]]></description>
                     <addressOffset>0x0018</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13652,6 +14881,8 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_DONE</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/ips/vexriscv/cram-
+soc/candidate/mbox_v0.1.sv]]></description>
                     <addressOffset>0x001c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13679,6 +14910,7 @@ position to clear the flag]]></description>
             <registers>
                 <register>
                     <name>SFR_GCMASK</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sec/gluechain_v0.1.sv]]></description>
                     <addressOffset>0x0000</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13694,6 +14926,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GCSR</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sec/gluechain_v0.1.sv]]></description>
                     <addressOffset>0x0004</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13709,6 +14942,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GCRST</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sec/gluechain_v0.1.sv]]></description>
                     <addressOffset>0x0008</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13724,6 +14958,7 @@ position to clear the flag]]></description>
                 </register>
                 <register>
                     <name>SFR_GCTEST</name>
+                    <description><![CDATA[See file:///F:/code/cram-soc/soc-oss/rtl/sec/gluechain_v0.1.sv]]></description>
                     <addressOffset>0x000c</addressOffset>
                     <resetValue>0x00</resetValue>
                     <size>32</size>
@@ -13741,466 +14976,6 @@ position to clear the flag]]></description>
             <addressBlock>
                 <offset>0</offset>
                 <size>0x10</size>
-                <usage>registers</usage>
-            </addressBlock>
-        </peripheral>
-        <peripheral>
-            <name>MESH</name>
-            <baseAddress>0x40052000</baseAddress>
-            <groupName>MESH</groupName>
-            <registers>
-                <register>
-                    <name>SFR_MLDRV_CR_MLDRV0</name>
-                    <addressOffset>0x0000</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_mldrv0</name>
-                            <msb>31</msb>
-                            <bitRange>[31:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_mldrv read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_MLIE_CR_MLIE0</name>
-                    <addressOffset>0x0004</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_mlie0</name>
-                            <msb>31</msb>
-                            <bitRange>[31:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_mlie read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_MLSR_SR_MLSR0</name>
-                    <addressOffset>0x0008</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>sr_mlsr0</name>
-                            <msb>31</msb>
-                            <bitRange>[31:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[sr_mlsr read only status register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_MLSR_SR_MLSR1</name>
-                    <addressOffset>0x000c</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>sr_mlsr1</name>
-                            <msb>31</msb>
-                            <bitRange>[31:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[sr_mlsr read only status register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_MLSR_SR_MLSR2</name>
-                    <addressOffset>0x0010</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>sr_mlsr2</name>
-                            <msb>31</msb>
-                            <bitRange>[31:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[sr_mlsr read only status register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_MLSR_SR_MLSR3</name>
-                    <addressOffset>0x0014</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>sr_mlsr3</name>
-                            <msb>31</msb>
-                            <bitRange>[31:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[sr_mlsr read only status register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_MLSR_SR_MLSR4</name>
-                    <addressOffset>0x0018</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>sr_mlsr4</name>
-                            <msb>31</msb>
-                            <bitRange>[31:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[sr_mlsr read only status register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_MLSR_SR_MLSR5</name>
-                    <addressOffset>0x001c</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>sr_mlsr5</name>
-                            <msb>31</msb>
-                            <bitRange>[31:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[sr_mlsr read only status register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_MLSR_SR_MLSR6</name>
-                    <addressOffset>0x0020</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>sr_mlsr6</name>
-                            <msb>31</msb>
-                            <bitRange>[31:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[sr_mlsr read only status register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_MLSR_SR_MLSR7</name>
-                    <addressOffset>0x0024</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>sr_mlsr7</name>
-                            <msb>31</msb>
-                            <bitRange>[31:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[sr_mlsr read only status register]]></description>
-                        </field>
-                    </fields>
-                </register>
-            </registers>
-            <addressBlock>
-                <offset>0</offset>
-                <size>0x28</size>
-                <usage>registers</usage>
-            </addressBlock>
-        </peripheral>
-        <peripheral>
-            <name>SENSORC</name>
-            <baseAddress>0x40053000</baseAddress>
-            <groupName>SENSORC</groupName>
-            <registers>
-                <register>
-                    <name>SFR_VDMASK0</name>
-                    <addressOffset>0x0000</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_vdmask0</name>
-                            <msb>7</msb>
-                            <bitRange>[7:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_vdmask0 read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDMASK1</name>
-                    <addressOffset>0x0004</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_vdmask1</name>
-                            <msb>7</msb>
-                            <bitRange>[7:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_vdmask1 read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDSR</name>
-                    <addressOffset>0x0008</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>vdflag</name>
-                            <msb>7</msb>
-                            <bitRange>[7:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[vdflag read only status register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDFR</name>
-                    <addressOffset>0x000c</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>vdflag</name>
-                            <msb>7</msb>
-                            <bitRange>[7:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[vdflag flag register. `1` means event happened, write back `1` in respective bit
-position to clear the flag]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_LDMASK</name>
-                    <addressOffset>0x0010</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_ldmask</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_ldmask read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_LDSR</name>
-                    <addressOffset>0x0014</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>sr_ldsr</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[sr_ldsr read only status register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_LDCFG</name>
-                    <addressOffset>0x0018</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>sfr_ldcfg</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[sfr_ldcfg read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDCFG_CR_VDCFG0</name>
-                    <addressOffset>0x0020</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_vdcfg0</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_vdcfg read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDCFG_CR_VDCFG1</name>
-                    <addressOffset>0x0024</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_vdcfg1</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_vdcfg read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDCFG_CR_VDCFG2</name>
-                    <addressOffset>0x0028</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_vdcfg2</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_vdcfg read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDCFG_CR_VDCFG3</name>
-                    <addressOffset>0x002c</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_vdcfg3</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_vdcfg read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDCFG_CR_VDCFG4</name>
-                    <addressOffset>0x0030</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_vdcfg4</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_vdcfg read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDCFG_CR_VDCFG5</name>
-                    <addressOffset>0x0034</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_vdcfg5</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_vdcfg read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDCFG_CR_VDCFG6</name>
-                    <addressOffset>0x0038</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_vdcfg6</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_vdcfg read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDCFG_CR_VDCFG7</name>
-                    <addressOffset>0x003c</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>cr_vdcfg7</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[cr_vdcfg read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDIP_ENA</name>
-                    <addressOffset>0x0040</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>vdena</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[vdena read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_VDIP_TEST</name>
-                    <addressOffset>0x0044</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>vdtst</name>
-                            <msb>7</msb>
-                            <bitRange>[7:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[vdtst read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_LDIP_TEST</name>
-                    <addressOffset>0x0048</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>ldtst</name>
-                            <msb>3</msb>
-                            <bitRange>[3:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[ldtst read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <name>SFR_LDIP_FD</name>
-                    <addressOffset>0x004c</addressOffset>
-                    <resetValue>0x00</resetValue>
-                    <size>32</size>
-                    <fields>
-                        <field>
-                            <name>sfr_ldip_fd</name>
-                            <msb>15</msb>
-                            <bitRange>[15:0]</bitRange>
-                            <lsb>0</lsb>
-                            <description><![CDATA[sfr_ldip_fd read/write control register]]></description>
-                        </field>
-                    </fields>
-                </register>
-            </registers>
-            <addressBlock>
-                <offset>0</offset>
-                <size>0x50</size>
                 <usage>registers</usage>
             </addressBlock>
         </peripheral>

--- a/utralib/cramium/soc.svd
+++ b/utralib/cramium/soc.svd
@@ -3,7 +3,7 @@
 <device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd" >
     <vendor>litex</vendor>
     <name>SOC</name>
-    <description><![CDATA[Litex SoC 2023-09-15 20:42:27]]></description>
+    <description><![CDATA[Litex SoC 2024-01-16 14:55:54]]></description>
 
     <addressUnitBits>8</addressUnitBits>
     <width>32</width>

--- a/utralib/src/generated.rs
+++ b/utralib/src/generated.rs
@@ -29,13 +29,6 @@ mod precursor_pvt;
 #[rustfmt::skip]
 pub use precursor_pvt::*;
 
-#[cfg(feature = "atsama5d27")]
-#[rustfmt::skip]
-mod atsama5d27;
-#[cfg(feature = "atsama5d27")]
-#[rustfmt::skip]
-pub use atsama5d27::*;
-
 #[cfg(feature = "cramium-soc")]
 #[rustfmt::skip]
 mod cramium_soc;
@@ -49,6 +42,13 @@ mod cramium_fpga;
 #[cfg(feature = "cramium-fpga")]
 #[rustfmt::skip]
 pub use cramium_fpga::*;
+
+#[cfg(feature = "atsama5d27")]
+#[rustfmt::skip]
+mod atsama5d27;
+#[cfg(feature = "atsama5d27")]
+#[rustfmt::skip]
+pub use atsama5d27::*;
 
 // Hosted mode includes nothing, as it relies on the abstract host
 // architecture for I/O; so this file is empty when the "hosted"

--- a/utralib/src/generated/cramium_fpga.rs
+++ b/utralib/src/generated/cramium_fpga.rs
@@ -406,8 +406,6 @@ pub const HW_MDMA_BASE :   usize = 0x40012000;
 pub const HW_QFC_BASE :   usize = 0x40010000;
 pub const HW_MBOX_APB_BASE :   usize = 0x40013000;
 pub const HW_GLUECHAIN_BASE :   usize = 0x40054000;
-pub const HW_MESH_BASE :   usize = 0x40052000;
-pub const HW_SENSORC_BASE :   usize = 0x40053000;
 
 
 pub mod utra {
@@ -2910,9 +2908,10 @@ pub mod utra {
         pub const REG_TX_CFG_R_TX_EN: crate::Field = crate::Field::new(1, 4, REG_TX_CFG);
         pub const REG_TX_CFG_R_TX_CLR: crate::Field = crate::Field::new(1, 5, REG_TX_CFG);
 
-        pub const REG_CMD_OP: crate::Register = crate::Register::new(8, 0x3f07);
+        pub const REG_CMD_OP: crate::Register = crate::Register::new(8, 0x33f07);
         pub const REG_CMD_OP_R_CMD_RSP_TYPE: crate::Field = crate::Field::new(3, 0, REG_CMD_OP);
         pub const REG_CMD_OP_R_CMD_OP: crate::Field = crate::Field::new(6, 8, REG_CMD_OP);
+        pub const REG_CMD_OP_R_CMD_STOPOPT: crate::Field = crate::Field::new(2, 16, REG_CMD_OP);
 
         pub const REG_DATA_SETUP: crate::Register = crate::Register::new(10, 0x3ffff07);
         pub const REG_DATA_SETUP_R_DATA_EN: crate::Field = crate::Field::new(1, 0, REG_DATA_SETUP);
@@ -3288,7 +3287,7 @@ pub mod utra {
     }
 
     pub mod aes {
-        pub const AES_NUMREGS: usize = 11;
+        pub const AES_NUMREGS: usize = 13;
 
         pub const SFR_CRFUNC: crate::Register = crate::Register::new(0, 0xff);
         pub const SFR_CRFUNC_SFR_CRFUNC: crate::Field = crate::Field::new(8, 0, SFR_CRFUNC);
@@ -3313,8 +3312,14 @@ pub mod utra {
         pub const SFR_OPT1: crate::Register = crate::Register::new(5, 0xffff);
         pub const SFR_OPT1_SFR_OPT1: crate::Field = crate::Field::new(16, 0, SFR_OPT1);
 
-        pub const SFR_OPTLTX: crate::Register = crate::Register::new(6, 0xf);
-        pub const SFR_OPTLTX_SFR_OPTLTX: crate::Field = crate::Field::new(4, 0, SFR_OPTLTX);
+        pub const SFR_OPTLTX: crate::Register = crate::Register::new(6, 0x3f);
+        pub const SFR_OPTLTX_SFR_OPTLTX: crate::Field = crate::Field::new(6, 0, SFR_OPTLTX);
+
+        pub const SFR_MASKSEED: crate::Register = crate::Register::new(8, 0xffffffff);
+        pub const SFR_MASKSEED_SFR_MASKSEED: crate::Field = crate::Field::new(32, 0, SFR_MASKSEED);
+
+        pub const SFR_MASKSEEDAR: crate::Register = crate::Register::new(9, 0xffffffff);
+        pub const SFR_MASKSEEDAR_SFR_MASKSEEDAR: crate::Field = crate::Field::new(32, 0, SFR_MASKSEEDAR);
 
         pub const SFR_SEGPTR_PTRID_IV: crate::Register = crate::Register::new(12, 0xfff);
         pub const SFR_SEGPTR_PTRID_IV_PTRID_IV: crate::Field = crate::Field::new(12, 0, SFR_SEGPTR_PTRID_IV);
@@ -3561,7 +3566,7 @@ pub mod utra {
     }
 
     pub mod trng {
-        pub const TRNG_NUMREGS: usize = 9;
+        pub const TRNG_NUMREGS: usize = 13;
 
         pub const SFR_CRSRC: crate::Register = crate::Register::new(0, 0xfff);
         pub const SFR_CRSRC_SFR_CRSRC: crate::Field = crate::Field::new(12, 0, SFR_CRSRC);
@@ -3583,6 +3588,18 @@ pub mod utra {
 
         pub const SFR_FR: crate::Register = crate::Register::new(6, 0x3);
         pub const SFR_FR_SFR_FR: crate::Field = crate::Field::new(2, 0, SFR_FR);
+
+        pub const SFR_DRPSZ: crate::Register = crate::Register::new(8, 0xffffffff);
+        pub const SFR_DRPSZ_SFR_DRPSZ: crate::Field = crate::Field::new(32, 0, SFR_DRPSZ);
+
+        pub const SFR_DRGEN: crate::Register = crate::Register::new(9, 0xffffffff);
+        pub const SFR_DRGEN_SFR_DRGEN: crate::Field = crate::Field::new(32, 0, SFR_DRGEN);
+
+        pub const SFR_DRRESEED: crate::Register = crate::Register::new(10, 0xffffffff);
+        pub const SFR_DRRESEED_SFR_DRRESEED: crate::Field = crate::Field::new(32, 0, SFR_DRRESEED);
+
+        pub const SFR_BUF: crate::Register = crate::Register::new(12, 0xffffffff);
+        pub const SFR_BUF_SFR_BUF: crate::Field = crate::Field::new(32, 0, SFR_BUF);
 
         pub const SFR_CHAIN_RNGCHAINEN0: crate::Register = crate::Register::new(16, 0xffffffff);
         pub const SFR_CHAIN_RNGCHAINEN0_RNGCHAINEN0: crate::Field = crate::Field::new(32, 0, SFR_CHAIN_RNGCHAINEN0);
@@ -3702,13 +3719,19 @@ pub mod utra {
     }
 
     pub mod sysctrl {
-        pub const SYSCTRL_NUMREGS: usize = 33;
+        pub const SYSCTRL_NUMREGS: usize = 35;
 
         pub const SFR_CGUSEC: crate::Register = crate::Register::new(0, 0xffff);
         pub const SFR_CGUSEC_SFR_CGUSEC: crate::Field = crate::Field::new(16, 0, SFR_CGUSEC);
 
         pub const SFR_CGULP: crate::Register = crate::Register::new(1, 0xffff);
         pub const SFR_CGULP_SFR_CGULP: crate::Field = crate::Field::new(16, 0, SFR_CGULP);
+
+        pub const SFR_SEED: crate::Register = crate::Register::new(2, 0xffffffff);
+        pub const SFR_SEED_SFR_SEED: crate::Field = crate::Field::new(32, 0, SFR_SEED);
+
+        pub const SFR_SEEDAR: crate::Register = crate::Register::new(3, 0xffffffff);
+        pub const SFR_SEEDAR_SFR_SEEDAR: crate::Field = crate::Field::new(32, 0, SFR_SEEDAR);
 
         pub const SFR_CGUSEL0: crate::Register = crate::Register::new(4, 0x3);
         pub const SFR_CGUSEL0_SFR_CGUSEL0: crate::Field = crate::Field::new(2, 0, SFR_CGUSEL0);
@@ -3813,7 +3836,7 @@ pub mod utra {
     }
 
     pub mod iox {
-        pub const IOX_NUMREGS: usize = 46;
+        pub const IOX_NUMREGS: usize = 64;
 
         pub const SFR_AFSEL_CRAFSEL0: crate::Register = crate::Register::new(0, 0xffff);
         pub const SFR_AFSEL_CRAFSEL0_CRAFSEL0: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL0);
@@ -3838,6 +3861,18 @@ pub mod utra {
 
         pub const SFR_AFSEL_CRAFSEL7: crate::Register = crate::Register::new(7, 0xffff);
         pub const SFR_AFSEL_CRAFSEL7_CRAFSEL7: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL7);
+
+        pub const SFR_AFSEL_CRAFSEL8: crate::Register = crate::Register::new(8, 0xffff);
+        pub const SFR_AFSEL_CRAFSEL8_CRAFSEL8: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL8);
+
+        pub const SFR_AFSEL_CRAFSEL9: crate::Register = crate::Register::new(9, 0xffff);
+        pub const SFR_AFSEL_CRAFSEL9_CRAFSEL9: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL9);
+
+        pub const SFR_AFSEL_CRAFSEL10: crate::Register = crate::Register::new(10, 0xffff);
+        pub const SFR_AFSEL_CRAFSEL10_CRAFSEL10: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL10);
+
+        pub const SFR_AFSEL_CRAFSEL11: crate::Register = crate::Register::new(11, 0xffff);
+        pub const SFR_AFSEL_CRAFSEL11_CRAFSEL11: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL11);
 
         pub const SFR_INTCR_CRINT0: crate::Register = crate::Register::new(64, 0x3ff);
         pub const SFR_INTCR_CRINT0_CRINT0: crate::Field = crate::Field::new(10, 0, SFR_INTCR_CRINT0);
@@ -3878,41 +3913,65 @@ pub mod utra {
         pub const SFR_GPIOOUT_CRGO3: crate::Register = crate::Register::new(79, 0xffff);
         pub const SFR_GPIOOUT_CRGO3_CRGO3: crate::Field = crate::Field::new(16, 0, SFR_GPIOOUT_CRGO3);
 
-        pub const SFR_GPIOOE_CRGOE0: crate::Register = crate::Register::new(80, 0xffff);
+        pub const SFR_GPIOOUT_CRGO4: crate::Register = crate::Register::new(80, 0xffff);
+        pub const SFR_GPIOOUT_CRGO4_CRGO4: crate::Field = crate::Field::new(16, 0, SFR_GPIOOUT_CRGO4);
+
+        pub const SFR_GPIOOUT_CRGO5: crate::Register = crate::Register::new(81, 0xffff);
+        pub const SFR_GPIOOUT_CRGO5_CRGO5: crate::Field = crate::Field::new(16, 0, SFR_GPIOOUT_CRGO5);
+
+        pub const SFR_GPIOOE_CRGOE0: crate::Register = crate::Register::new(82, 0xffff);
         pub const SFR_GPIOOE_CRGOE0_CRGOE0: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE0);
 
-        pub const SFR_GPIOOE_CRGOE1: crate::Register = crate::Register::new(81, 0xffff);
+        pub const SFR_GPIOOE_CRGOE1: crate::Register = crate::Register::new(83, 0xffff);
         pub const SFR_GPIOOE_CRGOE1_CRGOE1: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE1);
 
-        pub const SFR_GPIOOE_CRGOE2: crate::Register = crate::Register::new(82, 0xffff);
+        pub const SFR_GPIOOE_CRGOE2: crate::Register = crate::Register::new(84, 0xffff);
         pub const SFR_GPIOOE_CRGOE2_CRGOE2: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE2);
 
-        pub const SFR_GPIOOE_CRGOE3: crate::Register = crate::Register::new(83, 0xffff);
+        pub const SFR_GPIOOE_CRGOE3: crate::Register = crate::Register::new(85, 0xffff);
         pub const SFR_GPIOOE_CRGOE3_CRGOE3: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE3);
 
-        pub const SFR_GPIOPU_CRGPU0: crate::Register = crate::Register::new(84, 0xffff);
+        pub const SFR_GPIOOE_CRGOE4: crate::Register = crate::Register::new(86, 0xffff);
+        pub const SFR_GPIOOE_CRGOE4_CRGOE4: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE4);
+
+        pub const SFR_GPIOOE_CRGOE5: crate::Register = crate::Register::new(87, 0xffff);
+        pub const SFR_GPIOOE_CRGOE5_CRGOE5: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE5);
+
+        pub const SFR_GPIOPU_CRGPU0: crate::Register = crate::Register::new(88, 0xffff);
         pub const SFR_GPIOPU_CRGPU0_CRGPU0: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU0);
 
-        pub const SFR_GPIOPU_CRGPU1: crate::Register = crate::Register::new(85, 0xffff);
+        pub const SFR_GPIOPU_CRGPU1: crate::Register = crate::Register::new(89, 0xffff);
         pub const SFR_GPIOPU_CRGPU1_CRGPU1: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU1);
 
-        pub const SFR_GPIOPU_CRGPU2: crate::Register = crate::Register::new(86, 0xffff);
+        pub const SFR_GPIOPU_CRGPU2: crate::Register = crate::Register::new(90, 0xffff);
         pub const SFR_GPIOPU_CRGPU2_CRGPU2: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU2);
 
-        pub const SFR_GPIOPU_CRGPU3: crate::Register = crate::Register::new(87, 0xffff);
+        pub const SFR_GPIOPU_CRGPU3: crate::Register = crate::Register::new(91, 0xffff);
         pub const SFR_GPIOPU_CRGPU3_CRGPU3: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU3);
 
-        pub const SFR_GPIOIN_SRGI0: crate::Register = crate::Register::new(88, 0xffff);
+        pub const SFR_GPIOPU_CRGPU4: crate::Register = crate::Register::new(92, 0xffff);
+        pub const SFR_GPIOPU_CRGPU4_CRGPU4: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU4);
+
+        pub const SFR_GPIOPU_CRGPU5: crate::Register = crate::Register::new(93, 0xffff);
+        pub const SFR_GPIOPU_CRGPU5_CRGPU5: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU5);
+
+        pub const SFR_GPIOIN_SRGI0: crate::Register = crate::Register::new(94, 0xffff);
         pub const SFR_GPIOIN_SRGI0_SRGI0: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI0);
 
-        pub const SFR_GPIOIN_SRGI1: crate::Register = crate::Register::new(89, 0xffff);
+        pub const SFR_GPIOIN_SRGI1: crate::Register = crate::Register::new(95, 0xffff);
         pub const SFR_GPIOIN_SRGI1_SRGI1: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI1);
 
-        pub const SFR_GPIOIN_SRGI2: crate::Register = crate::Register::new(90, 0xffff);
+        pub const SFR_GPIOIN_SRGI2: crate::Register = crate::Register::new(96, 0xffff);
         pub const SFR_GPIOIN_SRGI2_SRGI2: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI2);
 
-        pub const SFR_GPIOIN_SRGI3: crate::Register = crate::Register::new(91, 0xffff);
+        pub const SFR_GPIOIN_SRGI3: crate::Register = crate::Register::new(97, 0xffff);
         pub const SFR_GPIOIN_SRGI3_SRGI3: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI3);
+
+        pub const SFR_GPIOIN_SRGI4: crate::Register = crate::Register::new(98, 0xffff);
+        pub const SFR_GPIOIN_SRGI4_SRGI4: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI4);
+
+        pub const SFR_GPIOIN_SRGI5: crate::Register = crate::Register::new(99, 0xffff);
+        pub const SFR_GPIOIN_SRGI5_SRGI5: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI5);
 
         pub const SFR_PIOSEL: crate::Register = crate::Register::new(128, 0xffffffff);
         pub const SFR_PIOSEL_PIOSEL: crate::Field = crate::Field::new(32, 0, SFR_PIOSEL);
@@ -3929,29 +3988,47 @@ pub mod utra {
         pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL3: crate::Register = crate::Register::new(143, 0xffff);
         pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL3_CR_CFG_SCHMSEL3: crate::Field = crate::Field::new(16, 0, SFR_CFG_SCHM_CR_CFG_SCHMSEL3);
 
-        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW0: crate::Register = crate::Register::new(144, 0xffff);
+        pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL4: crate::Register = crate::Register::new(144, 0xffff);
+        pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4: crate::Field = crate::Field::new(16, 0, SFR_CFG_SCHM_CR_CFG_SCHMSEL4);
+
+        pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL5: crate::Register = crate::Register::new(145, 0xffff);
+        pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5: crate::Field = crate::Field::new(16, 0, SFR_CFG_SCHM_CR_CFG_SCHMSEL5);
+
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW0: crate::Register = crate::Register::new(146, 0xffff);
         pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW0_CR_CFG_SLEWSLOW0: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW0);
 
-        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW1: crate::Register = crate::Register::new(145, 0xffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW1: crate::Register = crate::Register::new(147, 0xffff);
         pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW1_CR_CFG_SLEWSLOW1: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW1);
 
-        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW2: crate::Register = crate::Register::new(146, 0xffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW2: crate::Register = crate::Register::new(148, 0xffff);
         pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW2_CR_CFG_SLEWSLOW2: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW2);
 
-        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW3: crate::Register = crate::Register::new(147, 0xffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW3: crate::Register = crate::Register::new(149, 0xffff);
         pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW3_CR_CFG_SLEWSLOW3: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW3);
 
-        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL0: crate::Register = crate::Register::new(148, 0xffffffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW4: crate::Register = crate::Register::new(150, 0xffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW4);
+
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW5: crate::Register = crate::Register::new(151, 0xffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW5);
+
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL0: crate::Register = crate::Register::new(152, 0xffffffff);
         pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL0_CR_CFG_DRVSEL0: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL0);
 
-        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL1: crate::Register = crate::Register::new(149, 0xffffffff);
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL1: crate::Register = crate::Register::new(153, 0xffffffff);
         pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL1_CR_CFG_DRVSEL1: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL1);
 
-        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL2: crate::Register = crate::Register::new(150, 0xffffffff);
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL2: crate::Register = crate::Register::new(154, 0xffffffff);
         pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL2_CR_CFG_DRVSEL2: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL2);
 
-        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL3: crate::Register = crate::Register::new(151, 0xffffffff);
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL3: crate::Register = crate::Register::new(155, 0xffffffff);
         pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL3_CR_CFG_DRVSEL3: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL3);
+
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL4: crate::Register = crate::Register::new(156, 0xffffffff);
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL4);
+
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL5: crate::Register = crate::Register::new(157, 0xffffffff);
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL5);
 
         pub const HW_IOX_BASE: usize = 0x5012f000;
     }
@@ -4743,7 +4820,7 @@ pub mod utra {
     }
 
     pub mod coresub_sramtrm {
-        pub const CORESUB_SRAMTRM_NUMREGS: usize = 6;
+        pub const CORESUB_SRAMTRM_NUMREGS: usize = 7;
 
         pub const SFR_CACHE: crate::Register = crate::Register::new(0, 0x7);
         pub const SFR_CACHE_SFR_CACHE: crate::Field = crate::Field::new(3, 0, SFR_CACHE);
@@ -4762,6 +4839,9 @@ pub mod utra {
 
         pub const SFR_VEXRAM: crate::Register = crate::Register::new(5, 0x7);
         pub const SFR_VEXRAM_SFR_VEXRAM: crate::Field = crate::Field::new(3, 0, SFR_VEXRAM);
+
+        pub const SFR_SRAMERR: crate::Register = crate::Register::new(8, 0xf);
+        pub const SFR_SRAMERR_SRAMBANKERR: crate::Field = crate::Field::new(4, 0, SFR_SRAMERR);
 
         pub const HW_CORESUB_SRAMTRM_BASE: usize = 0x40014000;
     }
@@ -4934,105 +5014,6 @@ pub mod utra {
         pub const SFR_GCTEST_GLUETEST: crate::Field = crate::Field::new(32, 0, SFR_GCTEST);
 
         pub const HW_GLUECHAIN_BASE: usize = 0x40054000;
-    }
-
-    pub mod mesh {
-        pub const MESH_NUMREGS: usize = 10;
-
-        pub const SFR_MLDRV_CR_MLDRV0: crate::Register = crate::Register::new(0, 0xffffffff);
-        pub const SFR_MLDRV_CR_MLDRV0_CR_MLDRV0: crate::Field = crate::Field::new(32, 0, SFR_MLDRV_CR_MLDRV0);
-
-        pub const SFR_MLIE_CR_MLIE0: crate::Register = crate::Register::new(1, 0xffffffff);
-        pub const SFR_MLIE_CR_MLIE0_CR_MLIE0: crate::Field = crate::Field::new(32, 0, SFR_MLIE_CR_MLIE0);
-
-        pub const SFR_MLSR_SR_MLSR0: crate::Register = crate::Register::new(2, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR0_SR_MLSR0: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR0);
-
-        pub const SFR_MLSR_SR_MLSR1: crate::Register = crate::Register::new(3, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR1_SR_MLSR1: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR1);
-
-        pub const SFR_MLSR_SR_MLSR2: crate::Register = crate::Register::new(4, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR2_SR_MLSR2: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR2);
-
-        pub const SFR_MLSR_SR_MLSR3: crate::Register = crate::Register::new(5, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR3_SR_MLSR3: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR3);
-
-        pub const SFR_MLSR_SR_MLSR4: crate::Register = crate::Register::new(6, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR4_SR_MLSR4: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR4);
-
-        pub const SFR_MLSR_SR_MLSR5: crate::Register = crate::Register::new(7, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR5_SR_MLSR5: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR5);
-
-        pub const SFR_MLSR_SR_MLSR6: crate::Register = crate::Register::new(8, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR6_SR_MLSR6: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR6);
-
-        pub const SFR_MLSR_SR_MLSR7: crate::Register = crate::Register::new(9, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR7_SR_MLSR7: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR7);
-
-        pub const HW_MESH_BASE: usize = 0x40052000;
-    }
-
-    pub mod sensorc {
-        pub const SENSORC_NUMREGS: usize = 19;
-
-        pub const SFR_VDMASK0: crate::Register = crate::Register::new(0, 0xff);
-        pub const SFR_VDMASK0_CR_VDMASK0: crate::Field = crate::Field::new(8, 0, SFR_VDMASK0);
-
-        pub const SFR_VDMASK1: crate::Register = crate::Register::new(1, 0xff);
-        pub const SFR_VDMASK1_CR_VDMASK1: crate::Field = crate::Field::new(8, 0, SFR_VDMASK1);
-
-        pub const SFR_VDSR: crate::Register = crate::Register::new(2, 0xff);
-        pub const SFR_VDSR_VDFLAG: crate::Field = crate::Field::new(8, 0, SFR_VDSR);
-
-        pub const SFR_VDFR: crate::Register = crate::Register::new(3, 0xff);
-        pub const SFR_VDFR_VDFLAG: crate::Field = crate::Field::new(8, 0, SFR_VDFR);
-
-        pub const SFR_LDMASK: crate::Register = crate::Register::new(4, 0xf);
-        pub const SFR_LDMASK_CR_LDMASK: crate::Field = crate::Field::new(4, 0, SFR_LDMASK);
-
-        pub const SFR_LDSR: crate::Register = crate::Register::new(5, 0xf);
-        pub const SFR_LDSR_SR_LDSR: crate::Field = crate::Field::new(4, 0, SFR_LDSR);
-
-        pub const SFR_LDCFG: crate::Register = crate::Register::new(6, 0xf);
-        pub const SFR_LDCFG_SFR_LDCFG: crate::Field = crate::Field::new(4, 0, SFR_LDCFG);
-
-        pub const SFR_VDCFG_CR_VDCFG0: crate::Register = crate::Register::new(8, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG0_CR_VDCFG0: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG0);
-
-        pub const SFR_VDCFG_CR_VDCFG1: crate::Register = crate::Register::new(9, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG1_CR_VDCFG1: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG1);
-
-        pub const SFR_VDCFG_CR_VDCFG2: crate::Register = crate::Register::new(10, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG2_CR_VDCFG2: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG2);
-
-        pub const SFR_VDCFG_CR_VDCFG3: crate::Register = crate::Register::new(11, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG3_CR_VDCFG3: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG3);
-
-        pub const SFR_VDCFG_CR_VDCFG4: crate::Register = crate::Register::new(12, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG4_CR_VDCFG4: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG4);
-
-        pub const SFR_VDCFG_CR_VDCFG5: crate::Register = crate::Register::new(13, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG5_CR_VDCFG5: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG5);
-
-        pub const SFR_VDCFG_CR_VDCFG6: crate::Register = crate::Register::new(14, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG6_CR_VDCFG6: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG6);
-
-        pub const SFR_VDCFG_CR_VDCFG7: crate::Register = crate::Register::new(15, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG7_CR_VDCFG7: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG7);
-
-        pub const SFR_VDIP_ENA: crate::Register = crate::Register::new(16, 0xf);
-        pub const SFR_VDIP_ENA_VDENA: crate::Field = crate::Field::new(4, 0, SFR_VDIP_ENA);
-
-        pub const SFR_VDIP_TEST: crate::Register = crate::Register::new(17, 0xff);
-        pub const SFR_VDIP_TEST_VDTST: crate::Field = crate::Field::new(8, 0, SFR_VDIP_TEST);
-
-        pub const SFR_LDIP_TEST: crate::Register = crate::Register::new(18, 0xf);
-        pub const SFR_LDIP_TEST_LDTST: crate::Field = crate::Field::new(4, 0, SFR_LDIP_TEST);
-
-        pub const SFR_LDIP_FD: crate::Register = crate::Register::new(19, 0xffff);
-        pub const SFR_LDIP_FD_SFR_LDIP_FD: crate::Field = crate::Field::new(16, 0, SFR_LDIP_FD);
-
-        pub const HW_SENSORC_BASE: usize = 0x40053000;
     }
 }
 
@@ -13759,6 +13740,11 @@ mod tests {
         let mut baz = udma_sdio_csr.zf(utra::udma_sdio::REG_CMD_OP_R_CMD_OP, bar);
         baz |= udma_sdio_csr.ms(utra::udma_sdio::REG_CMD_OP_R_CMD_OP, 1);
         udma_sdio_csr.wfo(utra::udma_sdio::REG_CMD_OP_R_CMD_OP, baz);
+        let bar = udma_sdio_csr.rf(utra::udma_sdio::REG_CMD_OP_R_CMD_STOPOPT);
+        udma_sdio_csr.rmwf(utra::udma_sdio::REG_CMD_OP_R_CMD_STOPOPT, bar);
+        let mut baz = udma_sdio_csr.zf(utra::udma_sdio::REG_CMD_OP_R_CMD_STOPOPT, bar);
+        baz |= udma_sdio_csr.ms(utra::udma_sdio::REG_CMD_OP_R_CMD_STOPOPT, 1);
+        udma_sdio_csr.wfo(utra::udma_sdio::REG_CMD_OP_R_CMD_STOPOPT, baz);
 
         let foo = udma_sdio_csr.r(utra::udma_sdio::REG_DATA_SETUP);
         udma_sdio_csr.wo(utra::udma_sdio::REG_DATA_SETUP, foo);
@@ -14921,6 +14907,22 @@ mod tests {
         baz |= aes_csr.ms(utra::aes::SFR_OPTLTX_SFR_OPTLTX, 1);
         aes_csr.wfo(utra::aes::SFR_OPTLTX_SFR_OPTLTX, baz);
 
+        let foo = aes_csr.r(utra::aes::SFR_MASKSEED);
+        aes_csr.wo(utra::aes::SFR_MASKSEED, foo);
+        let bar = aes_csr.rf(utra::aes::SFR_MASKSEED_SFR_MASKSEED);
+        aes_csr.rmwf(utra::aes::SFR_MASKSEED_SFR_MASKSEED, bar);
+        let mut baz = aes_csr.zf(utra::aes::SFR_MASKSEED_SFR_MASKSEED, bar);
+        baz |= aes_csr.ms(utra::aes::SFR_MASKSEED_SFR_MASKSEED, 1);
+        aes_csr.wfo(utra::aes::SFR_MASKSEED_SFR_MASKSEED, baz);
+
+        let foo = aes_csr.r(utra::aes::SFR_MASKSEEDAR);
+        aes_csr.wo(utra::aes::SFR_MASKSEEDAR, foo);
+        let bar = aes_csr.rf(utra::aes::SFR_MASKSEEDAR_SFR_MASKSEEDAR);
+        aes_csr.rmwf(utra::aes::SFR_MASKSEEDAR_SFR_MASKSEEDAR, bar);
+        let mut baz = aes_csr.zf(utra::aes::SFR_MASKSEEDAR_SFR_MASKSEEDAR, bar);
+        baz |= aes_csr.ms(utra::aes::SFR_MASKSEEDAR_SFR_MASKSEEDAR, 1);
+        aes_csr.wfo(utra::aes::SFR_MASKSEEDAR_SFR_MASKSEEDAR, baz);
+
         let foo = aes_csr.r(utra::aes::SFR_SEGPTR_PTRID_IV);
         aes_csr.wo(utra::aes::SFR_SEGPTR_PTRID_IV, foo);
         let bar = aes_csr.rf(utra::aes::SFR_SEGPTR_PTRID_IV_PTRID_IV);
@@ -15621,6 +15623,38 @@ mod tests {
         baz |= trng_csr.ms(utra::trng::SFR_FR_SFR_FR, 1);
         trng_csr.wfo(utra::trng::SFR_FR_SFR_FR, baz);
 
+        let foo = trng_csr.r(utra::trng::SFR_DRPSZ);
+        trng_csr.wo(utra::trng::SFR_DRPSZ, foo);
+        let bar = trng_csr.rf(utra::trng::SFR_DRPSZ_SFR_DRPSZ);
+        trng_csr.rmwf(utra::trng::SFR_DRPSZ_SFR_DRPSZ, bar);
+        let mut baz = trng_csr.zf(utra::trng::SFR_DRPSZ_SFR_DRPSZ, bar);
+        baz |= trng_csr.ms(utra::trng::SFR_DRPSZ_SFR_DRPSZ, 1);
+        trng_csr.wfo(utra::trng::SFR_DRPSZ_SFR_DRPSZ, baz);
+
+        let foo = trng_csr.r(utra::trng::SFR_DRGEN);
+        trng_csr.wo(utra::trng::SFR_DRGEN, foo);
+        let bar = trng_csr.rf(utra::trng::SFR_DRGEN_SFR_DRGEN);
+        trng_csr.rmwf(utra::trng::SFR_DRGEN_SFR_DRGEN, bar);
+        let mut baz = trng_csr.zf(utra::trng::SFR_DRGEN_SFR_DRGEN, bar);
+        baz |= trng_csr.ms(utra::trng::SFR_DRGEN_SFR_DRGEN, 1);
+        trng_csr.wfo(utra::trng::SFR_DRGEN_SFR_DRGEN, baz);
+
+        let foo = trng_csr.r(utra::trng::SFR_DRRESEED);
+        trng_csr.wo(utra::trng::SFR_DRRESEED, foo);
+        let bar = trng_csr.rf(utra::trng::SFR_DRRESEED_SFR_DRRESEED);
+        trng_csr.rmwf(utra::trng::SFR_DRRESEED_SFR_DRRESEED, bar);
+        let mut baz = trng_csr.zf(utra::trng::SFR_DRRESEED_SFR_DRRESEED, bar);
+        baz |= trng_csr.ms(utra::trng::SFR_DRRESEED_SFR_DRRESEED, 1);
+        trng_csr.wfo(utra::trng::SFR_DRRESEED_SFR_DRRESEED, baz);
+
+        let foo = trng_csr.r(utra::trng::SFR_BUF);
+        trng_csr.wo(utra::trng::SFR_BUF, foo);
+        let bar = trng_csr.rf(utra::trng::SFR_BUF_SFR_BUF);
+        trng_csr.rmwf(utra::trng::SFR_BUF_SFR_BUF, bar);
+        let mut baz = trng_csr.zf(utra::trng::SFR_BUF_SFR_BUF, bar);
+        baz |= trng_csr.ms(utra::trng::SFR_BUF_SFR_BUF, 1);
+        trng_csr.wfo(utra::trng::SFR_BUF_SFR_BUF, baz);
+
         let foo = trng_csr.r(utra::trng::SFR_CHAIN_RNGCHAINEN0);
         trng_csr.wo(utra::trng::SFR_CHAIN_RNGCHAINEN0, foo);
         let bar = trng_csr.rf(utra::trng::SFR_CHAIN_RNGCHAINEN0_RNGCHAINEN0);
@@ -15902,6 +15936,22 @@ mod tests {
         let mut baz = sysctrl_csr.zf(utra::sysctrl::SFR_CGULP_SFR_CGULP, bar);
         baz |= sysctrl_csr.ms(utra::sysctrl::SFR_CGULP_SFR_CGULP, 1);
         sysctrl_csr.wfo(utra::sysctrl::SFR_CGULP_SFR_CGULP, baz);
+
+        let foo = sysctrl_csr.r(utra::sysctrl::SFR_SEED);
+        sysctrl_csr.wo(utra::sysctrl::SFR_SEED, foo);
+        let bar = sysctrl_csr.rf(utra::sysctrl::SFR_SEED_SFR_SEED);
+        sysctrl_csr.rmwf(utra::sysctrl::SFR_SEED_SFR_SEED, bar);
+        let mut baz = sysctrl_csr.zf(utra::sysctrl::SFR_SEED_SFR_SEED, bar);
+        baz |= sysctrl_csr.ms(utra::sysctrl::SFR_SEED_SFR_SEED, 1);
+        sysctrl_csr.wfo(utra::sysctrl::SFR_SEED_SFR_SEED, baz);
+
+        let foo = sysctrl_csr.r(utra::sysctrl::SFR_SEEDAR);
+        sysctrl_csr.wo(utra::sysctrl::SFR_SEEDAR, foo);
+        let bar = sysctrl_csr.rf(utra::sysctrl::SFR_SEEDAR_SFR_SEEDAR);
+        sysctrl_csr.rmwf(utra::sysctrl::SFR_SEEDAR_SFR_SEEDAR, bar);
+        let mut baz = sysctrl_csr.zf(utra::sysctrl::SFR_SEEDAR_SFR_SEEDAR, bar);
+        baz |= sysctrl_csr.ms(utra::sysctrl::SFR_SEEDAR_SFR_SEEDAR, 1);
+        sysctrl_csr.wfo(utra::sysctrl::SFR_SEEDAR_SFR_SEEDAR, baz);
 
         let foo = sysctrl_csr.r(utra::sysctrl::SFR_CGUSEL0);
         sysctrl_csr.wo(utra::sysctrl::SFR_CGUSEL0, foo);
@@ -16229,6 +16279,38 @@ mod tests {
         baz |= iox_csr.ms(utra::iox::SFR_AFSEL_CRAFSEL7_CRAFSEL7, 1);
         iox_csr.wfo(utra::iox::SFR_AFSEL_CRAFSEL7_CRAFSEL7, baz);
 
+        let foo = iox_csr.r(utra::iox::SFR_AFSEL_CRAFSEL8);
+        iox_csr.wo(utra::iox::SFR_AFSEL_CRAFSEL8, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_AFSEL_CRAFSEL8_CRAFSEL8);
+        iox_csr.rmwf(utra::iox::SFR_AFSEL_CRAFSEL8_CRAFSEL8, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_AFSEL_CRAFSEL8_CRAFSEL8, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_AFSEL_CRAFSEL8_CRAFSEL8, 1);
+        iox_csr.wfo(utra::iox::SFR_AFSEL_CRAFSEL8_CRAFSEL8, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_AFSEL_CRAFSEL9);
+        iox_csr.wo(utra::iox::SFR_AFSEL_CRAFSEL9, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_AFSEL_CRAFSEL9_CRAFSEL9);
+        iox_csr.rmwf(utra::iox::SFR_AFSEL_CRAFSEL9_CRAFSEL9, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_AFSEL_CRAFSEL9_CRAFSEL9, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_AFSEL_CRAFSEL9_CRAFSEL9, 1);
+        iox_csr.wfo(utra::iox::SFR_AFSEL_CRAFSEL9_CRAFSEL9, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_AFSEL_CRAFSEL10);
+        iox_csr.wo(utra::iox::SFR_AFSEL_CRAFSEL10, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_AFSEL_CRAFSEL10_CRAFSEL10);
+        iox_csr.rmwf(utra::iox::SFR_AFSEL_CRAFSEL10_CRAFSEL10, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_AFSEL_CRAFSEL10_CRAFSEL10, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_AFSEL_CRAFSEL10_CRAFSEL10, 1);
+        iox_csr.wfo(utra::iox::SFR_AFSEL_CRAFSEL10_CRAFSEL10, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_AFSEL_CRAFSEL11);
+        iox_csr.wo(utra::iox::SFR_AFSEL_CRAFSEL11, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_AFSEL_CRAFSEL11_CRAFSEL11);
+        iox_csr.rmwf(utra::iox::SFR_AFSEL_CRAFSEL11_CRAFSEL11, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_AFSEL_CRAFSEL11_CRAFSEL11, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_AFSEL_CRAFSEL11_CRAFSEL11, 1);
+        iox_csr.wfo(utra::iox::SFR_AFSEL_CRAFSEL11_CRAFSEL11, baz);
+
         let foo = iox_csr.r(utra::iox::SFR_INTCR_CRINT0);
         iox_csr.wo(utra::iox::SFR_INTCR_CRINT0, foo);
         let bar = iox_csr.rf(utra::iox::SFR_INTCR_CRINT0_CRINT0);
@@ -16333,6 +16415,22 @@ mod tests {
         baz |= iox_csr.ms(utra::iox::SFR_GPIOOUT_CRGO3_CRGO3, 1);
         iox_csr.wfo(utra::iox::SFR_GPIOOUT_CRGO3_CRGO3, baz);
 
+        let foo = iox_csr.r(utra::iox::SFR_GPIOOUT_CRGO4);
+        iox_csr.wo(utra::iox::SFR_GPIOOUT_CRGO4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOOUT_CRGO4_CRGO4);
+        iox_csr.rmwf(utra::iox::SFR_GPIOOUT_CRGO4_CRGO4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOOUT_CRGO4_CRGO4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOOUT_CRGO4_CRGO4, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOOUT_CRGO4_CRGO4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOOUT_CRGO5);
+        iox_csr.wo(utra::iox::SFR_GPIOOUT_CRGO5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOOUT_CRGO5_CRGO5);
+        iox_csr.rmwf(utra::iox::SFR_GPIOOUT_CRGO5_CRGO5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOOUT_CRGO5_CRGO5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOOUT_CRGO5_CRGO5, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOOUT_CRGO5_CRGO5, baz);
+
         let foo = iox_csr.r(utra::iox::SFR_GPIOOE_CRGOE0);
         iox_csr.wo(utra::iox::SFR_GPIOOE_CRGOE0, foo);
         let bar = iox_csr.rf(utra::iox::SFR_GPIOOE_CRGOE0_CRGOE0);
@@ -16364,6 +16462,22 @@ mod tests {
         let mut baz = iox_csr.zf(utra::iox::SFR_GPIOOE_CRGOE3_CRGOE3, bar);
         baz |= iox_csr.ms(utra::iox::SFR_GPIOOE_CRGOE3_CRGOE3, 1);
         iox_csr.wfo(utra::iox::SFR_GPIOOE_CRGOE3_CRGOE3, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOOE_CRGOE4);
+        iox_csr.wo(utra::iox::SFR_GPIOOE_CRGOE4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOOE_CRGOE4_CRGOE4);
+        iox_csr.rmwf(utra::iox::SFR_GPIOOE_CRGOE4_CRGOE4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOOE_CRGOE4_CRGOE4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOOE_CRGOE4_CRGOE4, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOOE_CRGOE4_CRGOE4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOOE_CRGOE5);
+        iox_csr.wo(utra::iox::SFR_GPIOOE_CRGOE5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOOE_CRGOE5_CRGOE5);
+        iox_csr.rmwf(utra::iox::SFR_GPIOOE_CRGOE5_CRGOE5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOOE_CRGOE5_CRGOE5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOOE_CRGOE5_CRGOE5, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOOE_CRGOE5_CRGOE5, baz);
 
         let foo = iox_csr.r(utra::iox::SFR_GPIOPU_CRGPU0);
         iox_csr.wo(utra::iox::SFR_GPIOPU_CRGPU0, foo);
@@ -16397,6 +16511,22 @@ mod tests {
         baz |= iox_csr.ms(utra::iox::SFR_GPIOPU_CRGPU3_CRGPU3, 1);
         iox_csr.wfo(utra::iox::SFR_GPIOPU_CRGPU3_CRGPU3, baz);
 
+        let foo = iox_csr.r(utra::iox::SFR_GPIOPU_CRGPU4);
+        iox_csr.wo(utra::iox::SFR_GPIOPU_CRGPU4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOPU_CRGPU4_CRGPU4);
+        iox_csr.rmwf(utra::iox::SFR_GPIOPU_CRGPU4_CRGPU4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOPU_CRGPU4_CRGPU4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOPU_CRGPU4_CRGPU4, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOPU_CRGPU4_CRGPU4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOPU_CRGPU5);
+        iox_csr.wo(utra::iox::SFR_GPIOPU_CRGPU5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOPU_CRGPU5_CRGPU5);
+        iox_csr.rmwf(utra::iox::SFR_GPIOPU_CRGPU5_CRGPU5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOPU_CRGPU5_CRGPU5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOPU_CRGPU5_CRGPU5, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOPU_CRGPU5_CRGPU5, baz);
+
         let foo = iox_csr.r(utra::iox::SFR_GPIOIN_SRGI0);
         iox_csr.wo(utra::iox::SFR_GPIOIN_SRGI0, foo);
         let bar = iox_csr.rf(utra::iox::SFR_GPIOIN_SRGI0_SRGI0);
@@ -16428,6 +16558,22 @@ mod tests {
         let mut baz = iox_csr.zf(utra::iox::SFR_GPIOIN_SRGI3_SRGI3, bar);
         baz |= iox_csr.ms(utra::iox::SFR_GPIOIN_SRGI3_SRGI3, 1);
         iox_csr.wfo(utra::iox::SFR_GPIOIN_SRGI3_SRGI3, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOIN_SRGI4);
+        iox_csr.wo(utra::iox::SFR_GPIOIN_SRGI4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOIN_SRGI4_SRGI4);
+        iox_csr.rmwf(utra::iox::SFR_GPIOIN_SRGI4_SRGI4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOIN_SRGI4_SRGI4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOIN_SRGI4_SRGI4, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOIN_SRGI4_SRGI4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOIN_SRGI5);
+        iox_csr.wo(utra::iox::SFR_GPIOIN_SRGI5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOIN_SRGI5_SRGI5);
+        iox_csr.rmwf(utra::iox::SFR_GPIOIN_SRGI5_SRGI5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOIN_SRGI5_SRGI5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOIN_SRGI5_SRGI5, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOIN_SRGI5_SRGI5, baz);
 
         let foo = iox_csr.r(utra::iox::SFR_PIOSEL);
         iox_csr.wo(utra::iox::SFR_PIOSEL, foo);
@@ -16469,6 +16615,22 @@ mod tests {
         baz |= iox_csr.ms(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL3_CR_CFG_SCHMSEL3, 1);
         iox_csr.wfo(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL3_CR_CFG_SCHMSEL3, baz);
 
+        let foo = iox_csr.r(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4);
+        iox_csr.wo(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4);
+        iox_csr.rmwf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5);
+        iox_csr.wo(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5);
+        iox_csr.rmwf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5, baz);
+
         let foo = iox_csr.r(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW0);
         iox_csr.wo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW0, foo);
         let bar = iox_csr.rf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW0_CR_CFG_SLEWSLOW0);
@@ -16501,6 +16663,22 @@ mod tests {
         baz |= iox_csr.ms(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW3_CR_CFG_SLEWSLOW3, 1);
         iox_csr.wfo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW3_CR_CFG_SLEWSLOW3, baz);
 
+        let foo = iox_csr.r(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4);
+        iox_csr.wo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4);
+        iox_csr.rmwf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5);
+        iox_csr.wo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5);
+        iox_csr.rmwf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5, baz);
+
         let foo = iox_csr.r(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL0);
         iox_csr.wo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL0, foo);
         let bar = iox_csr.rf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL0_CR_CFG_DRVSEL0);
@@ -16532,6 +16710,22 @@ mod tests {
         let mut baz = iox_csr.zf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL3_CR_CFG_DRVSEL3, bar);
         baz |= iox_csr.ms(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL3_CR_CFG_DRVSEL3, 1);
         iox_csr.wfo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL3_CR_CFG_DRVSEL3, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4);
+        iox_csr.wo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4);
+        iox_csr.rmwf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5);
+        iox_csr.wo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5);
+        iox_csr.rmwf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5, baz);
   }
 
     #[test]
@@ -19041,6 +19235,14 @@ mod tests {
         let mut baz = coresub_sramtrm_csr.zf(utra::coresub_sramtrm::SFR_VEXRAM_SFR_VEXRAM, bar);
         baz |= coresub_sramtrm_csr.ms(utra::coresub_sramtrm::SFR_VEXRAM_SFR_VEXRAM, 1);
         coresub_sramtrm_csr.wfo(utra::coresub_sramtrm::SFR_VEXRAM_SFR_VEXRAM, baz);
+
+        let foo = coresub_sramtrm_csr.r(utra::coresub_sramtrm::SFR_SRAMERR);
+        coresub_sramtrm_csr.wo(utra::coresub_sramtrm::SFR_SRAMERR, foo);
+        let bar = coresub_sramtrm_csr.rf(utra::coresub_sramtrm::SFR_SRAMERR_SRAMBANKERR);
+        coresub_sramtrm_csr.rmwf(utra::coresub_sramtrm::SFR_SRAMERR_SRAMBANKERR, bar);
+        let mut baz = coresub_sramtrm_csr.zf(utra::coresub_sramtrm::SFR_SRAMERR_SRAMBANKERR, bar);
+        baz |= coresub_sramtrm_csr.ms(utra::coresub_sramtrm::SFR_SRAMERR_SRAMBANKERR, 1);
+        coresub_sramtrm_csr.wfo(utra::coresub_sramtrm::SFR_SRAMERR_SRAMBANKERR, baz);
   }
 
     #[test]
@@ -19470,251 +19672,5 @@ mod tests {
         let mut baz = gluechain_csr.zf(utra::gluechain::SFR_GCTEST_GLUETEST, bar);
         baz |= gluechain_csr.ms(utra::gluechain::SFR_GCTEST_GLUETEST, 1);
         gluechain_csr.wfo(utra::gluechain::SFR_GCTEST_GLUETEST, baz);
-  }
-
-    #[test]
-    #[ignore]
-    fn compile_check_mesh_csr() {
-        use super::*;
-        let mut mesh_csr = CSR::new(HW_MESH_BASE as *mut u32);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLDRV_CR_MLDRV0);
-        mesh_csr.wo(utra::mesh::SFR_MLDRV_CR_MLDRV0, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLDRV_CR_MLDRV0_CR_MLDRV0);
-        mesh_csr.rmwf(utra::mesh::SFR_MLDRV_CR_MLDRV0_CR_MLDRV0, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLDRV_CR_MLDRV0_CR_MLDRV0, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLDRV_CR_MLDRV0_CR_MLDRV0, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLDRV_CR_MLDRV0_CR_MLDRV0, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLIE_CR_MLIE0);
-        mesh_csr.wo(utra::mesh::SFR_MLIE_CR_MLIE0, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLIE_CR_MLIE0_CR_MLIE0);
-        mesh_csr.rmwf(utra::mesh::SFR_MLIE_CR_MLIE0_CR_MLIE0, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLIE_CR_MLIE0_CR_MLIE0, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLIE_CR_MLIE0_CR_MLIE0, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLIE_CR_MLIE0_CR_MLIE0, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR0);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR0, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR0_SR_MLSR0);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR0_SR_MLSR0, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR0_SR_MLSR0, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR0_SR_MLSR0, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR0_SR_MLSR0, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR1);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR1, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR1_SR_MLSR1);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR1_SR_MLSR1, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR1_SR_MLSR1, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR1_SR_MLSR1, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR1_SR_MLSR1, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR2);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR2, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR2_SR_MLSR2);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR2_SR_MLSR2, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR2_SR_MLSR2, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR2_SR_MLSR2, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR2_SR_MLSR2, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR3);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR3, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR3_SR_MLSR3);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR3_SR_MLSR3, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR3_SR_MLSR3, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR3_SR_MLSR3, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR3_SR_MLSR3, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR4);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR4, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR4_SR_MLSR4);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR4_SR_MLSR4, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR4_SR_MLSR4, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR4_SR_MLSR4, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR4_SR_MLSR4, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR5);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR5, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR5_SR_MLSR5);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR5_SR_MLSR5, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR5_SR_MLSR5, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR5_SR_MLSR5, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR5_SR_MLSR5, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR6);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR6, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR6_SR_MLSR6);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR6_SR_MLSR6, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR6_SR_MLSR6, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR6_SR_MLSR6, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR6_SR_MLSR6, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR7);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR7, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR7_SR_MLSR7);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR7_SR_MLSR7, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR7_SR_MLSR7, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR7_SR_MLSR7, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR7_SR_MLSR7, baz);
-  }
-
-    #[test]
-    #[ignore]
-    fn compile_check_sensorc_csr() {
-        use super::*;
-        let mut sensorc_csr = CSR::new(HW_SENSORC_BASE as *mut u32);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDMASK0);
-        sensorc_csr.wo(utra::sensorc::SFR_VDMASK0, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDMASK0_CR_VDMASK0);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDMASK0_CR_VDMASK0, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDMASK0_CR_VDMASK0, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDMASK0_CR_VDMASK0, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDMASK0_CR_VDMASK0, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDMASK1);
-        sensorc_csr.wo(utra::sensorc::SFR_VDMASK1, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDMASK1_CR_VDMASK1);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDMASK1_CR_VDMASK1, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDMASK1_CR_VDMASK1, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDMASK1_CR_VDMASK1, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDMASK1_CR_VDMASK1, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDSR);
-        sensorc_csr.wo(utra::sensorc::SFR_VDSR, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDSR_VDFLAG);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDSR_VDFLAG, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDSR_VDFLAG, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDSR_VDFLAG, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDSR_VDFLAG, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDFR);
-        sensorc_csr.wo(utra::sensorc::SFR_VDFR, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDFR_VDFLAG);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDFR_VDFLAG, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDFR_VDFLAG, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDFR_VDFLAG, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDFR_VDFLAG, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_LDMASK);
-        sensorc_csr.wo(utra::sensorc::SFR_LDMASK, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_LDMASK_CR_LDMASK);
-        sensorc_csr.rmwf(utra::sensorc::SFR_LDMASK_CR_LDMASK, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_LDMASK_CR_LDMASK, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_LDMASK_CR_LDMASK, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_LDMASK_CR_LDMASK, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_LDSR);
-        sensorc_csr.wo(utra::sensorc::SFR_LDSR, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_LDSR_SR_LDSR);
-        sensorc_csr.rmwf(utra::sensorc::SFR_LDSR_SR_LDSR, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_LDSR_SR_LDSR, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_LDSR_SR_LDSR, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_LDSR_SR_LDSR, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_LDCFG);
-        sensorc_csr.wo(utra::sensorc::SFR_LDCFG, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_LDCFG_SFR_LDCFG);
-        sensorc_csr.rmwf(utra::sensorc::SFR_LDCFG_SFR_LDCFG, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_LDCFG_SFR_LDCFG, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_LDCFG_SFR_LDCFG, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_LDCFG_SFR_LDCFG, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG0);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG0, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG0_CR_VDCFG0);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG0_CR_VDCFG0, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG0_CR_VDCFG0, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG0_CR_VDCFG0, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG0_CR_VDCFG0, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG1);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG1, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG1_CR_VDCFG1);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG1_CR_VDCFG1, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG1_CR_VDCFG1, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG1_CR_VDCFG1, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG1_CR_VDCFG1, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG2);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG2, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG2_CR_VDCFG2);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG2_CR_VDCFG2, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG2_CR_VDCFG2, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG2_CR_VDCFG2, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG2_CR_VDCFG2, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG3);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG3, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG3_CR_VDCFG3);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG3_CR_VDCFG3, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG3_CR_VDCFG3, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG3_CR_VDCFG3, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG3_CR_VDCFG3, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG4);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG4, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG4_CR_VDCFG4);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG4_CR_VDCFG4, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG4_CR_VDCFG4, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG4_CR_VDCFG4, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG4_CR_VDCFG4, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG5);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG5, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG5_CR_VDCFG5);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG5_CR_VDCFG5, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG5_CR_VDCFG5, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG5_CR_VDCFG5, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG5_CR_VDCFG5, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG6);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG6, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG6_CR_VDCFG6);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG6_CR_VDCFG6, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG6_CR_VDCFG6, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG6_CR_VDCFG6, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG6_CR_VDCFG6, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG7);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG7, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG7_CR_VDCFG7);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG7_CR_VDCFG7, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG7_CR_VDCFG7, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG7_CR_VDCFG7, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG7_CR_VDCFG7, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDIP_ENA);
-        sensorc_csr.wo(utra::sensorc::SFR_VDIP_ENA, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDIP_ENA_VDENA);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDIP_ENA_VDENA, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDIP_ENA_VDENA, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDIP_ENA_VDENA, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDIP_ENA_VDENA, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDIP_TEST);
-        sensorc_csr.wo(utra::sensorc::SFR_VDIP_TEST, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDIP_TEST_VDTST);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDIP_TEST_VDTST, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDIP_TEST_VDTST, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDIP_TEST_VDTST, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDIP_TEST_VDTST, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_LDIP_TEST);
-        sensorc_csr.wo(utra::sensorc::SFR_LDIP_TEST, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_LDIP_TEST_LDTST);
-        sensorc_csr.rmwf(utra::sensorc::SFR_LDIP_TEST_LDTST, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_LDIP_TEST_LDTST, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_LDIP_TEST_LDTST, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_LDIP_TEST_LDTST, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_LDIP_FD);
-        sensorc_csr.wo(utra::sensorc::SFR_LDIP_FD, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_LDIP_FD_SFR_LDIP_FD);
-        sensorc_csr.rmwf(utra::sensorc::SFR_LDIP_FD_SFR_LDIP_FD, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_LDIP_FD_SFR_LDIP_FD, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_LDIP_FD_SFR_LDIP_FD, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_LDIP_FD_SFR_LDIP_FD, baz);
   }
 }

--- a/utralib/src/generated/cramium_soc.rs
+++ b/utralib/src/generated/cramium_soc.rs
@@ -1,4 +1,5 @@
 
+#![cfg_attr(rustfmt, rustfmt_skip)] // don't format generated files
 #![allow(dead_code)]
 use core::convert::TryInto;
 #[cfg(feature="std")]
@@ -389,8 +390,6 @@ pub const HW_MDMA_BASE :   usize = 0x40012000;
 pub const HW_QFC_BASE :   usize = 0x40010000;
 pub const HW_MBOX_APB_BASE :   usize = 0x40013000;
 pub const HW_GLUECHAIN_BASE :   usize = 0x40054000;
-pub const HW_MESH_BASE :   usize = 0x40052000;
-pub const HW_SENSORC_BASE :   usize = 0x40053000;
 
 
 pub mod utra {
@@ -2746,9 +2745,10 @@ pub mod utra {
         pub const REG_TX_CFG_R_TX_EN: crate::Field = crate::Field::new(1, 4, REG_TX_CFG);
         pub const REG_TX_CFG_R_TX_CLR: crate::Field = crate::Field::new(1, 5, REG_TX_CFG);
 
-        pub const REG_CMD_OP: crate::Register = crate::Register::new(8, 0x3f07);
+        pub const REG_CMD_OP: crate::Register = crate::Register::new(8, 0x33f07);
         pub const REG_CMD_OP_R_CMD_RSP_TYPE: crate::Field = crate::Field::new(3, 0, REG_CMD_OP);
         pub const REG_CMD_OP_R_CMD_OP: crate::Field = crate::Field::new(6, 8, REG_CMD_OP);
+        pub const REG_CMD_OP_R_CMD_STOPOPT: crate::Field = crate::Field::new(2, 16, REG_CMD_OP);
 
         pub const REG_DATA_SETUP: crate::Register = crate::Register::new(10, 0x3ffff07);
         pub const REG_DATA_SETUP_R_DATA_EN: crate::Field = crate::Field::new(1, 0, REG_DATA_SETUP);
@@ -3124,7 +3124,7 @@ pub mod utra {
     }
 
     pub mod aes {
-        pub const AES_NUMREGS: usize = 11;
+        pub const AES_NUMREGS: usize = 13;
 
         pub const SFR_CRFUNC: crate::Register = crate::Register::new(0, 0xff);
         pub const SFR_CRFUNC_SFR_CRFUNC: crate::Field = crate::Field::new(8, 0, SFR_CRFUNC);
@@ -3149,8 +3149,14 @@ pub mod utra {
         pub const SFR_OPT1: crate::Register = crate::Register::new(5, 0xffff);
         pub const SFR_OPT1_SFR_OPT1: crate::Field = crate::Field::new(16, 0, SFR_OPT1);
 
-        pub const SFR_OPTLTX: crate::Register = crate::Register::new(6, 0xf);
-        pub const SFR_OPTLTX_SFR_OPTLTX: crate::Field = crate::Field::new(4, 0, SFR_OPTLTX);
+        pub const SFR_OPTLTX: crate::Register = crate::Register::new(6, 0x3f);
+        pub const SFR_OPTLTX_SFR_OPTLTX: crate::Field = crate::Field::new(6, 0, SFR_OPTLTX);
+
+        pub const SFR_MASKSEED: crate::Register = crate::Register::new(8, 0xffffffff);
+        pub const SFR_MASKSEED_SFR_MASKSEED: crate::Field = crate::Field::new(32, 0, SFR_MASKSEED);
+
+        pub const SFR_MASKSEEDAR: crate::Register = crate::Register::new(9, 0xffffffff);
+        pub const SFR_MASKSEEDAR_SFR_MASKSEEDAR: crate::Field = crate::Field::new(32, 0, SFR_MASKSEEDAR);
 
         pub const SFR_SEGPTR_PTRID_IV: crate::Register = crate::Register::new(12, 0xfff);
         pub const SFR_SEGPTR_PTRID_IV_PTRID_IV: crate::Field = crate::Field::new(12, 0, SFR_SEGPTR_PTRID_IV);
@@ -3397,7 +3403,7 @@ pub mod utra {
     }
 
     pub mod trng {
-        pub const TRNG_NUMREGS: usize = 9;
+        pub const TRNG_NUMREGS: usize = 13;
 
         pub const SFR_CRSRC: crate::Register = crate::Register::new(0, 0xfff);
         pub const SFR_CRSRC_SFR_CRSRC: crate::Field = crate::Field::new(12, 0, SFR_CRSRC);
@@ -3419,6 +3425,18 @@ pub mod utra {
 
         pub const SFR_FR: crate::Register = crate::Register::new(6, 0x3);
         pub const SFR_FR_SFR_FR: crate::Field = crate::Field::new(2, 0, SFR_FR);
+
+        pub const SFR_DRPSZ: crate::Register = crate::Register::new(8, 0xffffffff);
+        pub const SFR_DRPSZ_SFR_DRPSZ: crate::Field = crate::Field::new(32, 0, SFR_DRPSZ);
+
+        pub const SFR_DRGEN: crate::Register = crate::Register::new(9, 0xffffffff);
+        pub const SFR_DRGEN_SFR_DRGEN: crate::Field = crate::Field::new(32, 0, SFR_DRGEN);
+
+        pub const SFR_DRRESEED: crate::Register = crate::Register::new(10, 0xffffffff);
+        pub const SFR_DRRESEED_SFR_DRRESEED: crate::Field = crate::Field::new(32, 0, SFR_DRRESEED);
+
+        pub const SFR_BUF: crate::Register = crate::Register::new(12, 0xffffffff);
+        pub const SFR_BUF_SFR_BUF: crate::Field = crate::Field::new(32, 0, SFR_BUF);
 
         pub const SFR_CHAIN_RNGCHAINEN0: crate::Register = crate::Register::new(16, 0xffffffff);
         pub const SFR_CHAIN_RNGCHAINEN0_RNGCHAINEN0: crate::Field = crate::Field::new(32, 0, SFR_CHAIN_RNGCHAINEN0);
@@ -3538,13 +3556,19 @@ pub mod utra {
     }
 
     pub mod sysctrl {
-        pub const SYSCTRL_NUMREGS: usize = 33;
+        pub const SYSCTRL_NUMREGS: usize = 35;
 
         pub const SFR_CGUSEC: crate::Register = crate::Register::new(0, 0xffff);
         pub const SFR_CGUSEC_SFR_CGUSEC: crate::Field = crate::Field::new(16, 0, SFR_CGUSEC);
 
         pub const SFR_CGULP: crate::Register = crate::Register::new(1, 0xffff);
         pub const SFR_CGULP_SFR_CGULP: crate::Field = crate::Field::new(16, 0, SFR_CGULP);
+
+        pub const SFR_SEED: crate::Register = crate::Register::new(2, 0xffffffff);
+        pub const SFR_SEED_SFR_SEED: crate::Field = crate::Field::new(32, 0, SFR_SEED);
+
+        pub const SFR_SEEDAR: crate::Register = crate::Register::new(3, 0xffffffff);
+        pub const SFR_SEEDAR_SFR_SEEDAR: crate::Field = crate::Field::new(32, 0, SFR_SEEDAR);
 
         pub const SFR_CGUSEL0: crate::Register = crate::Register::new(4, 0x3);
         pub const SFR_CGUSEL0_SFR_CGUSEL0: crate::Field = crate::Field::new(2, 0, SFR_CGUSEL0);
@@ -3649,7 +3673,7 @@ pub mod utra {
     }
 
     pub mod iox {
-        pub const IOX_NUMREGS: usize = 46;
+        pub const IOX_NUMREGS: usize = 64;
 
         pub const SFR_AFSEL_CRAFSEL0: crate::Register = crate::Register::new(0, 0xffff);
         pub const SFR_AFSEL_CRAFSEL0_CRAFSEL0: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL0);
@@ -3674,6 +3698,18 @@ pub mod utra {
 
         pub const SFR_AFSEL_CRAFSEL7: crate::Register = crate::Register::new(7, 0xffff);
         pub const SFR_AFSEL_CRAFSEL7_CRAFSEL7: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL7);
+
+        pub const SFR_AFSEL_CRAFSEL8: crate::Register = crate::Register::new(8, 0xffff);
+        pub const SFR_AFSEL_CRAFSEL8_CRAFSEL8: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL8);
+
+        pub const SFR_AFSEL_CRAFSEL9: crate::Register = crate::Register::new(9, 0xffff);
+        pub const SFR_AFSEL_CRAFSEL9_CRAFSEL9: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL9);
+
+        pub const SFR_AFSEL_CRAFSEL10: crate::Register = crate::Register::new(10, 0xffff);
+        pub const SFR_AFSEL_CRAFSEL10_CRAFSEL10: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL10);
+
+        pub const SFR_AFSEL_CRAFSEL11: crate::Register = crate::Register::new(11, 0xffff);
+        pub const SFR_AFSEL_CRAFSEL11_CRAFSEL11: crate::Field = crate::Field::new(16, 0, SFR_AFSEL_CRAFSEL11);
 
         pub const SFR_INTCR_CRINT0: crate::Register = crate::Register::new(64, 0x3ff);
         pub const SFR_INTCR_CRINT0_CRINT0: crate::Field = crate::Field::new(10, 0, SFR_INTCR_CRINT0);
@@ -3714,41 +3750,65 @@ pub mod utra {
         pub const SFR_GPIOOUT_CRGO3: crate::Register = crate::Register::new(79, 0xffff);
         pub const SFR_GPIOOUT_CRGO3_CRGO3: crate::Field = crate::Field::new(16, 0, SFR_GPIOOUT_CRGO3);
 
-        pub const SFR_GPIOOE_CRGOE0: crate::Register = crate::Register::new(80, 0xffff);
+        pub const SFR_GPIOOUT_CRGO4: crate::Register = crate::Register::new(80, 0xffff);
+        pub const SFR_GPIOOUT_CRGO4_CRGO4: crate::Field = crate::Field::new(16, 0, SFR_GPIOOUT_CRGO4);
+
+        pub const SFR_GPIOOUT_CRGO5: crate::Register = crate::Register::new(81, 0xffff);
+        pub const SFR_GPIOOUT_CRGO5_CRGO5: crate::Field = crate::Field::new(16, 0, SFR_GPIOOUT_CRGO5);
+
+        pub const SFR_GPIOOE_CRGOE0: crate::Register = crate::Register::new(82, 0xffff);
         pub const SFR_GPIOOE_CRGOE0_CRGOE0: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE0);
 
-        pub const SFR_GPIOOE_CRGOE1: crate::Register = crate::Register::new(81, 0xffff);
+        pub const SFR_GPIOOE_CRGOE1: crate::Register = crate::Register::new(83, 0xffff);
         pub const SFR_GPIOOE_CRGOE1_CRGOE1: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE1);
 
-        pub const SFR_GPIOOE_CRGOE2: crate::Register = crate::Register::new(82, 0xffff);
+        pub const SFR_GPIOOE_CRGOE2: crate::Register = crate::Register::new(84, 0xffff);
         pub const SFR_GPIOOE_CRGOE2_CRGOE2: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE2);
 
-        pub const SFR_GPIOOE_CRGOE3: crate::Register = crate::Register::new(83, 0xffff);
+        pub const SFR_GPIOOE_CRGOE3: crate::Register = crate::Register::new(85, 0xffff);
         pub const SFR_GPIOOE_CRGOE3_CRGOE3: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE3);
 
-        pub const SFR_GPIOPU_CRGPU0: crate::Register = crate::Register::new(84, 0xffff);
+        pub const SFR_GPIOOE_CRGOE4: crate::Register = crate::Register::new(86, 0xffff);
+        pub const SFR_GPIOOE_CRGOE4_CRGOE4: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE4);
+
+        pub const SFR_GPIOOE_CRGOE5: crate::Register = crate::Register::new(87, 0xffff);
+        pub const SFR_GPIOOE_CRGOE5_CRGOE5: crate::Field = crate::Field::new(16, 0, SFR_GPIOOE_CRGOE5);
+
+        pub const SFR_GPIOPU_CRGPU0: crate::Register = crate::Register::new(88, 0xffff);
         pub const SFR_GPIOPU_CRGPU0_CRGPU0: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU0);
 
-        pub const SFR_GPIOPU_CRGPU1: crate::Register = crate::Register::new(85, 0xffff);
+        pub const SFR_GPIOPU_CRGPU1: crate::Register = crate::Register::new(89, 0xffff);
         pub const SFR_GPIOPU_CRGPU1_CRGPU1: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU1);
 
-        pub const SFR_GPIOPU_CRGPU2: crate::Register = crate::Register::new(86, 0xffff);
+        pub const SFR_GPIOPU_CRGPU2: crate::Register = crate::Register::new(90, 0xffff);
         pub const SFR_GPIOPU_CRGPU2_CRGPU2: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU2);
 
-        pub const SFR_GPIOPU_CRGPU3: crate::Register = crate::Register::new(87, 0xffff);
+        pub const SFR_GPIOPU_CRGPU3: crate::Register = crate::Register::new(91, 0xffff);
         pub const SFR_GPIOPU_CRGPU3_CRGPU3: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU3);
 
-        pub const SFR_GPIOIN_SRGI0: crate::Register = crate::Register::new(88, 0xffff);
+        pub const SFR_GPIOPU_CRGPU4: crate::Register = crate::Register::new(92, 0xffff);
+        pub const SFR_GPIOPU_CRGPU4_CRGPU4: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU4);
+
+        pub const SFR_GPIOPU_CRGPU5: crate::Register = crate::Register::new(93, 0xffff);
+        pub const SFR_GPIOPU_CRGPU5_CRGPU5: crate::Field = crate::Field::new(16, 0, SFR_GPIOPU_CRGPU5);
+
+        pub const SFR_GPIOIN_SRGI0: crate::Register = crate::Register::new(94, 0xffff);
         pub const SFR_GPIOIN_SRGI0_SRGI0: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI0);
 
-        pub const SFR_GPIOIN_SRGI1: crate::Register = crate::Register::new(89, 0xffff);
+        pub const SFR_GPIOIN_SRGI1: crate::Register = crate::Register::new(95, 0xffff);
         pub const SFR_GPIOIN_SRGI1_SRGI1: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI1);
 
-        pub const SFR_GPIOIN_SRGI2: crate::Register = crate::Register::new(90, 0xffff);
+        pub const SFR_GPIOIN_SRGI2: crate::Register = crate::Register::new(96, 0xffff);
         pub const SFR_GPIOIN_SRGI2_SRGI2: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI2);
 
-        pub const SFR_GPIOIN_SRGI3: crate::Register = crate::Register::new(91, 0xffff);
+        pub const SFR_GPIOIN_SRGI3: crate::Register = crate::Register::new(97, 0xffff);
         pub const SFR_GPIOIN_SRGI3_SRGI3: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI3);
+
+        pub const SFR_GPIOIN_SRGI4: crate::Register = crate::Register::new(98, 0xffff);
+        pub const SFR_GPIOIN_SRGI4_SRGI4: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI4);
+
+        pub const SFR_GPIOIN_SRGI5: crate::Register = crate::Register::new(99, 0xffff);
+        pub const SFR_GPIOIN_SRGI5_SRGI5: crate::Field = crate::Field::new(16, 0, SFR_GPIOIN_SRGI5);
 
         pub const SFR_PIOSEL: crate::Register = crate::Register::new(128, 0xffffffff);
         pub const SFR_PIOSEL_PIOSEL: crate::Field = crate::Field::new(32, 0, SFR_PIOSEL);
@@ -3765,29 +3825,47 @@ pub mod utra {
         pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL3: crate::Register = crate::Register::new(143, 0xffff);
         pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL3_CR_CFG_SCHMSEL3: crate::Field = crate::Field::new(16, 0, SFR_CFG_SCHM_CR_CFG_SCHMSEL3);
 
-        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW0: crate::Register = crate::Register::new(144, 0xffff);
+        pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL4: crate::Register = crate::Register::new(144, 0xffff);
+        pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4: crate::Field = crate::Field::new(16, 0, SFR_CFG_SCHM_CR_CFG_SCHMSEL4);
+
+        pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL5: crate::Register = crate::Register::new(145, 0xffff);
+        pub const SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5: crate::Field = crate::Field::new(16, 0, SFR_CFG_SCHM_CR_CFG_SCHMSEL5);
+
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW0: crate::Register = crate::Register::new(146, 0xffff);
         pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW0_CR_CFG_SLEWSLOW0: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW0);
 
-        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW1: crate::Register = crate::Register::new(145, 0xffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW1: crate::Register = crate::Register::new(147, 0xffff);
         pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW1_CR_CFG_SLEWSLOW1: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW1);
 
-        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW2: crate::Register = crate::Register::new(146, 0xffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW2: crate::Register = crate::Register::new(148, 0xffff);
         pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW2_CR_CFG_SLEWSLOW2: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW2);
 
-        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW3: crate::Register = crate::Register::new(147, 0xffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW3: crate::Register = crate::Register::new(149, 0xffff);
         pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW3_CR_CFG_SLEWSLOW3: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW3);
 
-        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL0: crate::Register = crate::Register::new(148, 0xffffffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW4: crate::Register = crate::Register::new(150, 0xffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW4);
+
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW5: crate::Register = crate::Register::new(151, 0xffff);
+        pub const SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5: crate::Field = crate::Field::new(16, 0, SFR_CFG_SLEW_CR_CFG_SLEWSLOW5);
+
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL0: crate::Register = crate::Register::new(152, 0xffffffff);
         pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL0_CR_CFG_DRVSEL0: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL0);
 
-        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL1: crate::Register = crate::Register::new(149, 0xffffffff);
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL1: crate::Register = crate::Register::new(153, 0xffffffff);
         pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL1_CR_CFG_DRVSEL1: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL1);
 
-        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL2: crate::Register = crate::Register::new(150, 0xffffffff);
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL2: crate::Register = crate::Register::new(154, 0xffffffff);
         pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL2_CR_CFG_DRVSEL2: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL2);
 
-        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL3: crate::Register = crate::Register::new(151, 0xffffffff);
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL3: crate::Register = crate::Register::new(155, 0xffffffff);
         pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL3_CR_CFG_DRVSEL3: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL3);
+
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL4: crate::Register = crate::Register::new(156, 0xffffffff);
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL4);
+
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL5: crate::Register = crate::Register::new(157, 0xffffffff);
+        pub const SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5: crate::Field = crate::Field::new(32, 0, SFR_CFG_DRVSEL_CR_CFG_DRVSEL5);
 
         pub const HW_IOX_BASE: usize = 0x5012f000;
     }
@@ -4579,7 +4657,7 @@ pub mod utra {
     }
 
     pub mod coresub_sramtrm {
-        pub const CORESUB_SRAMTRM_NUMREGS: usize = 6;
+        pub const CORESUB_SRAMTRM_NUMREGS: usize = 7;
 
         pub const SFR_CACHE: crate::Register = crate::Register::new(0, 0x7);
         pub const SFR_CACHE_SFR_CACHE: crate::Field = crate::Field::new(3, 0, SFR_CACHE);
@@ -4598,6 +4676,9 @@ pub mod utra {
 
         pub const SFR_VEXRAM: crate::Register = crate::Register::new(5, 0x7);
         pub const SFR_VEXRAM_SFR_VEXRAM: crate::Field = crate::Field::new(3, 0, SFR_VEXRAM);
+
+        pub const SFR_SRAMERR: crate::Register = crate::Register::new(8, 0xf);
+        pub const SFR_SRAMERR_SRAMBANKERR: crate::Field = crate::Field::new(4, 0, SFR_SRAMERR);
 
         pub const HW_CORESUB_SRAMTRM_BASE: usize = 0x40014000;
     }
@@ -4770,105 +4851,6 @@ pub mod utra {
         pub const SFR_GCTEST_GLUETEST: crate::Field = crate::Field::new(32, 0, SFR_GCTEST);
 
         pub const HW_GLUECHAIN_BASE: usize = 0x40054000;
-    }
-
-    pub mod mesh {
-        pub const MESH_NUMREGS: usize = 10;
-
-        pub const SFR_MLDRV_CR_MLDRV0: crate::Register = crate::Register::new(0, 0xffffffff);
-        pub const SFR_MLDRV_CR_MLDRV0_CR_MLDRV0: crate::Field = crate::Field::new(32, 0, SFR_MLDRV_CR_MLDRV0);
-
-        pub const SFR_MLIE_CR_MLIE0: crate::Register = crate::Register::new(1, 0xffffffff);
-        pub const SFR_MLIE_CR_MLIE0_CR_MLIE0: crate::Field = crate::Field::new(32, 0, SFR_MLIE_CR_MLIE0);
-
-        pub const SFR_MLSR_SR_MLSR0: crate::Register = crate::Register::new(2, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR0_SR_MLSR0: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR0);
-
-        pub const SFR_MLSR_SR_MLSR1: crate::Register = crate::Register::new(3, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR1_SR_MLSR1: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR1);
-
-        pub const SFR_MLSR_SR_MLSR2: crate::Register = crate::Register::new(4, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR2_SR_MLSR2: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR2);
-
-        pub const SFR_MLSR_SR_MLSR3: crate::Register = crate::Register::new(5, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR3_SR_MLSR3: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR3);
-
-        pub const SFR_MLSR_SR_MLSR4: crate::Register = crate::Register::new(6, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR4_SR_MLSR4: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR4);
-
-        pub const SFR_MLSR_SR_MLSR5: crate::Register = crate::Register::new(7, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR5_SR_MLSR5: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR5);
-
-        pub const SFR_MLSR_SR_MLSR6: crate::Register = crate::Register::new(8, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR6_SR_MLSR6: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR6);
-
-        pub const SFR_MLSR_SR_MLSR7: crate::Register = crate::Register::new(9, 0xffffffff);
-        pub const SFR_MLSR_SR_MLSR7_SR_MLSR7: crate::Field = crate::Field::new(32, 0, SFR_MLSR_SR_MLSR7);
-
-        pub const HW_MESH_BASE: usize = 0x40052000;
-    }
-
-    pub mod sensorc {
-        pub const SENSORC_NUMREGS: usize = 19;
-
-        pub const SFR_VDMASK0: crate::Register = crate::Register::new(0, 0xff);
-        pub const SFR_VDMASK0_CR_VDMASK0: crate::Field = crate::Field::new(8, 0, SFR_VDMASK0);
-
-        pub const SFR_VDMASK1: crate::Register = crate::Register::new(1, 0xff);
-        pub const SFR_VDMASK1_CR_VDMASK1: crate::Field = crate::Field::new(8, 0, SFR_VDMASK1);
-
-        pub const SFR_VDSR: crate::Register = crate::Register::new(2, 0xff);
-        pub const SFR_VDSR_VDFLAG: crate::Field = crate::Field::new(8, 0, SFR_VDSR);
-
-        pub const SFR_VDFR: crate::Register = crate::Register::new(3, 0xff);
-        pub const SFR_VDFR_VDFLAG: crate::Field = crate::Field::new(8, 0, SFR_VDFR);
-
-        pub const SFR_LDMASK: crate::Register = crate::Register::new(4, 0xf);
-        pub const SFR_LDMASK_CR_LDMASK: crate::Field = crate::Field::new(4, 0, SFR_LDMASK);
-
-        pub const SFR_LDSR: crate::Register = crate::Register::new(5, 0xf);
-        pub const SFR_LDSR_SR_LDSR: crate::Field = crate::Field::new(4, 0, SFR_LDSR);
-
-        pub const SFR_LDCFG: crate::Register = crate::Register::new(6, 0xf);
-        pub const SFR_LDCFG_SFR_LDCFG: crate::Field = crate::Field::new(4, 0, SFR_LDCFG);
-
-        pub const SFR_VDCFG_CR_VDCFG0: crate::Register = crate::Register::new(8, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG0_CR_VDCFG0: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG0);
-
-        pub const SFR_VDCFG_CR_VDCFG1: crate::Register = crate::Register::new(9, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG1_CR_VDCFG1: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG1);
-
-        pub const SFR_VDCFG_CR_VDCFG2: crate::Register = crate::Register::new(10, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG2_CR_VDCFG2: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG2);
-
-        pub const SFR_VDCFG_CR_VDCFG3: crate::Register = crate::Register::new(11, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG3_CR_VDCFG3: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG3);
-
-        pub const SFR_VDCFG_CR_VDCFG4: crate::Register = crate::Register::new(12, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG4_CR_VDCFG4: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG4);
-
-        pub const SFR_VDCFG_CR_VDCFG5: crate::Register = crate::Register::new(13, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG5_CR_VDCFG5: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG5);
-
-        pub const SFR_VDCFG_CR_VDCFG6: crate::Register = crate::Register::new(14, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG6_CR_VDCFG6: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG6);
-
-        pub const SFR_VDCFG_CR_VDCFG7: crate::Register = crate::Register::new(15, 0xf);
-        pub const SFR_VDCFG_CR_VDCFG7_CR_VDCFG7: crate::Field = crate::Field::new(4, 0, SFR_VDCFG_CR_VDCFG7);
-
-        pub const SFR_VDIP_ENA: crate::Register = crate::Register::new(16, 0xf);
-        pub const SFR_VDIP_ENA_VDENA: crate::Field = crate::Field::new(4, 0, SFR_VDIP_ENA);
-
-        pub const SFR_VDIP_TEST: crate::Register = crate::Register::new(17, 0xff);
-        pub const SFR_VDIP_TEST_VDTST: crate::Field = crate::Field::new(8, 0, SFR_VDIP_TEST);
-
-        pub const SFR_LDIP_TEST: crate::Register = crate::Register::new(18, 0xf);
-        pub const SFR_LDIP_TEST_LDTST: crate::Field = crate::Field::new(4, 0, SFR_LDIP_TEST);
-
-        pub const SFR_LDIP_FD: crate::Register = crate::Register::new(19, 0xffff);
-        pub const SFR_LDIP_FD_SFR_LDIP_FD: crate::Field = crate::Field::new(16, 0, SFR_LDIP_FD);
-
-        pub const HW_SENSORC_BASE: usize = 0x40053000;
     }
 }
 
@@ -13230,6 +13212,11 @@ mod tests {
         let mut baz = udma_sdio_csr.zf(utra::udma_sdio::REG_CMD_OP_R_CMD_OP, bar);
         baz |= udma_sdio_csr.ms(utra::udma_sdio::REG_CMD_OP_R_CMD_OP, 1);
         udma_sdio_csr.wfo(utra::udma_sdio::REG_CMD_OP_R_CMD_OP, baz);
+        let bar = udma_sdio_csr.rf(utra::udma_sdio::REG_CMD_OP_R_CMD_STOPOPT);
+        udma_sdio_csr.rmwf(utra::udma_sdio::REG_CMD_OP_R_CMD_STOPOPT, bar);
+        let mut baz = udma_sdio_csr.zf(utra::udma_sdio::REG_CMD_OP_R_CMD_STOPOPT, bar);
+        baz |= udma_sdio_csr.ms(utra::udma_sdio::REG_CMD_OP_R_CMD_STOPOPT, 1);
+        udma_sdio_csr.wfo(utra::udma_sdio::REG_CMD_OP_R_CMD_STOPOPT, baz);
 
         let foo = udma_sdio_csr.r(utra::udma_sdio::REG_DATA_SETUP);
         udma_sdio_csr.wo(utra::udma_sdio::REG_DATA_SETUP, foo);
@@ -14392,6 +14379,22 @@ mod tests {
         baz |= aes_csr.ms(utra::aes::SFR_OPTLTX_SFR_OPTLTX, 1);
         aes_csr.wfo(utra::aes::SFR_OPTLTX_SFR_OPTLTX, baz);
 
+        let foo = aes_csr.r(utra::aes::SFR_MASKSEED);
+        aes_csr.wo(utra::aes::SFR_MASKSEED, foo);
+        let bar = aes_csr.rf(utra::aes::SFR_MASKSEED_SFR_MASKSEED);
+        aes_csr.rmwf(utra::aes::SFR_MASKSEED_SFR_MASKSEED, bar);
+        let mut baz = aes_csr.zf(utra::aes::SFR_MASKSEED_SFR_MASKSEED, bar);
+        baz |= aes_csr.ms(utra::aes::SFR_MASKSEED_SFR_MASKSEED, 1);
+        aes_csr.wfo(utra::aes::SFR_MASKSEED_SFR_MASKSEED, baz);
+
+        let foo = aes_csr.r(utra::aes::SFR_MASKSEEDAR);
+        aes_csr.wo(utra::aes::SFR_MASKSEEDAR, foo);
+        let bar = aes_csr.rf(utra::aes::SFR_MASKSEEDAR_SFR_MASKSEEDAR);
+        aes_csr.rmwf(utra::aes::SFR_MASKSEEDAR_SFR_MASKSEEDAR, bar);
+        let mut baz = aes_csr.zf(utra::aes::SFR_MASKSEEDAR_SFR_MASKSEEDAR, bar);
+        baz |= aes_csr.ms(utra::aes::SFR_MASKSEEDAR_SFR_MASKSEEDAR, 1);
+        aes_csr.wfo(utra::aes::SFR_MASKSEEDAR_SFR_MASKSEEDAR, baz);
+
         let foo = aes_csr.r(utra::aes::SFR_SEGPTR_PTRID_IV);
         aes_csr.wo(utra::aes::SFR_SEGPTR_PTRID_IV, foo);
         let bar = aes_csr.rf(utra::aes::SFR_SEGPTR_PTRID_IV_PTRID_IV);
@@ -15092,6 +15095,38 @@ mod tests {
         baz |= trng_csr.ms(utra::trng::SFR_FR_SFR_FR, 1);
         trng_csr.wfo(utra::trng::SFR_FR_SFR_FR, baz);
 
+        let foo = trng_csr.r(utra::trng::SFR_DRPSZ);
+        trng_csr.wo(utra::trng::SFR_DRPSZ, foo);
+        let bar = trng_csr.rf(utra::trng::SFR_DRPSZ_SFR_DRPSZ);
+        trng_csr.rmwf(utra::trng::SFR_DRPSZ_SFR_DRPSZ, bar);
+        let mut baz = trng_csr.zf(utra::trng::SFR_DRPSZ_SFR_DRPSZ, bar);
+        baz |= trng_csr.ms(utra::trng::SFR_DRPSZ_SFR_DRPSZ, 1);
+        trng_csr.wfo(utra::trng::SFR_DRPSZ_SFR_DRPSZ, baz);
+
+        let foo = trng_csr.r(utra::trng::SFR_DRGEN);
+        trng_csr.wo(utra::trng::SFR_DRGEN, foo);
+        let bar = trng_csr.rf(utra::trng::SFR_DRGEN_SFR_DRGEN);
+        trng_csr.rmwf(utra::trng::SFR_DRGEN_SFR_DRGEN, bar);
+        let mut baz = trng_csr.zf(utra::trng::SFR_DRGEN_SFR_DRGEN, bar);
+        baz |= trng_csr.ms(utra::trng::SFR_DRGEN_SFR_DRGEN, 1);
+        trng_csr.wfo(utra::trng::SFR_DRGEN_SFR_DRGEN, baz);
+
+        let foo = trng_csr.r(utra::trng::SFR_DRRESEED);
+        trng_csr.wo(utra::trng::SFR_DRRESEED, foo);
+        let bar = trng_csr.rf(utra::trng::SFR_DRRESEED_SFR_DRRESEED);
+        trng_csr.rmwf(utra::trng::SFR_DRRESEED_SFR_DRRESEED, bar);
+        let mut baz = trng_csr.zf(utra::trng::SFR_DRRESEED_SFR_DRRESEED, bar);
+        baz |= trng_csr.ms(utra::trng::SFR_DRRESEED_SFR_DRRESEED, 1);
+        trng_csr.wfo(utra::trng::SFR_DRRESEED_SFR_DRRESEED, baz);
+
+        let foo = trng_csr.r(utra::trng::SFR_BUF);
+        trng_csr.wo(utra::trng::SFR_BUF, foo);
+        let bar = trng_csr.rf(utra::trng::SFR_BUF_SFR_BUF);
+        trng_csr.rmwf(utra::trng::SFR_BUF_SFR_BUF, bar);
+        let mut baz = trng_csr.zf(utra::trng::SFR_BUF_SFR_BUF, bar);
+        baz |= trng_csr.ms(utra::trng::SFR_BUF_SFR_BUF, 1);
+        trng_csr.wfo(utra::trng::SFR_BUF_SFR_BUF, baz);
+
         let foo = trng_csr.r(utra::trng::SFR_CHAIN_RNGCHAINEN0);
         trng_csr.wo(utra::trng::SFR_CHAIN_RNGCHAINEN0, foo);
         let bar = trng_csr.rf(utra::trng::SFR_CHAIN_RNGCHAINEN0_RNGCHAINEN0);
@@ -15373,6 +15408,22 @@ mod tests {
         let mut baz = sysctrl_csr.zf(utra::sysctrl::SFR_CGULP_SFR_CGULP, bar);
         baz |= sysctrl_csr.ms(utra::sysctrl::SFR_CGULP_SFR_CGULP, 1);
         sysctrl_csr.wfo(utra::sysctrl::SFR_CGULP_SFR_CGULP, baz);
+
+        let foo = sysctrl_csr.r(utra::sysctrl::SFR_SEED);
+        sysctrl_csr.wo(utra::sysctrl::SFR_SEED, foo);
+        let bar = sysctrl_csr.rf(utra::sysctrl::SFR_SEED_SFR_SEED);
+        sysctrl_csr.rmwf(utra::sysctrl::SFR_SEED_SFR_SEED, bar);
+        let mut baz = sysctrl_csr.zf(utra::sysctrl::SFR_SEED_SFR_SEED, bar);
+        baz |= sysctrl_csr.ms(utra::sysctrl::SFR_SEED_SFR_SEED, 1);
+        sysctrl_csr.wfo(utra::sysctrl::SFR_SEED_SFR_SEED, baz);
+
+        let foo = sysctrl_csr.r(utra::sysctrl::SFR_SEEDAR);
+        sysctrl_csr.wo(utra::sysctrl::SFR_SEEDAR, foo);
+        let bar = sysctrl_csr.rf(utra::sysctrl::SFR_SEEDAR_SFR_SEEDAR);
+        sysctrl_csr.rmwf(utra::sysctrl::SFR_SEEDAR_SFR_SEEDAR, bar);
+        let mut baz = sysctrl_csr.zf(utra::sysctrl::SFR_SEEDAR_SFR_SEEDAR, bar);
+        baz |= sysctrl_csr.ms(utra::sysctrl::SFR_SEEDAR_SFR_SEEDAR, 1);
+        sysctrl_csr.wfo(utra::sysctrl::SFR_SEEDAR_SFR_SEEDAR, baz);
 
         let foo = sysctrl_csr.r(utra::sysctrl::SFR_CGUSEL0);
         sysctrl_csr.wo(utra::sysctrl::SFR_CGUSEL0, foo);
@@ -15700,6 +15751,38 @@ mod tests {
         baz |= iox_csr.ms(utra::iox::SFR_AFSEL_CRAFSEL7_CRAFSEL7, 1);
         iox_csr.wfo(utra::iox::SFR_AFSEL_CRAFSEL7_CRAFSEL7, baz);
 
+        let foo = iox_csr.r(utra::iox::SFR_AFSEL_CRAFSEL8);
+        iox_csr.wo(utra::iox::SFR_AFSEL_CRAFSEL8, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_AFSEL_CRAFSEL8_CRAFSEL8);
+        iox_csr.rmwf(utra::iox::SFR_AFSEL_CRAFSEL8_CRAFSEL8, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_AFSEL_CRAFSEL8_CRAFSEL8, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_AFSEL_CRAFSEL8_CRAFSEL8, 1);
+        iox_csr.wfo(utra::iox::SFR_AFSEL_CRAFSEL8_CRAFSEL8, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_AFSEL_CRAFSEL9);
+        iox_csr.wo(utra::iox::SFR_AFSEL_CRAFSEL9, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_AFSEL_CRAFSEL9_CRAFSEL9);
+        iox_csr.rmwf(utra::iox::SFR_AFSEL_CRAFSEL9_CRAFSEL9, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_AFSEL_CRAFSEL9_CRAFSEL9, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_AFSEL_CRAFSEL9_CRAFSEL9, 1);
+        iox_csr.wfo(utra::iox::SFR_AFSEL_CRAFSEL9_CRAFSEL9, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_AFSEL_CRAFSEL10);
+        iox_csr.wo(utra::iox::SFR_AFSEL_CRAFSEL10, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_AFSEL_CRAFSEL10_CRAFSEL10);
+        iox_csr.rmwf(utra::iox::SFR_AFSEL_CRAFSEL10_CRAFSEL10, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_AFSEL_CRAFSEL10_CRAFSEL10, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_AFSEL_CRAFSEL10_CRAFSEL10, 1);
+        iox_csr.wfo(utra::iox::SFR_AFSEL_CRAFSEL10_CRAFSEL10, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_AFSEL_CRAFSEL11);
+        iox_csr.wo(utra::iox::SFR_AFSEL_CRAFSEL11, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_AFSEL_CRAFSEL11_CRAFSEL11);
+        iox_csr.rmwf(utra::iox::SFR_AFSEL_CRAFSEL11_CRAFSEL11, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_AFSEL_CRAFSEL11_CRAFSEL11, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_AFSEL_CRAFSEL11_CRAFSEL11, 1);
+        iox_csr.wfo(utra::iox::SFR_AFSEL_CRAFSEL11_CRAFSEL11, baz);
+
         let foo = iox_csr.r(utra::iox::SFR_INTCR_CRINT0);
         iox_csr.wo(utra::iox::SFR_INTCR_CRINT0, foo);
         let bar = iox_csr.rf(utra::iox::SFR_INTCR_CRINT0_CRINT0);
@@ -15804,6 +15887,22 @@ mod tests {
         baz |= iox_csr.ms(utra::iox::SFR_GPIOOUT_CRGO3_CRGO3, 1);
         iox_csr.wfo(utra::iox::SFR_GPIOOUT_CRGO3_CRGO3, baz);
 
+        let foo = iox_csr.r(utra::iox::SFR_GPIOOUT_CRGO4);
+        iox_csr.wo(utra::iox::SFR_GPIOOUT_CRGO4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOOUT_CRGO4_CRGO4);
+        iox_csr.rmwf(utra::iox::SFR_GPIOOUT_CRGO4_CRGO4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOOUT_CRGO4_CRGO4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOOUT_CRGO4_CRGO4, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOOUT_CRGO4_CRGO4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOOUT_CRGO5);
+        iox_csr.wo(utra::iox::SFR_GPIOOUT_CRGO5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOOUT_CRGO5_CRGO5);
+        iox_csr.rmwf(utra::iox::SFR_GPIOOUT_CRGO5_CRGO5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOOUT_CRGO5_CRGO5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOOUT_CRGO5_CRGO5, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOOUT_CRGO5_CRGO5, baz);
+
         let foo = iox_csr.r(utra::iox::SFR_GPIOOE_CRGOE0);
         iox_csr.wo(utra::iox::SFR_GPIOOE_CRGOE0, foo);
         let bar = iox_csr.rf(utra::iox::SFR_GPIOOE_CRGOE0_CRGOE0);
@@ -15835,6 +15934,22 @@ mod tests {
         let mut baz = iox_csr.zf(utra::iox::SFR_GPIOOE_CRGOE3_CRGOE3, bar);
         baz |= iox_csr.ms(utra::iox::SFR_GPIOOE_CRGOE3_CRGOE3, 1);
         iox_csr.wfo(utra::iox::SFR_GPIOOE_CRGOE3_CRGOE3, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOOE_CRGOE4);
+        iox_csr.wo(utra::iox::SFR_GPIOOE_CRGOE4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOOE_CRGOE4_CRGOE4);
+        iox_csr.rmwf(utra::iox::SFR_GPIOOE_CRGOE4_CRGOE4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOOE_CRGOE4_CRGOE4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOOE_CRGOE4_CRGOE4, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOOE_CRGOE4_CRGOE4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOOE_CRGOE5);
+        iox_csr.wo(utra::iox::SFR_GPIOOE_CRGOE5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOOE_CRGOE5_CRGOE5);
+        iox_csr.rmwf(utra::iox::SFR_GPIOOE_CRGOE5_CRGOE5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOOE_CRGOE5_CRGOE5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOOE_CRGOE5_CRGOE5, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOOE_CRGOE5_CRGOE5, baz);
 
         let foo = iox_csr.r(utra::iox::SFR_GPIOPU_CRGPU0);
         iox_csr.wo(utra::iox::SFR_GPIOPU_CRGPU0, foo);
@@ -15868,6 +15983,22 @@ mod tests {
         baz |= iox_csr.ms(utra::iox::SFR_GPIOPU_CRGPU3_CRGPU3, 1);
         iox_csr.wfo(utra::iox::SFR_GPIOPU_CRGPU3_CRGPU3, baz);
 
+        let foo = iox_csr.r(utra::iox::SFR_GPIOPU_CRGPU4);
+        iox_csr.wo(utra::iox::SFR_GPIOPU_CRGPU4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOPU_CRGPU4_CRGPU4);
+        iox_csr.rmwf(utra::iox::SFR_GPIOPU_CRGPU4_CRGPU4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOPU_CRGPU4_CRGPU4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOPU_CRGPU4_CRGPU4, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOPU_CRGPU4_CRGPU4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOPU_CRGPU5);
+        iox_csr.wo(utra::iox::SFR_GPIOPU_CRGPU5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOPU_CRGPU5_CRGPU5);
+        iox_csr.rmwf(utra::iox::SFR_GPIOPU_CRGPU5_CRGPU5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOPU_CRGPU5_CRGPU5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOPU_CRGPU5_CRGPU5, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOPU_CRGPU5_CRGPU5, baz);
+
         let foo = iox_csr.r(utra::iox::SFR_GPIOIN_SRGI0);
         iox_csr.wo(utra::iox::SFR_GPIOIN_SRGI0, foo);
         let bar = iox_csr.rf(utra::iox::SFR_GPIOIN_SRGI0_SRGI0);
@@ -15899,6 +16030,22 @@ mod tests {
         let mut baz = iox_csr.zf(utra::iox::SFR_GPIOIN_SRGI3_SRGI3, bar);
         baz |= iox_csr.ms(utra::iox::SFR_GPIOIN_SRGI3_SRGI3, 1);
         iox_csr.wfo(utra::iox::SFR_GPIOIN_SRGI3_SRGI3, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOIN_SRGI4);
+        iox_csr.wo(utra::iox::SFR_GPIOIN_SRGI4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOIN_SRGI4_SRGI4);
+        iox_csr.rmwf(utra::iox::SFR_GPIOIN_SRGI4_SRGI4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOIN_SRGI4_SRGI4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOIN_SRGI4_SRGI4, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOIN_SRGI4_SRGI4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_GPIOIN_SRGI5);
+        iox_csr.wo(utra::iox::SFR_GPIOIN_SRGI5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_GPIOIN_SRGI5_SRGI5);
+        iox_csr.rmwf(utra::iox::SFR_GPIOIN_SRGI5_SRGI5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_GPIOIN_SRGI5_SRGI5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_GPIOIN_SRGI5_SRGI5, 1);
+        iox_csr.wfo(utra::iox::SFR_GPIOIN_SRGI5_SRGI5, baz);
 
         let foo = iox_csr.r(utra::iox::SFR_PIOSEL);
         iox_csr.wo(utra::iox::SFR_PIOSEL, foo);
@@ -15940,6 +16087,22 @@ mod tests {
         baz |= iox_csr.ms(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL3_CR_CFG_SCHMSEL3, 1);
         iox_csr.wfo(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL3_CR_CFG_SCHMSEL3, baz);
 
+        let foo = iox_csr.r(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4);
+        iox_csr.wo(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4);
+        iox_csr.rmwf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL4_CR_CFG_SCHMSEL4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5);
+        iox_csr.wo(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5);
+        iox_csr.rmwf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_SCHM_CR_CFG_SCHMSEL5_CR_CFG_SCHMSEL5, baz);
+
         let foo = iox_csr.r(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW0);
         iox_csr.wo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW0, foo);
         let bar = iox_csr.rf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW0_CR_CFG_SLEWSLOW0);
@@ -15972,6 +16135,22 @@ mod tests {
         baz |= iox_csr.ms(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW3_CR_CFG_SLEWSLOW3, 1);
         iox_csr.wfo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW3_CR_CFG_SLEWSLOW3, baz);
 
+        let foo = iox_csr.r(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4);
+        iox_csr.wo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4);
+        iox_csr.rmwf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW4_CR_CFG_SLEWSLOW4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5);
+        iox_csr.wo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5);
+        iox_csr.rmwf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_SLEW_CR_CFG_SLEWSLOW5_CR_CFG_SLEWSLOW5, baz);
+
         let foo = iox_csr.r(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL0);
         iox_csr.wo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL0, foo);
         let bar = iox_csr.rf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL0_CR_CFG_DRVSEL0);
@@ -16003,6 +16182,22 @@ mod tests {
         let mut baz = iox_csr.zf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL3_CR_CFG_DRVSEL3, bar);
         baz |= iox_csr.ms(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL3_CR_CFG_DRVSEL3, 1);
         iox_csr.wfo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL3_CR_CFG_DRVSEL3, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4);
+        iox_csr.wo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4);
+        iox_csr.rmwf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL4_CR_CFG_DRVSEL4, baz);
+
+        let foo = iox_csr.r(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5);
+        iox_csr.wo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5, foo);
+        let bar = iox_csr.rf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5);
+        iox_csr.rmwf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5, bar);
+        let mut baz = iox_csr.zf(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5, bar);
+        baz |= iox_csr.ms(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5, 1);
+        iox_csr.wfo(utra::iox::SFR_CFG_DRVSEL_CR_CFG_DRVSEL5_CR_CFG_DRVSEL5, baz);
   }
 
     #[test]
@@ -18512,6 +18707,14 @@ mod tests {
         let mut baz = coresub_sramtrm_csr.zf(utra::coresub_sramtrm::SFR_VEXRAM_SFR_VEXRAM, bar);
         baz |= coresub_sramtrm_csr.ms(utra::coresub_sramtrm::SFR_VEXRAM_SFR_VEXRAM, 1);
         coresub_sramtrm_csr.wfo(utra::coresub_sramtrm::SFR_VEXRAM_SFR_VEXRAM, baz);
+
+        let foo = coresub_sramtrm_csr.r(utra::coresub_sramtrm::SFR_SRAMERR);
+        coresub_sramtrm_csr.wo(utra::coresub_sramtrm::SFR_SRAMERR, foo);
+        let bar = coresub_sramtrm_csr.rf(utra::coresub_sramtrm::SFR_SRAMERR_SRAMBANKERR);
+        coresub_sramtrm_csr.rmwf(utra::coresub_sramtrm::SFR_SRAMERR_SRAMBANKERR, bar);
+        let mut baz = coresub_sramtrm_csr.zf(utra::coresub_sramtrm::SFR_SRAMERR_SRAMBANKERR, bar);
+        baz |= coresub_sramtrm_csr.ms(utra::coresub_sramtrm::SFR_SRAMERR_SRAMBANKERR, 1);
+        coresub_sramtrm_csr.wfo(utra::coresub_sramtrm::SFR_SRAMERR_SRAMBANKERR, baz);
   }
 
     #[test]
@@ -18941,251 +19144,5 @@ mod tests {
         let mut baz = gluechain_csr.zf(utra::gluechain::SFR_GCTEST_GLUETEST, bar);
         baz |= gluechain_csr.ms(utra::gluechain::SFR_GCTEST_GLUETEST, 1);
         gluechain_csr.wfo(utra::gluechain::SFR_GCTEST_GLUETEST, baz);
-  }
-
-    #[test]
-    #[ignore]
-    fn compile_check_mesh_csr() {
-        use super::*;
-        let mut mesh_csr = CSR::new(HW_MESH_BASE as *mut u32);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLDRV_CR_MLDRV0);
-        mesh_csr.wo(utra::mesh::SFR_MLDRV_CR_MLDRV0, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLDRV_CR_MLDRV0_CR_MLDRV0);
-        mesh_csr.rmwf(utra::mesh::SFR_MLDRV_CR_MLDRV0_CR_MLDRV0, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLDRV_CR_MLDRV0_CR_MLDRV0, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLDRV_CR_MLDRV0_CR_MLDRV0, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLDRV_CR_MLDRV0_CR_MLDRV0, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLIE_CR_MLIE0);
-        mesh_csr.wo(utra::mesh::SFR_MLIE_CR_MLIE0, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLIE_CR_MLIE0_CR_MLIE0);
-        mesh_csr.rmwf(utra::mesh::SFR_MLIE_CR_MLIE0_CR_MLIE0, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLIE_CR_MLIE0_CR_MLIE0, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLIE_CR_MLIE0_CR_MLIE0, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLIE_CR_MLIE0_CR_MLIE0, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR0);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR0, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR0_SR_MLSR0);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR0_SR_MLSR0, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR0_SR_MLSR0, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR0_SR_MLSR0, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR0_SR_MLSR0, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR1);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR1, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR1_SR_MLSR1);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR1_SR_MLSR1, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR1_SR_MLSR1, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR1_SR_MLSR1, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR1_SR_MLSR1, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR2);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR2, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR2_SR_MLSR2);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR2_SR_MLSR2, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR2_SR_MLSR2, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR2_SR_MLSR2, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR2_SR_MLSR2, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR3);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR3, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR3_SR_MLSR3);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR3_SR_MLSR3, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR3_SR_MLSR3, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR3_SR_MLSR3, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR3_SR_MLSR3, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR4);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR4, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR4_SR_MLSR4);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR4_SR_MLSR4, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR4_SR_MLSR4, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR4_SR_MLSR4, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR4_SR_MLSR4, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR5);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR5, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR5_SR_MLSR5);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR5_SR_MLSR5, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR5_SR_MLSR5, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR5_SR_MLSR5, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR5_SR_MLSR5, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR6);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR6, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR6_SR_MLSR6);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR6_SR_MLSR6, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR6_SR_MLSR6, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR6_SR_MLSR6, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR6_SR_MLSR6, baz);
-
-        let foo = mesh_csr.r(utra::mesh::SFR_MLSR_SR_MLSR7);
-        mesh_csr.wo(utra::mesh::SFR_MLSR_SR_MLSR7, foo);
-        let bar = mesh_csr.rf(utra::mesh::SFR_MLSR_SR_MLSR7_SR_MLSR7);
-        mesh_csr.rmwf(utra::mesh::SFR_MLSR_SR_MLSR7_SR_MLSR7, bar);
-        let mut baz = mesh_csr.zf(utra::mesh::SFR_MLSR_SR_MLSR7_SR_MLSR7, bar);
-        baz |= mesh_csr.ms(utra::mesh::SFR_MLSR_SR_MLSR7_SR_MLSR7, 1);
-        mesh_csr.wfo(utra::mesh::SFR_MLSR_SR_MLSR7_SR_MLSR7, baz);
-  }
-
-    #[test]
-    #[ignore]
-    fn compile_check_sensorc_csr() {
-        use super::*;
-        let mut sensorc_csr = CSR::new(HW_SENSORC_BASE as *mut u32);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDMASK0);
-        sensorc_csr.wo(utra::sensorc::SFR_VDMASK0, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDMASK0_CR_VDMASK0);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDMASK0_CR_VDMASK0, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDMASK0_CR_VDMASK0, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDMASK0_CR_VDMASK0, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDMASK0_CR_VDMASK0, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDMASK1);
-        sensorc_csr.wo(utra::sensorc::SFR_VDMASK1, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDMASK1_CR_VDMASK1);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDMASK1_CR_VDMASK1, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDMASK1_CR_VDMASK1, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDMASK1_CR_VDMASK1, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDMASK1_CR_VDMASK1, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDSR);
-        sensorc_csr.wo(utra::sensorc::SFR_VDSR, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDSR_VDFLAG);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDSR_VDFLAG, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDSR_VDFLAG, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDSR_VDFLAG, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDSR_VDFLAG, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDFR);
-        sensorc_csr.wo(utra::sensorc::SFR_VDFR, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDFR_VDFLAG);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDFR_VDFLAG, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDFR_VDFLAG, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDFR_VDFLAG, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDFR_VDFLAG, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_LDMASK);
-        sensorc_csr.wo(utra::sensorc::SFR_LDMASK, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_LDMASK_CR_LDMASK);
-        sensorc_csr.rmwf(utra::sensorc::SFR_LDMASK_CR_LDMASK, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_LDMASK_CR_LDMASK, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_LDMASK_CR_LDMASK, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_LDMASK_CR_LDMASK, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_LDSR);
-        sensorc_csr.wo(utra::sensorc::SFR_LDSR, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_LDSR_SR_LDSR);
-        sensorc_csr.rmwf(utra::sensorc::SFR_LDSR_SR_LDSR, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_LDSR_SR_LDSR, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_LDSR_SR_LDSR, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_LDSR_SR_LDSR, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_LDCFG);
-        sensorc_csr.wo(utra::sensorc::SFR_LDCFG, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_LDCFG_SFR_LDCFG);
-        sensorc_csr.rmwf(utra::sensorc::SFR_LDCFG_SFR_LDCFG, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_LDCFG_SFR_LDCFG, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_LDCFG_SFR_LDCFG, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_LDCFG_SFR_LDCFG, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG0);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG0, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG0_CR_VDCFG0);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG0_CR_VDCFG0, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG0_CR_VDCFG0, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG0_CR_VDCFG0, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG0_CR_VDCFG0, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG1);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG1, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG1_CR_VDCFG1);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG1_CR_VDCFG1, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG1_CR_VDCFG1, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG1_CR_VDCFG1, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG1_CR_VDCFG1, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG2);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG2, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG2_CR_VDCFG2);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG2_CR_VDCFG2, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG2_CR_VDCFG2, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG2_CR_VDCFG2, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG2_CR_VDCFG2, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG3);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG3, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG3_CR_VDCFG3);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG3_CR_VDCFG3, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG3_CR_VDCFG3, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG3_CR_VDCFG3, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG3_CR_VDCFG3, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG4);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG4, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG4_CR_VDCFG4);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG4_CR_VDCFG4, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG4_CR_VDCFG4, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG4_CR_VDCFG4, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG4_CR_VDCFG4, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG5);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG5, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG5_CR_VDCFG5);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG5_CR_VDCFG5, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG5_CR_VDCFG5, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG5_CR_VDCFG5, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG5_CR_VDCFG5, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG6);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG6, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG6_CR_VDCFG6);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG6_CR_VDCFG6, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG6_CR_VDCFG6, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG6_CR_VDCFG6, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG6_CR_VDCFG6, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDCFG_CR_VDCFG7);
-        sensorc_csr.wo(utra::sensorc::SFR_VDCFG_CR_VDCFG7, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDCFG_CR_VDCFG7_CR_VDCFG7);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDCFG_CR_VDCFG7_CR_VDCFG7, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDCFG_CR_VDCFG7_CR_VDCFG7, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDCFG_CR_VDCFG7_CR_VDCFG7, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDCFG_CR_VDCFG7_CR_VDCFG7, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDIP_ENA);
-        sensorc_csr.wo(utra::sensorc::SFR_VDIP_ENA, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDIP_ENA_VDENA);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDIP_ENA_VDENA, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDIP_ENA_VDENA, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDIP_ENA_VDENA, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDIP_ENA_VDENA, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_VDIP_TEST);
-        sensorc_csr.wo(utra::sensorc::SFR_VDIP_TEST, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_VDIP_TEST_VDTST);
-        sensorc_csr.rmwf(utra::sensorc::SFR_VDIP_TEST_VDTST, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_VDIP_TEST_VDTST, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_VDIP_TEST_VDTST, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_VDIP_TEST_VDTST, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_LDIP_TEST);
-        sensorc_csr.wo(utra::sensorc::SFR_LDIP_TEST, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_LDIP_TEST_LDTST);
-        sensorc_csr.rmwf(utra::sensorc::SFR_LDIP_TEST_LDTST, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_LDIP_TEST_LDTST, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_LDIP_TEST_LDTST, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_LDIP_TEST_LDTST, baz);
-
-        let foo = sensorc_csr.r(utra::sensorc::SFR_LDIP_FD);
-        sensorc_csr.wo(utra::sensorc::SFR_LDIP_FD, foo);
-        let bar = sensorc_csr.rf(utra::sensorc::SFR_LDIP_FD_SFR_LDIP_FD);
-        sensorc_csr.rmwf(utra::sensorc::SFR_LDIP_FD_SFR_LDIP_FD, bar);
-        let mut baz = sensorc_csr.zf(utra::sensorc::SFR_LDIP_FD_SFR_LDIP_FD, bar);
-        baz |= sensorc_csr.ms(utra::sensorc::SFR_LDIP_FD_SFR_LDIP_FD, 1);
-        sensorc_csr.wfo(utra::sensorc::SFR_LDIP_FD_SFR_LDIP_FD, baz);
   }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -394,6 +394,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // ------ Cramium hardware image configs ------
         Some("cramium-fpga") | Some("cramium-soc") => {
             let cramium_pkgs = ["xous-log", "xous-names", "xous-ticktimer", "cram-console"].to_vec();
+            builder.add_loader_feature("debug-print");
+            builder.add_loader_feature("board-bringup");
             match task.as_deref() {
                 Some("cramium-fpga") => builder.target_cramium_fpga(),
                 Some("cramium-soc") => builder.target_cramium_soc(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -396,6 +396,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let cramium_pkgs = ["xous-log", "xous-names", "xous-ticktimer", "cram-console"].to_vec();
             builder.add_loader_feature("debug-print");
             builder.add_loader_feature("board-bringup");
+            builder.add_kernel_feature("v2p");
             match task.as_deref() {
                 Some("cramium-fpga") => builder.target_cramium_fpga(),
                 Some("cramium-soc") => builder.target_cramium_soc(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -393,7 +393,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // ------ Cramium hardware image configs ------
         Some("cramium-fpga") | Some("cramium-soc") => {
-            let cramium_pkgs = ["xous-log", "xous-names", "xous-ticktimer", "cram-console"].to_vec();
+            let cramium_pkgs = ["xous-log", "xous-names", "xous-ticktimer", "cram-hal-service"].to_vec();
             builder.add_loader_feature("debug-print");
             builder.add_loader_feature("board-bringup");
             builder.add_kernel_feature("v2p");


### PR DESCRIPTION
This is a deep-dive refactor of the Cramium target interfaces to go from loosely held-together SoC validation code to something meant to be more durable and safe.

An interesting observation is that when designing a chip, the hardware interfaces can and will change. Often times at the last minute. Writing good Rust abstractions is like casting concrete -- it's a lot of effort, and only makes sense if the foundations have been laid out and won't shift. I do think the right process for using Rust in the context of an actively developed chip is to bodge things over initially with a lot of unsafe memory pokes, and digging into the hardware co-sim environment making sure that the hardware is even working. Usually all you're doing is something pretty simple -- like configuring a peripheral with a few pokes just to see it do some bus transactions, and you're eye-balling the results in a waveform viewer and doing some self-checks of correctness with peeks. You want the code layer at this point in time to be really loose, so you don't have unnecessary barriers holding you back from making the hardware correct.

However, once the chip goes to tape-out, nothing is going to change -- foundations are poured. At this point, it does feel more right to do a pass of clean-up to bring things up to standard. It does take some discipline, however, to grit through and toss out those peeks and pokes because the pile of abstractions necessary to do it right is not small.

Also, not every piece of hardware was made for Rust. While designing abstractions for the UDMA IP (which is from the Pulp project out of ETH Zurich & University of Bologna), it's pretty clear the designers did not have a strictly typed language like Rust in mind. It looks like a goal was to do some sort of "hardware polymorphism" where a common interface template is derived to enable DMA transfer to peripherals, and then you implement traits on a DMA channel that would be unique to each peripheral. It's nice conceptually...but there is a major wart, in that the peripherals all require access to some global shared state to manage clocks and events. So the constructor would ideally be able to reach into a global shared clock/event constructor, and Drop could do the same, to map and unmap the objects. I can't think of any way to implement this nicely in Rust, so, the constructor is simply marked as `unsafe` and you're meant to remember to map the clocks & events before creating an object, and you have no unmap after they Drop.

This is particularly tricky in the case that a peripheral is meant to be owned by different processes -- maybe if we had one process own all peripherals we could use a `static mut` of some sort and unsafe access to paper over this. But ideally the same abstraction works in raw-iron as it would in a multi-process system, and there is simply no way to do a `static mut` that's shared between different virtual memory spaces in Xous. Maybe the abstraction could be extended to use a "well known server" that manages global shared state and syscalls could be introduced into the constructor/destructor that manages clocks and what nots, and then use a `cfg` flag to generate separate code paths for raw-iron targets and OS targets. But I kind of don't like this approach because it hides the expense of these global operations -- philosophically I prefer the `unsafe` decorator and force the driver writer to think a little bit before introducing a potentially expensive global lock into some low-level code.

Anyways. These are mostly notes for myself, PR is WIP, but exists in a branch simply because `main` is protected.