### PR TITLE
check keymap on every call to "type" over USB

### DIFF
--- a/RELEASE-v0.9.md
+++ b/RELEASE-v0.9.md
@@ -472,6 +472,7 @@ perform the Xous firmware upgrade. This requires running manual update commands,
 - @gsora has added the `hidapi` - apps can now register a HID descriptor for custom interactions over USB. See `apps/hidv2` for democumentation.
 - change kernel and loader targets to riscv-unknown-elf-none because `xous` is now a proper target (required for Rust 1.76 compatibility)
 - `curve25519-dalek` API is now at 4.1.2, thanks to @kotval for pulling it together. The new API removes `engine-25519` and rolls hardware allocate/release into the forked crate, similar to how sha2 was ported. `engine-25519` crate now removed from source tree, as it is now depracted since all the functionality was pulled into `curve25519-dalek`.
+- keymap is checked on every call to send a key to the USB keyboard. This allows us to toggle the keymap temporarily to allow typing into hosts with a different keymap (instead of requiring a reboot)
 
 ## Roadmap
 - Lots of testing and bug fixes

--- a/services/usb-device-xous/src/main_hw.rs
+++ b/services/usb-device-xous/src/main_hw.rs
@@ -85,8 +85,6 @@ pub(crate) fn main_hw() -> ! {
     let tt = ticktimer_server::Ticktimer::new().unwrap();
     #[cfg(not(feature = "minimal"))]
     let native_kbd = keyboard::Keyboard::new(&xns).unwrap();
-    #[cfg(not(feature = "minimal"))]
-    let native_map = native_kbd.get_keymap().unwrap();
 
     #[cfg(not(feature = "minimal"))]
     let serial_number = format!("{:x}", llio.soc_dna().unwrap());
@@ -1165,6 +1163,7 @@ pub(crate) fn main_hw() -> ! {
                 match view {
                     Views::FidoWithKbd => {
                         if usb_dev.state() == UsbDeviceState::Configured {
+                            let native_map = native_kbd.get_keymap().unwrap();
                             let mut codes = Vec::<Keyboard>::new();
                             if code0 != 0 {
                                 codes.push(match native_map {
@@ -1262,6 +1261,9 @@ pub(crate) fn main_hw() -> ! {
                 match view {
                     #[cfg(not(feature = "minimal"))]
                     Views::FidoWithKbd => {
+                        // check keymap on every call because we may need to toggle this for e.g. plugging
+                        // into a new host with a different map
+                        let native_map = native_kbd.get_keymap().unwrap();
                         for ch in usb_send.s.as_str().unwrap().chars() {
                             // ASSUME: user's keyboard type matches the preference on their Precursor device.
                             let codes = match native_map {


### PR DESCRIPTION
this allows us to type into hosts that have different keymappings from each other without requiring a reboot.