### PR TITLE
emulation: expose gdb serial to port 3456

### DIFF
--- a/emulation/betrusted.resc
+++ b/emulation/betrusted.resc
@@ -107,6 +107,12 @@ macro reset
 emulation CreateServerSocketTerminal 8888 "kernel" False
 connector Connect sysbus.uart kernel
 
+# Connect the `app_uart` port -- which is the port on which
+# the Xous gdbserver runs -- to TCP port 3456, to allow for
+# application-aware debugging
+emulation CreateServerSocketTerminal 3456 "gdb" False
+connector Connect sysbus.app_uart gdb
+
 runMacro $reset
 
 mach clear


### PR DESCRIPTION
Expose `app_uart` to TCP port 3456 to allow for attaching GDB.