### PR TITLE
renode: vexriscv: fix CPU on newer Renode versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Xous uses [Renode](https://renode.io/) as the preferred emulator, because
 it is easy to extend the hardware peripherals without recompiling the
 entire emulator.
 
+Due to a breaking change in Renode, this codebase is only compatible with Renode equal to or later than `1.15.2.7965 （e6e79aad-202408180425)`
+
 [Download Renode](https://renode.io/#downloads) and ensure it is in your path.
 For now, you need to [download the nightly build](https://dl.antmicro.com/projects/renode/builds/),
 until `DecodedOperation` is included in the release.

--- a/RELEASE-v0.9.md
+++ b/RELEASE-v0.9.md
@@ -483,7 +483,10 @@ perform the Xous firmware upgrade. This requires running manual update commands,
   - USB core able to enumerate, communicate to Linux devices. Windows compat still WIP.
   - Mailbox protocol to other devices has been tested, working.
   - TRNG has been tuned, partially validated.
-
+  - BIO-BDMA test cases added
+- Various fixes to track changes in Rust 1.80
+- Add documentation to the `modals` library (thanks @rowr111)
+- Due to a breaking change in Renode, this release is only compatible with Renode equal to or later than 1.15.2.7965（e6e79aad-202408180425) (see issue #570 / PR #572)
 
 ## Roadmap
 - Lots of testing and bug fixes

--- a/emulation/peripherals/vexriscv-aes.cs
+++ b/emulation/peripherals/vexriscv-aes.cs
@@ -15,7 +15,7 @@ namespace Antmicro.Renode.Peripherals.CPU.Betrusted
         public AesVexRiscv(Core.Machine machine,
             uint hartId = 0,
             IRiscVTimeProvider timeProvider = null,
-            PrivilegeArchitecture privilegeArchitecture = PrivilegeArchitecture.Priv1_10,
+            PrivilegedArchitecture privilegeArchitecture = PrivilegedArchitecture.Priv1_10,
             string cpuType = "rv32im",
             bool builtInIrqController = true) : base(machine, hartId, timeProvider, privilegeArchitecture, cpuType, builtInIrqController)
         {


### PR DESCRIPTION
Newer versions of Renode rename PrivilegeArchitecture to PrivilegedArchitecture. They appear to have tried to work around this by annotating it with `[NameAlias("privilegeArchitecture")]`, however that doesn't change the fact that the actual type itself changed as well.

This incompatible change will cause breakage on older versions of Renode.

This closes #570