### PR TITLE
Implement #478

### DIFF
--- a/RELEASE-v0.9.md
+++ b/RELEASE-v0.9.md
@@ -465,6 +465,7 @@ perform the Xous firmware upgrade. This requires running manual update commands,
 - `sigchat` moved to its own repo with AGPL licensing: https://github.com/betrusted-io/sigchat
 - Formatting and contribution standards have been modified. Formatting with `rustfmt` and trailing white space removal is now mandatory for all Xous contributions, see [#477](https://github.com/betrusted-io/xous-core/pull/477) for a discussion of how we got there and why.
 - The repo has gone through a "flag day" where all the crates have been formatted, which means commits before the flag day may be more difficult to undo. The changes are committed on a crate-by-crate basis, so if something is really broken we can undo the formatting for the crate and add an exception to the rustfmt rules.
+- Implement #478: backlight should turn on automatically when a U2F/FIDO packet comes in from the host, allowing users in dark conditions to see the screen and know what they are approving.
 
 
 ## Roadmap

--- a/services/usb-device-xous/src/api.rs
+++ b/services/usb-device-xous/src/api.rs
@@ -27,6 +27,8 @@ pub(crate) enum Opcode {
     DebugUsbOp = 9,
     /// Set autotype rate
     SetAutotypeRate = 10,
+    /// Register a USB event observer
+    RegisterUsbObserver = 11,
 
     /// Send a U2F message
     U2fTx = 128,
@@ -138,4 +140,11 @@ pub struct UsbSerialAscii {
 pub struct UsbSerialBinary {
     pub d: [u8; SERIAL_BINARY_BUFLEN],
     pub len: usize,
+}
+
+/// this structure is used to register a USB listener.
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Copy, Clone)]
+pub(crate) struct UsbListenerRegistration {
+    pub server_name: xous_ipc::String<64>,
+    pub listener_op_id: usize,
 }

--- a/services/usb-device-xous/src/lib.rs
+++ b/services/usb-device-xous/src/lib.rs
@@ -370,6 +370,16 @@ impl UsbHid {
         )
         .unwrap();
     }
+
+    pub fn register_u2f_observer(&self, server_name: &str, action_opcode: usize) {
+        let kr = UsbListenerRegistration {
+            server_name: xous_ipc::String::<64>::from_str(server_name),
+            listener_op_id: action_opcode,
+        };
+        let buf = Buffer::into_buf(kr).unwrap();
+        buf.lend(self.conn, Opcode::RegisterUsbObserver.to_u32().unwrap())
+            .expect("couldn't register listener");
+    }
 }
 
 use core::sync::atomic::{AtomicU32, Ordering};


### PR DESCRIPTION
This should implement #478.

I have tested that this works with webauthn/FIDO2, but unfortunately all of the U2F test sites that I know of have suffered from bit-rot and have ceased to work due to various security policies that have rolled out over the years.
