### PR TITLE
fix a doc warning that slipped through the cracks

### DIFF
--- a/services/com/src/lib.rs
+++ b/services/com/src/lib.rs
@@ -49,7 +49,7 @@ pub struct Com {
     ec_lock_id: Option<[u32; 4]>,
     ec_acquired: bool,
     /// this is a hack to make loopbacks work on smoltcp. Work-around taken from Redox, but tracking this
-    /// issue as well: https://github.com/smoltcp-rs/smoltcp/issues/50 and https://github.com/smoltcp-rs/smoltcp/issues/55
+    /// issue as well: <https://github.com/smoltcp-rs/smoltcp/issues/50> and <https://github.com/smoltcp-rs/smoltcp/issues/55>
     loopback_buf: RefCell<VecDeque<Vec<u8>>>,
 }
 impl Com {


### PR DESCRIPTION
hopefully this gets the CI build warning-free finally...some issues following the jenkins build log because the auto-scroll feature keeps disconnecting today...