### PR TITLE
bump xous-semver rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6363,9 +6363,9 @@ dependencies = [
 
 [[package]]
 name = "xous-semver"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed3278bb4e7be4895c1c597434e5269f7357ffb800ebc644f0398bb008a15ad"
+checksum = "4b79d97eaeab0fdf766f7f2c8d3b88bdae67ad36fac9694e2857defca345178c"
 
 [[package]]
 name = "xous-susres"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.14"
 pem = "0.8.3"
 svd2utra = "0.1.22"
 xmas-elf = "0.9.0"
-xous-semver = "0.1.2"
+xous-semver = "0.1.3"
 ed25519-dalek = { version = "2.1.0", features = ["digest"] }
 sha2 = { version = "0.10.8" }
 pkcs8 = { version = "0.8.0", features = ["pem"] }


### PR DESCRIPTION
git tags now returns a 9-digit commit rev instead of 8 in some versions of linux. This causes `u32` parsing of the rev to fail. handle this.