### PR TITLE
kernel: use addr_of!() and addr_of_mut!()

### DIFF
--- a/kernel/src/arch/riscv/process.rs
+++ b/kernel/src/arch/riscv/process.rs
@@ -516,7 +516,7 @@ impl Process {
     }
 
     pub fn destroy(pid: PID) -> Result<(), xous_kernel::Error> {
-        let process_table = unsafe { &mut PROCESS_TABLE };
+        let process_table = unsafe { &mut *core::ptr::addr_of_mut!(PROCESS_TABLE) };
         let pid_idx = pid.get() as usize - 1;
         if pid_idx >= process_table.table.len() {
             panic!("attempted to destroy PID that exceeds table index: {}", pid);
@@ -597,7 +597,7 @@ impl core::fmt::Display for Thread {
 pub fn set_current_pid(pid: PID) {
     let pid_idx = (pid.get() - 1) as usize;
     unsafe {
-        let pt = &mut PROCESS_TABLE;
+        let pt = &mut *core::ptr::addr_of_mut!(PROCESS_TABLE);
 
         match pt.table.get(pid_idx) {
             None | Some(false) => panic!("PID {} does not exist", pid),

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -93,7 +93,7 @@ impl MemoryManager {
     {
         #[cfg(baremetal)]
         unsafe {
-            f(&mut MEMORY_MANAGER)
+            f(&mut *core::ptr::addr_of_mut!(MEMORY_MANAGER))
         }
 
         #[cfg(not(baremetal))]
@@ -107,7 +107,7 @@ impl MemoryManager {
     {
         #[cfg(baremetal)]
         unsafe {
-            f(&MEMORY_MANAGER)
+            f(&*core::ptr::addr_of!(MEMORY_MANAGER))
         }
 
         #[cfg(not(baremetal))]

--- a/kernel/src/services.rs
+++ b/kernel/src/services.rs
@@ -314,7 +314,7 @@ impl SystemServices {
     {
         #[cfg(baremetal)]
         unsafe {
-            f(&SYSTEM_SERVICES)
+            f(&*core::ptr::addr_of!(SYSTEM_SERVICES))
         }
         #[cfg(not(baremetal))]
         SYSTEM_SERVICES.with(|ss| f(&ss.borrow()))
@@ -326,7 +326,7 @@ impl SystemServices {
     {
         #[cfg(baremetal)]
         unsafe {
-            f(&mut SYSTEM_SERVICES)
+            f(&mut *core::ptr::addr_of_mut!(SYSTEM_SERVICES))
         }
 
         #[cfg(not(baremetal))]


### PR DESCRIPTION
DUe to https://github.com/rust-lang/rust/issues/114447 direct access to static mut variables causes a warning which will be turned into an error in the 2024 edition.

The workaround is to use `addr_of!()` and `addr_of_mut!()` macros and then dereference that.