### PR TITLE
WIP: iron out swap integration in kernel

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -255,6 +255,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             builder.add_loader_feature("swap");
             builder.add_kernel_feature("swap");
             builder.add_kernel_feature("debug-swap");
+            builder.add_kernel_feature("debug-print");
 
             // It is important that this is the first service added, because the swapper *must* be in PID 2
             builder.add_service("xous-swapper", LoaderRegion::Ram);


### PR DESCRIPTION
This is the branch for working out swap integration into the kernel. A provisional to-do list includes:

- [ ] Rework argument setup from loader-to-kernel handoff, now that we know what the actual structures look like
- [ ] Rework RPT hand-off to the swapper PID
- [ ] Add baseline code to handle an actual swap event inside `xous-swapper` (eg `WriteToSwap`, `ReadFromSwap`) (for Precursor test case)
- [ ] Add baseline code to handle an actual swap event inside `xous-swapper` (for Cramium target)
- [ ] Add LRU aging (e.g. `AllocateAdvisory` handler + `EvictPage` call)
- [ ] Update documentation in Xous Book to match the reality of what was implemented
- [ ] Benchmark AES-GCM-SIV vs ChachaPoly for AEAD (optional)
