### PR TITLE
Build kernel and loader using `riscv32imac-unknown-none-elf` -- fixes 1.76.0

### DIFF
--- a/kernel/src/arch/mod.rs
+++ b/kernel/src/arch/mod.rs
@@ -16,9 +16,9 @@ mod riscv;
 #[cfg(target_arch = "riscv32")]
 pub use crate::arch::riscv::*;
 
-#[cfg(all(target_arch = "riscv64", not(target_os = "xous")))]
+#[cfg(all(target_arch = "riscv64", not(baremetal)))]
 mod riscv;
-#[cfg(all(target_arch = "riscv64", not(target_os = "xous")))]
+#[cfg(all(target_arch = "riscv64", not(baremetal)))]
 pub use riscv::*;
 
 #[cfg(all(target_arch = "x86_64", not(any(windows, unix))))]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -87,7 +87,7 @@ pub extern "C" fn kmain() {
     // Note that at this point, no new direct children of INIT may be created.
     let mut pid = None;
 
-    #[cfg(not(any(target_os = "none", target_os = "xous", all(ci, test))))]
+    #[cfg(not(any(baremetal, all(ci, test))))]
     {
         use std::panic;
         panic::set_hook(Box::new(|arg| {

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -501,23 +501,6 @@ impl MemoryManager {
         )
     }
 
-    // /// Transfer ownership of a page without moving it. This is a very
-    // /// specialized function which should only be used when creating a
-    // /// brand-new process.
-    // pub fn move_page_ownership(
-    //     &mut self,
-    //     src_addr: *mut u8,
-    //     src_pid: PID,
-    //     dest_pid: PID,
-    // ) -> Result<(), xous_kernel::Error> {
-    //     let phys_addr = crate::arch::mem::virt_to_phys(src_addr as usize)?;
-    //     self.claim_release_move(
-    //         phys_addr as *mut usize,
-    //         dest_pid,
-    //         ClaimReleaseMove::Move(src_pid),
-    //     )
-    // }
-
     /// Mark the page in the current process as being lent.  If the borrow is
     /// read-only, then additionally remove the "write" bit on it.  If the page
     /// is writable, then remove it from the current process until the borrow is

--- a/kernel/src/services.rs
+++ b/kernel/src/services.rs
@@ -876,7 +876,7 @@ impl SystemServices {
                 }
 
                 // Activate this process on this CPU
-                #[cfg(not(target_os = "xous"))]
+                #[cfg(not(baremetal))]
                 process.activate()?;
                 ArchProcess::current().set_tid(new_thread)?;
                 process.current_thread = new_thread as _;

--- a/kernel/src/services.rs
+++ b/kernel/src/services.rs
@@ -568,17 +568,6 @@ impl SystemServices {
         Ok(())
     }
 
-    // #[cfg(not(baremetal))]
-    // pub fn make_callback_to(
-    //     &mut self,
-    //     _pid: PID,
-    //     _pc: *const usize,
-    //     _irq_no: usize,
-    //     _arg: *mut usize,
-    // ) -> Result<(), xous_kernel::Error> {
-    //     Err(xous_kernel::Error::UnhandledSyscall)
-    // }
-
     /// Create a stack frame in the specified process and jump to it.
     /// 1. Pause the current process and switch to the new one
     /// 2. Save the process state, if it hasn't already been saved
@@ -934,11 +923,6 @@ impl SystemServices {
                 panic!("PID {} TID {} was not in a state to be switched from: {:?}", pid, tid, other);
             }
         };
-        // log_process_update(file!(), line!(), process, old_state);
-        // klog!(
-        //     "unschedule_thread({}:{}): New state is {:?}",
-        //     pid, tid, process.state
-        // );
         Ok(())
     }
 
@@ -950,14 +934,6 @@ impl SystemServices {
             }
         }
         panic!("PID {} TID {} not running: {:?}", pid, tid, process.state);
-        // match &process.state {
-        //     &ProcessState::Sleeping => false,
-        //     &ProcessState::Ready(_x) => false,
-        //     &ProcessState::Free => false,
-        //     &ProcessState::Running(x) if x & (1 << tid) != 0 => false,
-        //     &ProcessState::Setup(_) => false,
-        //     &ProcessState::Running(_) => true,
-        // }
     }
 
     pub fn set_thread_result(

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -709,27 +709,6 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
                 let range =
                     mm.map_range(phys_ptr, virt_ptr, size.get(), pid, req_flags, MemoryType::Default)?;
 
-                // If we're handing back an address in main RAM, zero it out. If
-                // phys is 0, then the page will be lazily allocated, so we
-                // don't need to do this.
-                // if !phys_ptr.is_null() {
-                //     for (phys, virt) in (phys_ptr as usize..range.len()).step_by(PAGE_SIZE).zip(
-                //         (range.as_ptr() as usize..(range.as_ptr() as usize + range.len()))
-                //             .step_by(PAGE_SIZE),
-                //     ) {
-                //         // Zero out the virtual page if it's in main memory
-                //         if mm.is_main_memory(phys as *mut u8) {
-                //             let start = virt as *mut usize;
-                //             for offset in 0..(PAGE_SIZE / core::mem::size_of::<usize>()) {
-                //                 unsafe { start.add(offset).write_volatile(0) };
-                //             }
-                //         }
-
-                //         // Hand the virtual page to the process
-                //         crate::arch::mem::hand_page_to_user(virt as *mut u8)
-                //             .expect("couldn't hand page to user");
-                //       }
-
                 if !phys_ptr.is_null() {
                     if mm.is_main_memory(phys_ptr) {
                         let range_start = range.as_mut_ptr() as *mut usize;

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -175,7 +175,7 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
 
             // Mark the server's context as "Ready". If this fails, return the context
             // to the blocking list.
-            #[cfg(target_os = "xous")]
+            #[cfg(baremetal)]
             ss.ready_thread(server_pid, server_tid).map_err(|e| {
                 ss.server_from_sidx_mut(sidx)
                     .expect("server couldn't be located")
@@ -883,7 +883,7 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
         SysCall::CreateThread(thread_init) => SystemServices::with_mut(|ss| {
             ss.create_thread(pid, thread_init).map(|new_tid| {
                 // Set the return value of the existing thread to be the new thread ID
-                if cfg!(target_os = "xous") {
+                if cfg!(baremetal) {
                     // Immediately switch to the new thread
                     ss.switch_to_thread(pid, Some(new_tid)).expect("couldn't activate new thread");
                     ss.set_thread_result(pid, tid, xous_kernel::Result::ThreadID(new_tid))

--- a/xous-rs/src/arch/mod.rs
+++ b/xous-rs/src/arch/mod.rs
@@ -1,16 +1,24 @@
-#[cfg(all(target_os = "xous", target_arch = "arm"))]
+#[cfg(all(any(target_os = "none", target_os = "xous"), target_arch = "arm"))]
 mod arm;
-#[cfg(all(target_os = "xous", target_arch = "arm"))]
+#[cfg(all(any(target_os = "none", target_os = "xous"), target_arch = "arm"))]
 pub use arm::*;
 
-#[cfg(all(target_os = "xous", target_arch = "riscv32"))]
+#[cfg(all(any(target_os = "xous", target_os = "none"), target_arch = "riscv32"))]
 pub mod riscv;
-#[cfg(all(target_os = "xous", target_arch = "riscv32"))]
+#[cfg(all(any(target_os = "xous", target_os = "none"), target_arch = "riscv32"))]
 pub use riscv::*;
 
-#[cfg(all(not(feature = "processes-as-threads"), not(target_os = "xous"), not(target_arch = "arm"),))]
+#[cfg(all(
+    not(feature = "processes-as-threads"),
+    not(any(target_os = "xous", target_os = "none")),
+    not(target_arch = "arm"),
+))]
 pub mod hosted;
-#[cfg(all(not(feature = "processes-as-threads"), not(target_os = "xous"), not(target_arch = "arm"),))]
+#[cfg(all(
+    not(feature = "processes-as-threads"),
+    not(any(target_os = "xous", target_os = "none")),
+    not(target_arch = "arm"),
+))]
 pub use hosted::*;
 
 #[cfg(feature = "processes-as-threads")]

--- a/xous-rs/src/definitions.rs
+++ b/xous-rs/src/definitions.rs
@@ -55,7 +55,7 @@ pub const BASE_QUANTA_MS: u32 = 10;
 pub const BOOKEND_START: &str = "_|TT|_";
 pub const BOOKEND_END: &str = "_|TE|_";
 
-#[cfg(not(target_os = "xous"))]
+#[cfg(not(any(target_os = "xous", target_os = "none")))]
 use core::sync::atomic::AtomicU64;
 
 // Secretly, you can change this by setting the XOUS_SEED environment variable.
@@ -64,7 +64,7 @@ use core::sync::atomic::AtomicU64;
 // The code that reads the varable this is all the way over in xous-rs\src\arch\hosted\mod.rs#29, and
 // it's glommed onto some other static process initialization code because I don't fully understand
 // what's going on over there.
-#[cfg(not(target_os = "xous"))]
+#[cfg(not(any(target_os = "xous", target_os = "none")))]
 pub static TESTING_RNG_SEED: AtomicU64 = AtomicU64::new(0);
 
 pub mod exceptions;

--- a/xtask/src/builder.rs
+++ b/xtask/src/builder.rs
@@ -637,6 +637,7 @@ impl Builder {
         }
 
         crate::utils::ensure_compiler(&self.target.as_ref().map(|s| s.as_str()), false, false)?;
+        crate::utils::ensure_kernel_compiler(&self.target_kernel.as_ref().map(|s| s.as_str()), false)?;
         self.locale_override(); // apply the locale override
 
         // ------ build the services & apps ------

--- a/xtask/src/builder.rs
+++ b/xtask/src/builder.rs
@@ -126,6 +126,8 @@ pub(crate) struct Builder {
     stream: BuildStream,
     min_ver: String,
     target: Option<String>,
+    /// The kernel might require a different target than the rest of the programs.
+    target_kernel: Option<String>,
     utra_target: String,
     run_svd2repl: bool,
     locale_override: Option<String>,
@@ -154,6 +156,7 @@ impl Builder {
             stream: BuildStream::Release,
             min_ver: crate::MIN_XOUS_VERSION.to_string(),
             target: Some(crate::TARGET_TRIPLE_RISCV32.to_string()),
+            target_kernel: Some(crate::TARGET_TRIPLE_RISCV32_KERNEL.to_string()),
             utra_target: format!("precursor-{}", crate::PRECURSOR_SOC_VERSION).to_string(),
             run_svd2repl: false,
             locale_override: None,
@@ -236,6 +239,7 @@ impl Builder {
     /// Configure for renode targets
     pub fn target_renode<'a>(&'a mut self) -> &'a mut Builder {
         self.target = Some(crate::TARGET_TRIPLE_RISCV32.to_string());
+        self.target_kernel = Some(crate::TARGET_TRIPLE_RISCV32_KERNEL.to_string());
         self.stream = BuildStream::Release;
         self.run_svd2repl = true;
         self.utra_target = "renode".to_string();
@@ -249,6 +253,7 @@ impl Builder {
     /// be just the gitrev of the soc version, not the entire feature name.
     pub fn target_precursor<'a>(&'a mut self, soc_version: &str) -> &'a mut Builder {
         self.target = Some(crate::TARGET_TRIPLE_RISCV32.to_string());
+        self.target_kernel = Some(crate::TARGET_TRIPLE_RISCV32_KERNEL.to_string());
         self.stream = BuildStream::Release;
         self.utra_target = format!("precursor-{}", soc_version).to_string();
         self.run_svd2repl = false;
@@ -259,6 +264,7 @@ impl Builder {
 
     pub fn target_precursor_no_image<'a>(&'a mut self, soc_version: &str) -> &'a mut Builder {
         self.target = Some(crate::TARGET_TRIPLE_RISCV32.to_string());
+        self.target_kernel = Some(crate::TARGET_TRIPLE_RISCV32_KERNEL.to_string());
         self.stream = BuildStream::Release;
         self.utra_target = format!("precursor-{}", soc_version).to_string();
         self.run_svd2repl = false;
@@ -269,6 +275,7 @@ impl Builder {
     /// Configure for ARM targets
     pub fn target_arm(&mut self) -> &mut Builder {
         self.target = Some(crate::TARGET_TRIPLE_ARM.to_string());
+        self.target_kernel = Some(crate::TARGET_TRIPLE_ARM_KERNEL.to_string());
         self.stream = BuildStream::Debug;
         self.utra_target = "atsama5d27".to_string();
         self.run_svd2repl = false;
@@ -280,6 +287,7 @@ impl Builder {
     /// Configure various Cramium targets
     pub fn target_cramium_fpga<'a>(&'a mut self) -> &'a mut Builder {
         self.target = Some(crate::TARGET_TRIPLE_RISCV32.to_string());
+        self.target_kernel = Some(crate::TARGET_TRIPLE_RISCV32_KERNEL.to_string());
         self.stream = BuildStream::Release;
         self.utra_target = "cramium-fpga".to_string();
         self.run_svd2repl = false;
@@ -290,6 +298,7 @@ impl Builder {
 
     pub fn target_cramium_soc<'a>(&'a mut self) -> &'a mut Builder {
         self.target = Some(crate::TARGET_TRIPLE_RISCV32.to_string());
+        self.target_kernel = Some(crate::TARGET_TRIPLE_RISCV32_KERNEL.to_string());
         self.stream = BuildStream::Release;
         self.utra_target = "cramium-soc".to_string();
         self.run_svd2repl = false;
@@ -591,16 +600,14 @@ impl Builder {
         }
 
         // ------ configure target generation feature flags ------
-        let target = if self.utra_target.contains("renode") {
+        if self.utra_target.contains("renode") {
             self.features.push("renode".into());
             self.loader_features.push("renode".into());
             self.kernel_features.push("renode".into());
-            Some(crate::TARGET_TRIPLE_RISCV32)
         } else if self.utra_target.contains("hosted") {
             self.features.push("hosted".into());
             // there is no loader in hosed mode
             self.kernel_features.push("hosted".into());
-            None
         } else if self.utra_target.contains("precursor") {
             self.features.push("precursor".into());
             self.features.push(format!("utralib/{}", &self.utra_target));
@@ -608,11 +615,9 @@ impl Builder {
             self.kernel_features.push(format!("utralib/{}", &self.utra_target));
             self.loader_features.push("precursor".into());
             self.loader_features.push(format!("utralib/{}", &self.utra_target));
-            Some(crate::TARGET_TRIPLE_RISCV32)
         } else if self.utra_target.contains("atsama5d2") {
             self.kernel_features.push("atsama5d27".into());
             self.loader_features.push("atsama5d27".into());
-            Some(crate::TARGET_TRIPLE_ARM)
         } else if self.utra_target.contains("cramium-fpga") {
             self.features.push("cramium-fpga".into());
             self.features.push(format!("utralib/{}", &self.utra_target));
@@ -620,7 +625,6 @@ impl Builder {
             self.kernel_features.push(format!("utralib/{}", &self.utra_target));
             self.loader_features.push("cramium-fpga".into());
             self.loader_features.push(format!("utralib/{}", &self.utra_target));
-            Some(crate::TARGET_TRIPLE_RISCV32)
         } else if self.utra_target.contains("cramium-soc") {
             self.features.push("cramium-soc".into());
             self.features.push(format!("utralib/{}", &self.utra_target));
@@ -628,10 +632,9 @@ impl Builder {
             self.kernel_features.push(format!("utralib/{}", &self.utra_target));
             self.loader_features.push("cramium-soc".into());
             self.loader_features.push(format!("utralib/{}", &self.utra_target));
-            Some(crate::TARGET_TRIPLE_RISCV32)
         } else {
             return Err("Target unknown: please check your UTRA target".into());
-        };
+        }
 
         crate::utils::ensure_compiler(&self.target.as_ref().map(|s| s.as_str()), false, false)?;
         self.locale_override(); // apply the locale override
@@ -656,7 +659,7 @@ impl Builder {
         let mut services_path = self.builder(
             &[&self.services[..], &self.apps[..]].concat(),
             &self.features,
-            &target,
+            &self.target.as_deref(),
             self.stream,
             &vec![],
             false,
@@ -735,7 +738,7 @@ impl Builder {
                 let _ = self.builder(
                     &vec![CrateSpec::Local("xous-kernel".into(), false)],
                     &self.kernel_features,
-                    &target,
+                    &self.target_kernel.as_deref(),
                     self.stream,
                     &vec![],
                     false,
@@ -751,7 +754,7 @@ impl Builder {
             let kernel_path = self.builder(
                 &vec![self.kernel.clone()],
                 &self.kernel_features,
-                &target,
+                &self.target_kernel.as_deref(),
                 self.stream,
                 &kernel_extra,
                 false,
@@ -773,7 +776,7 @@ impl Builder {
             let loader = self.builder(
                 &vec![self.loader.clone()],
                 &self.loader_features,
-                &target,
+                &self.target_kernel.as_deref(),
                 BuildStream::Release, // loader doesn't fit if you build with Debug
                 &loader_extra,
                 true, // loader builds without any default features

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -42,8 +42,10 @@ const MIN_XOUS_VERSION: &str = "v0.9.8-791";
 
 /// target triple for precursor builds
 pub(crate) const TARGET_TRIPLE_RISCV32: &str = "riscv32imac-unknown-xous-elf";
+pub(crate) const TARGET_TRIPLE_RISCV32_KERNEL: &str = "riscv32imac-unknown-none-elf";
 /// target triple for ARM builds
 pub(crate) const TARGET_TRIPLE_ARM: &str = "armv7a-unknown-xous-elf";
+pub(crate) const TARGET_TRIPLE_ARM_KERNEL: &str = "armv7a-unknown-none-elf";
 
 // because I have nowhere else to note this. The commit that contains the rkyv-enum derive
 // refactor to work around warnings thrown by Rust 1.64.0 is: f815ed85b58b671178fbf53b4cea34186fc406eb

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -166,7 +166,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match task.as_deref() {
         Some("install-toolkit") | Some("install-toolchain") => {
             let arg = env::args().nth(2);
-            ensure_compiler(&Some(TARGET_TRIPLE_RISCV32), true, arg.map(|x| x == "--force").unwrap_or(false))?
+            ensure_compiler(
+                &Some(TARGET_TRIPLE_RISCV32),
+                true,
+                arg.map(|x| x == "--force").unwrap_or(false),
+            )?;
+            ensure_kernel_compiler(&Some(TARGET_TRIPLE_RISCV32_KERNEL), true)?;
         }
         // ----- renode configs --------
         Some("renode-image") => {


### PR DESCRIPTION
Rust 1.76.0 is the first version that supports unwinding. This is a fairly major change for Xous.

One of the problems is that we apparently cannot build with `panic = "abort"` any more. This will need some more investigation, but for now the easiest approach is to just build everything normally.

Things get a bit funny with the kernel and loader, though. Because we don't want unwinding machinery on these targets, we'll need to build with `riscv32imac-unknown-none-elf` as a target.

This patchset supports this new arrangement. With this patchset, we are able to build under Rust 1.76.0 while we find a better solution for possibly supporting both `panic = "abort"` and `panic = "unwind"`.