### PR TITLE
fix default font settings

### DIFF
--- a/services/graphics-server/src/wordwrap.rs
+++ b/services/graphics-server/src/wordwrap.rs
@@ -235,13 +235,17 @@ impl Typesetter {
         let mut ellipsis = style_glyph('…', base_style);
         ellipsis.kern = 0;
 
-        #[cfg(feature = "cramium-soc")]
-        let base_style = GlyphStyle::Tall;
         #[cfg(not(feature = "cramium-soc"))]
-        let base_style = GlyphStyle::Cjk;
+        let mut large_space = style_glyph(' ', &GlyphStyle::Cjk);
+        #[cfg(feature = "cramium-soc")]
+        let mut large_space = style_glyph(' ', &GlyphStyle::Tall);
 
-        let mut large_space = style_glyph(' ', &base_style);
-        large_space.wide = glyph_to_height_hint(base_style) as u8;
+        if cfg!(feature = "cramium-soc") {
+            large_space.wide = glyph_to_height_hint(GlyphStyle::Tall) as u8;
+        } else {
+            large_space.wide = glyph_to_height_hint(GlyphStyle::Cjk) as u8;
+        }
+
         Typesetter {
             charpos: 0,
             cursor: Cursor::new(0, 0, 0),


### PR DESCRIPTION
there's something....weird....going on in the initializers here and ... something about configurations not being applicable to expressions??

i'm a little confused, but, the original work-around I had to this isuse somehow side-effected things in some way that I didn't expect. this reverts those side effects.