### PR TITLE
rustfmt: reformat repository according to latest rules

### DIFF
--- a/apps/app-loader/src/api.rs
+++ b/apps/app-loader/src/api.rs
@@ -1,8 +1,8 @@
 use std::io::Read;
 
 use gam::{
-    menu_matic, Gam, MenuItem, MenuMatic, TextEntryPayload, UxRegistration, APP_MENU_0_APP_LOADER,
-    APP_MENU_1_APP_LOADER, APP_NAME_APP_LOADER,
+    APP_MENU_0_APP_LOADER, APP_MENU_1_APP_LOADER, APP_NAME_APP_LOADER, Gam, MenuItem, MenuMatic,
+    TextEntryPayload, UxRegistration, menu_matic,
 };
 use locales::t;
 use modals::Modals;

--- a/apps/hello/src/main.rs
+++ b/apps/hello/src/main.rs
@@ -69,11 +69,11 @@ impl Hello {
         self.gam
             .draw_rectangle(
                 self.content,
-                Rectangle::new_with_style(
-                    Point::new(0, 0),
-                    self.screensize,
-                    DrawStyle { fill_color: Some(PixelColor::Light), stroke_color: None, stroke_width: 0 },
-                ),
+                Rectangle::new_with_style(Point::new(0, 0), self.screensize, DrawStyle {
+                    fill_color: Some(PixelColor::Light),
+                    stroke_color: None,
+                    stroke_width: 0,
+                }),
             )
             .expect("can't clear content area");
     }

--- a/apps/hidv2/src/main.rs
+++ b/apps/hidv2/src/main.rs
@@ -79,11 +79,11 @@ impl HIDv2Demo {
         self.gam
             .draw_rectangle(
                 self.content,
-                Rectangle::new_with_style(
-                    Point::new(0, 0),
-                    self.screensize,
-                    DrawStyle { fill_color: Some(PixelColor::Light), stroke_color: None, stroke_width: 0 },
-                ),
+                Rectangle::new_with_style(Point::new(0, 0), self.screensize, DrawStyle {
+                    fill_color: Some(PixelColor::Light),
+                    stroke_color: None,
+                    stroke_width: 0,
+                }),
             )
             .expect("can't clear content area");
     }

--- a/apps/mtxchat/src/listen.rs
+++ b/apps/mtxchat/src/listen.rs
@@ -7,7 +7,7 @@ use url::Url;
 use xous::CID;
 use xous_ipc::Buffer;
 
-use crate::{get_username, web, MTX_LONG_TIMEOUT_MS};
+use crate::{MTX_LONG_TIMEOUT_MS, get_username, web};
 
 pub fn listen(
     url: &mut Url,

--- a/apps/mtxcli/src/cmds/heap.rs
+++ b/apps/mtxcli/src/cmds/heap.rs
@@ -2,7 +2,7 @@ use core::fmt::Write;
 
 use xous_ipc::String as XousString;
 
-use crate::{heap_usage, CommonEnv, ShellCmdApi};
+use crate::{CommonEnv, ShellCmdApi, heap_usage};
 
 #[derive(Debug)]
 pub struct Heap {}

--- a/apps/mtxcli/src/mtxcli.rs
+++ b/apps/mtxcli/src/mtxcli.rs
@@ -156,11 +156,11 @@ impl Mtxcli {
         self.gam
             .draw_rectangle(
                 self.content,
-                Rectangle::new_with_style(
-                    Point::new(0, 0),
-                    self.screensize,
-                    DrawStyle { fill_color: Some(PixelColor::Light), stroke_color: None, stroke_width: 0 },
-                ),
+                Rectangle::new_with_style(Point::new(0, 0), self.screensize, DrawStyle {
+                    fill_color: Some(PixelColor::Light),
+                    stroke_color: None,
+                    stroke_width: 0,
+                }),
             )
             .expect("can't clear content area");
     }

--- a/apps/repl/src/repl.rs
+++ b/apps/repl/src/repl.rs
@@ -161,11 +161,11 @@ impl Repl {
         self.gam
             .draw_rectangle(
                 self.content,
-                Rectangle::new_with_style(
-                    Point::new(0, 0),
-                    self.screensize,
-                    DrawStyle { fill_color: Some(PixelColor::Light), stroke_color: None, stroke_width: 0 },
-                ),
+                Rectangle::new_with_style(Point::new(0, 0), self.screensize, DrawStyle {
+                    fill_color: Some(PixelColor::Light),
+                    stroke_color: None,
+                    stroke_width: 0,
+                }),
             )
             .expect("can't clear content area");
     }

--- a/apps/transientdisk/src/main.rs
+++ b/apps/transientdisk/src/main.rs
@@ -64,11 +64,11 @@ impl UI {
         self.gam
             .draw_rectangle(
                 self.content,
-                Rectangle::new_with_style(
-                    Point::new(0, 0),
-                    self.screensize,
-                    DrawStyle { fill_color: Some(PixelColor::Light), stroke_color: None, stroke_width: 0 },
-                ),
+                Rectangle::new_with_style(Point::new(0, 0), self.screensize, DrawStyle {
+                    fill_color: Some(PixelColor::Light),
+                    stroke_color: None,
+                    stroke_width: 0,
+                }),
             )
             .expect("can't clear content area");
     }

--- a/apps/vault/src/actions.rs
+++ b/apps/vault/src/actions.rs
@@ -3,8 +3,8 @@ use std::cell::RefCell;
 use std::io::ErrorKind;
 use std::io::{Read, Write};
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
 };
 
 use gam::TextEntryPayload;
@@ -17,15 +17,15 @@ use perflib::*;
 use persistent_store::store::OPENSK2_DICT;
 use vault::env::xous::U2F_APP_DICT;
 use vault::{
-    atime_to_str, basis_change, ctap::data_formats::PublicKeyCredentialSource, deserialize_app_info,
-    serialize_app_info, utc_now, AppInfo, VAULT_ALLOC_HINT, VAULT_PASSWORD_DICT, VAULT_TOTP_DICT,
+    AppInfo, VAULT_ALLOC_HINT, VAULT_PASSWORD_DICT, VAULT_TOTP_DICT, atime_to_str, basis_change,
+    ctap::data_formats::PublicKeyCredentialSource, deserialize_app_info, serialize_app_info, utc_now,
 };
-use xous::{send_message, Message};
+use xous::{Message, send_message};
 
 use crate::storage::{self, PasswordRecord, StorageContent};
 use crate::totp::TotpAlgorithm;
-use crate::{storage::TotpRecord, ListItem, ListKey};
 use crate::{ItemLists, SelectedEntry, VaultMode};
+use crate::{ListItem, ListKey, storage::TotpRecord};
 #[cfg(feature = "vaultperf")]
 const FILE_ID_APPS_VAULT_SRC_ACTIONS: u32 = 1;
 

--- a/apps/vault/src/main.rs
+++ b/apps/vault/src/main.rs
@@ -19,12 +19,12 @@ use actions::ActionOp;
 use itemcache::*;
 use locales::t;
 use num_traits::*;
-use ux::framework::{name_to_style, VaultUx, DEFAULT_FONT, FONT_LIST};
+use ux::framework::{DEFAULT_FONT, FONT_LIST, VaultUx, name_to_style};
 use vault::ctap::main_hid::HidIterType;
-use vault::env::xous::XousEnv;
 use vault::env::Env;
-use vault::{Transport, VaultOp, SELF_CONN};
-use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack, send_message, Message};
+use vault::env::xous::XousEnv;
+use vault::{SELF_CONN, Transport, VaultOp};
+use xous::{Message, msg_blocking_scalar_unpack, msg_scalar_unpack, send_message};
 use xous_ipc::Buffer;
 use xous_usb_hid::device::fido::*;
 

--- a/apps/vault/src/prereqs.rs
+++ b/apps/vault/src/prereqs.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
-use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
+use std::sync::{Arc, atomic::AtomicBool, atomic::Ordering};
 use std::thread;
 use std::time::SystemTime;
 
@@ -10,7 +10,7 @@ use graphics_server::{DrawStyle, PixelColor, Point, Rectangle, TextView};
 use locales::t;
 use num_traits::*;
 use sntpc::{Error, NtpContext, NtpTimestampGenerator, NtpUdpSocket, Result};
-use xous::{send_message, Message};
+use xous::{Message, send_message};
 
 use crate::VaultOp;
 
@@ -84,15 +84,11 @@ pub(crate) fn prereqs(sid: xous::SID, time_conn: xous::CID) -> ([u32; 4], bool) 
                 if allow_redraw {
                     gam.draw_rectangle(
                         content,
-                        Rectangle::new_with_style(
-                            Point::new(0, 0),
-                            screensize,
-                            DrawStyle {
-                                fill_color: Some(PixelColor::Light),
-                                stroke_color: None,
-                                stroke_width: 0,
-                            },
-                        ),
+                        Rectangle::new_with_style(Point::new(0, 0), screensize, DrawStyle {
+                            fill_color: Some(PixelColor::Light),
+                            stroke_color: None,
+                            stroke_width: 0,
+                        }),
                     )
                     .expect("can't clear content area");
 

--- a/apps/vault/src/totp.rs
+++ b/apps/vault/src/totp.rs
@@ -8,7 +8,7 @@ use std::{
 use hmac::{Hmac, Mac};
 use num_traits::*;
 use sha1::Sha1;
-use xous::{send_message, Message};
+use xous::{Message, send_message};
 
 use crate::VaultMode;
 

--- a/apps/vault/src/ux/framework.rs
+++ b/apps/vault/src/ux/framework.rs
@@ -12,10 +12,10 @@ use locales::t;
 use num_traits::*;
 use pddb::Pddb;
 use usb_device_xous::UsbDeviceType;
-use vault::{utc_now, VaultOp};
+use vault::{VaultOp, utc_now};
 
 use crate::actions::ActionOp;
-use crate::totp::{generate_totp_code, get_current_unix_time, TotpAlgorithm, TotpEntry};
+use crate::totp::{TotpAlgorithm, TotpEntry, generate_totp_code, get_current_unix_time};
 use crate::{ItemLists, SelectedEntry, VaultMode};
 
 pub enum NavDir {
@@ -313,15 +313,11 @@ impl VaultUx {
             self.gam
                 .draw_rectangle(
                     self.content,
-                    Rectangle::new_with_style(
-                        Point::new(0, 0),
-                        self.screensize,
-                        DrawStyle {
-                            fill_color: Some(PixelColor::Light),
-                            stroke_color: None,
-                            stroke_width: 0,
-                        },
-                    ),
+                    Rectangle::new_with_style(Point::new(0, 0), self.screensize, DrawStyle {
+                        fill_color: Some(PixelColor::Light),
+                        stroke_color: None,
+                        stroke_width: 0,
+                    }),
                 )
                 .expect("can't clear content area");
             self.title_dirty = true; // just blanked the whole area, have to redraw the title.
@@ -364,15 +360,11 @@ impl VaultUx {
                     self.gam
                         .draw_rectangle(
                             self.content,
-                            Rectangle::new_with_style(
-                                tl,
-                                br,
-                                DrawStyle {
-                                    fill_color: Some(PixelColor::Light),
-                                    stroke_color: None,
-                                    stroke_width: 0,
-                                },
-                            ),
+                            Rectangle::new_with_style(tl, br, DrawStyle {
+                                fill_color: Some(PixelColor::Light),
+                                stroke_color: None,
+                                stroke_width: 0,
+                            }),
                         )
                         .expect("can't clear content area");
                     // reset the search
@@ -387,15 +379,11 @@ impl VaultUx {
             self.gam
                 .draw_rectangle(
                     self.content,
-                    Rectangle::new_with_style(
-                        tl,
-                        self.screensize,
-                        DrawStyle {
-                            fill_color: Some(PixelColor::Light),
-                            stroke_color: None,
-                            stroke_width: 0,
-                        },
-                    ),
+                    Rectangle::new_with_style(tl, self.screensize, DrawStyle {
+                        fill_color: Some(PixelColor::Light),
+                        stroke_color: None,
+                        stroke_width: 0,
+                    }),
                 )
                 .expect("can't clear content area");
         } else if dirty_tl.is_none() && dirty_br.is_none() {
@@ -405,15 +393,11 @@ impl VaultUx {
             self.gam
                 .draw_rectangle(
                     self.content,
-                    Rectangle::new_with_style(
-                        Point::new(0, insert_at + 1),
-                        self.screensize,
-                        DrawStyle {
-                            fill_color: Some(PixelColor::Light),
-                            stroke_color: None,
-                            stroke_width: 0,
-                        },
-                    ),
+                    Rectangle::new_with_style(Point::new(0, insert_at + 1), self.screensize, DrawStyle {
+                        fill_color: Some(PixelColor::Light),
+                        stroke_color: None,
+                        stroke_width: 0,
+                    }),
                 )
                 .expect("can't clear content area");
         }
@@ -467,21 +451,18 @@ impl VaultUx {
                 let width = (self.screensize.x - (self.margin.x * 2)) as i32;
                 let delta_width = (delta * width * 100) / (30 * 100);
                 self.gam
-                    .draw_rectangle(
-                        self.content,
-                        Rectangle {
-                            tl: Point::new(self.margin.x, TITLE_HEIGHT - (BAR_HEIGHT + BAR_GAP)),
-                            br: Point::new(
-                                self.screensize.x - self.margin.x - delta_width as i16,
-                                TITLE_HEIGHT - BAR_GAP,
-                            ),
-                            style: DrawStyle {
-                                fill_color: Some(PixelColor::Dark),
-                                stroke_color: None,
-                                stroke_width: 0,
-                            },
+                    .draw_rectangle(self.content, Rectangle {
+                        tl: Point::new(self.margin.x, TITLE_HEIGHT - (BAR_HEIGHT + BAR_GAP)),
+                        br: Point::new(
+                            self.screensize.x - self.margin.x - delta_width as i16,
+                            TITLE_HEIGHT - BAR_GAP,
+                        ),
+                        style: DrawStyle {
+                            fill_color: Some(PixelColor::Dark),
+                            stroke_color: None,
+                            stroke_width: 0,
                         },
-                    )
+                    })
                     .ok();
             }
             self.title_dirty = false;

--- a/apps/vault/src/vendor_commands.rs
+++ b/apps/vault/src/vendor_commands.rs
@@ -2,7 +2,7 @@ use core::convert::TryFrom;
 
 use cbor::reader::DecoderError;
 use locales::t;
-use vault::ctap::hid::{send::HidPacketIterator, ChannelID, CtapHidCommand, Message};
+use vault::ctap::hid::{ChannelID, CtapHidCommand, Message, send::HidPacketIterator};
 use vault::vault_api::{COMMAND_BACKUP_TOTP_CODES, COMMAND_RESET_SESSION, COMMAND_RESTORE_TOTP_CODES};
 
 use crate::storage::{Error, PasswordRecord, TotpRecord};

--- a/apps/vault/tools/vaultbackup-rs/src/authenticator.rs
+++ b/apps/vault/tools/vaultbackup-rs/src/authenticator.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use protobuf::Message;
 
 include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));

--- a/kernel/src/arch/arm/irq.rs
+++ b/kernel/src/arch/arm/irq.rs
@@ -4,11 +4,11 @@
 use core::arch::asm;
 use core::convert::TryInto;
 
-use xous_kernel::{arch::Arguments, PID, TID};
+use xous_kernel::{PID, TID, arch::Arguments};
 
-use crate::arch::process::{current_pid, EXIT_THREAD, RETURN_FROM_EXCEPTION_HANDLER, RETURN_FROM_ISR};
-use crate::services::{ArchProcess, Thread};
 use crate::SystemServices;
+use crate::arch::process::{EXIT_THREAD, RETURN_FROM_EXCEPTION_HANDLER, RETURN_FROM_ISR, current_pid};
+use crate::services::{ArchProcess, Thread};
 
 extern "Rust" {
     fn _xous_syscall_return_result(context: &Thread) -> !;

--- a/kernel/src/arch/arm/mem.rs
+++ b/kernel/src/arch/arm/mem.rs
@@ -4,16 +4,16 @@
 use core::num::NonZeroU8;
 
 pub use armv7::structures::paging::{
-    InMemoryRegister, PageTable as L2PageTable, PageTableDescriptor, PageTableMemory, PageTableType,
-    Readable, TranslationTable, TranslationTableDescriptor, TranslationTableMemory, TranslationTableType,
-    Writeable, PAGE_TABLE_FLAGS, PAGE_TABLE_SIZE, SMALL_PAGE_FLAGS,
+    InMemoryRegister, PAGE_TABLE_FLAGS, PAGE_TABLE_SIZE, PageTable as L2PageTable, PageTableDescriptor,
+    PageTableMemory, PageTableType, Readable, SMALL_PAGE_FLAGS, TranslationTable, TranslationTableDescriptor,
+    TranslationTableMemory, TranslationTableType, Writeable,
 };
 pub use armv7::{PhysicalAddress, VirtualAddress};
 use xous_kernel::{MemoryFlags, PID};
 
+use crate::SystemServices;
 use crate::arch::arm::process::InitialProcess;
 use crate::mem::MemoryManager;
-use crate::SystemServices;
 
 pub const DEFAULT_HEAP_BASE: usize = 0x3000_0000;
 pub const DEFAULT_MESSAGE_BASE: usize = 0x4000_0000;

--- a/kernel/src/arch/arm/process.rs
+++ b/kernel/src/arch/arm/process.rs
@@ -3,7 +3,7 @@
 
 use core::mem;
 
-use xous_kernel::{arch::Arguments, ProcessInit, ProcessStartup, ThreadInit, PID, TID};
+use xous_kernel::{PID, ProcessInit, ProcessStartup, TID, ThreadInit, arch::Arguments};
 
 use crate::arch::mem::THREAD_CONTEXT_AREA;
 use crate::mem::PAGE_SIZE;
@@ -364,14 +364,9 @@ impl Process {
         if sp <= 16 {
             return Err(xous_kernel::Error::BadAddress);
         }
-        crate::arch::syscall::invoke(
-            thread,
-            pid == 1,
-            entrypoint,
-            (sp - 16) & !0xf,
-            EXIT_THREAD,
-            &[setup.arg1, setup.arg2, setup.arg3, setup.arg4],
-        );
+        crate::arch::syscall::invoke(thread, pid == 1, entrypoint, (sp - 16) & !0xf, EXIT_THREAD, &[
+            setup.arg1, setup.arg2, setup.arg3, setup.arg4,
+        ]);
         Ok(())
     }
 

--- a/kernel/src/arch/hosted/mod.rs
+++ b/kernel/src/arch/hosted/mod.rs
@@ -14,8 +14,8 @@ use std::io::Read;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::thread_local;
 
-use crossbeam_channel::{unbounded, Receiver, RecvError, RecvTimeoutError, Sender};
-use xous_kernel::{ProcessInit, ProcessKey, Result, SysCall, ThreadInit, PID, TID};
+use crossbeam_channel::{Receiver, RecvError, RecvTimeoutError, Sender, unbounded};
+use xous_kernel::{PID, ProcessInit, ProcessKey, Result, SysCall, TID, ThreadInit};
 
 use crate::arch::process::Process;
 use crate::services::SystemServices;
@@ -64,9 +64,9 @@ static LOCAL_RNG_STATE: AtomicU64 = AtomicU64::new(2);
 
 #[cfg(not(test))]
 fn generate_pid_key() -> [u8; 16] {
+    use rand_chacha::ChaCha8Rng;
     use rand_chacha::rand_core::RngCore;
     use rand_chacha::rand_core::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     let mut process_key = [0u8; 16];
     let mut rng = ChaCha8Rng::seed_from_u64(

--- a/kernel/src/arch/hosted/process.rs
+++ b/kernel/src/arch/hosted/process.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use std::net::TcpStream;
 use std::thread_local;
 
-use xous_kernel::{ProcessInit, ProcessKey, ProcessStartup, ThreadInit, PID, TID};
+use xous_kernel::{PID, ProcessInit, ProcessKey, ProcessStartup, TID, ThreadInit};
 
 use crate::services::ProcessInner;
 

--- a/kernel/src/arch/hosted/rand.rs
+++ b/kernel/src/arch/hosted/rand.rs
@@ -6,9 +6,9 @@ use core::sync::atomic::Ordering;
 use crate::arch::hosted::LOCAL_RNG_STATE;
 
 pub fn get_u32() -> u32 {
+    use rand_chacha::ChaCha8Rng;
     use rand_chacha::rand_core::RngCore;
     use rand_chacha::rand_core::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     let mut rng = ChaCha8Rng::seed_from_u64(LOCAL_RNG_STATE.load(Ordering::SeqCst));
     let r = rng.next_u32();

--- a/kernel/src/arch/riscv/irq.rs
+++ b/kernel/src/arch/riscv/irq.rs
@@ -4,15 +4,15 @@
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use riscv::register::{scause, sepc, sstatus, stval};
-use xous_kernel::{SysCall, PID, TID};
+use xous_kernel::{PID, SysCall, TID};
 
 use crate::arch::current_pid;
 use crate::arch::exception::RiscvException;
 use crate::arch::mem::MemoryMapping;
 #[cfg(feature = "swap")]
 use crate::arch::process::RETURN_FROM_SWAPPER;
+use crate::arch::process::{EXIT_THREAD, RETURN_FROM_ISR, Thread};
 use crate::arch::process::{Process as ArchProcess, RETURN_FROM_EXCEPTION_HANDLER};
-use crate::arch::process::{Thread, EXIT_THREAD, RETURN_FROM_ISR};
 use crate::services::SystemServices;
 #[cfg(feature = "swap")]
 use crate::swap::Swap;

--- a/kernel/src/arch/riscv/process.rs
+++ b/kernel/src/arch/riscv/process.rs
@@ -8,7 +8,7 @@ pub const EXCEPTION_TID: TID = 1;
 pub const INITIAL_TID: TID = 2;
 pub const IRQ_TID: TID = 0;
 
-use xous_kernel::{ProcessInit, ProcessStartup, ThreadInit, PID, TID};
+use xous_kernel::{PID, ProcessInit, ProcessStartup, TID, ThreadInit};
 
 use crate::arch::mem::PAGE_SIZE;
 use crate::services::ProcessInner;
@@ -414,14 +414,9 @@ impl Process {
             *val = 0;
         }
         thread.sepc = 0;
-        crate::arch::syscall::invoke(
-            thread,
-            pid == 1,
-            entrypoint,
-            (sp - 16) & !0xf,
-            EXIT_THREAD,
-            &[setup.arg1, setup.arg2, setup.arg3, setup.arg4],
-        );
+        crate::arch::syscall::invoke(thread, pid == 1, entrypoint, (sp - 16) & !0xf, EXIT_THREAD, &[
+            setup.arg1, setup.arg2, setup.arg3, setup.arg4,
+        ]);
         Ok(())
     }
 

--- a/kernel/src/debug/gdb.rs
+++ b/kernel/src/debug/gdb.rs
@@ -258,13 +258,10 @@ pub fn report_stop(_pid: xous_kernel::PID, tid: xous_kernel::TID, _pc: usize) {
         return;
     };
 
-    let Ok(new_gdb) = inner.report_stop(
-        &mut target,
-        MultiThreadStopReason::SignalWithThread {
-            signal: Signal::EXC_BREAKPOINT,
-            tid: Tid::new(tid).unwrap(),
-        },
-    ) else {
+    let Ok(new_gdb) = inner.report_stop(&mut target, MultiThreadStopReason::SignalWithThread {
+        signal: Signal::EXC_BREAKPOINT,
+        tid: Tid::new(tid).unwrap(),
+    }) else {
         println!("Unable to report stop");
         return;
     };

--- a/kernel/src/debug/gdb/breakpoints.rs
+++ b/kernel/src/debug/gdb/breakpoints.rs
@@ -1,5 +1,5 @@
-use gdbstub::target::ext::breakpoints::{Breakpoints, SwBreakpoint, SwBreakpointOps};
 use gdbstub::target::TargetResult;
+use gdbstub::target::ext::breakpoints::{Breakpoints, SwBreakpoint, SwBreakpointOps};
 
 use super::XousTarget;
 

--- a/kernel/src/debug/gdb/multi_thread_base.rs
+++ b/kernel/src/debug/gdb/multi_thread_base.rs
@@ -2,9 +2,9 @@ use core::convert::TryInto;
 
 use gdbstub::common::Tid;
 use gdbstub::target;
+use gdbstub::target::TargetResult;
 use gdbstub::target::ext::base::multithread::MultiThreadBase;
 use gdbstub::target::ext::base::single_register_access::SingleRegisterAccessOps;
-use gdbstub::target::TargetResult;
 
 use super::XousTarget;
 

--- a/kernel/src/debug/gdb/riscv.rs
+++ b/kernel/src/debug/gdb/riscv.rs
@@ -2,9 +2,9 @@ use core::convert::TryInto;
 use core::hint::unreachable_unchecked;
 
 use gdbstub::common::Tid;
+use gdbstub::target::Target;
 use gdbstub::target::ext::base::multithread::MultiThreadBase;
 use gdbstub::target::ext::base::single_register_access::SingleRegisterAccess;
-use gdbstub::target::Target;
 use gdbstub_arch::riscv::reg::id::RiscvRegId;
 
 // mod disasm;

--- a/kernel/src/debug/gdb/target.rs
+++ b/kernel/src/debug/gdb/target.rs
@@ -1,9 +1,9 @@
 use gdbstub::arch::SingleStepGdbBehavior;
+use gdbstub::target::Target;
 use gdbstub::target::ext::base::BaseOps;
 use gdbstub::target::ext::breakpoints::BreakpointsOps;
 use gdbstub::target::ext::extended_mode::ExtendedModeOps;
 use gdbstub::target::ext::monitor_cmd::MonitorCmdOps;
-use gdbstub::target::Target;
 
 use super::XousTarget;
 

--- a/kernel/src/platform/atsama5d2/aic.rs
+++ b/kernel/src/platform/atsama5d2/aic.rs
@@ -5,7 +5,7 @@ use atsama5d27::{
     pmc::PeripheralId,
 };
 use utralib::{HW_AIC_BASE, HW_SAIC_BASE};
-use xous_kernel::{arch::irq::IrqNumber, MemoryFlags, MemoryType, PID};
+use xous_kernel::{MemoryFlags, MemoryType, PID, arch::irq::IrqNumber};
 
 use crate::arch::irq::_irq_handler_rust;
 use crate::mem::MemoryManager;

--- a/kernel/src/platform/atsama5d2/uart.rs
+++ b/kernel/src/platform/atsama5d2/uart.rs
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Foundation Devices, Inc. <hello@foundationdevices.com>
 // SPDX-License-Identifier: Apache-2.0
 
-use atsama5d27::uart::{Uart as UartHw, Uart1, UART_BASE_ADDRESS};
-use xous_kernel::{arch::irq::IrqNumber, MemoryFlags, MemoryType};
+use atsama5d27::uart::{UART_BASE_ADDRESS, Uart as UartHw, Uart1};
+use xous_kernel::{MemoryFlags, MemoryType, arch::irq::IrqNumber};
 
 use crate::{
+    PID,
     debug::shell::process_characters,
     io::{SerialRead, SerialWrite},
     mem::MemoryManager,
-    PID,
 };
 
 const UART_NUMBER: usize = 1;

--- a/kernel/src/platform/cramium/rand.rs
+++ b/kernel/src/platform/cramium/rand.rs
@@ -6,9 +6,9 @@
 use core::convert::TryInto;
 
 use cramium_hal::sce;
+use rand_chacha::ChaCha8Rng;
 use rand_chacha::rand_core::RngCore;
 use rand_chacha::rand_core::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 use xous_kernel::{MemoryFlags, MemoryType, PID};
 
 use crate::mem::MemoryManager;

--- a/kernel/src/platform/cramium/uart.rs
+++ b/kernel/src/platform/cramium/uart.rs
@@ -8,17 +8,17 @@ use xous_kernel::{MemoryFlags, MemoryType};
 
 #[cfg(feature = "cramium-fpga")]
 use crate::{
+    PID,
     debug::shell::process_characters,
     io::{SerialRead, SerialWrite},
     mem::MemoryManager,
-    PID,
 };
 #[cfg(feature = "cramium-soc")]
 use crate::{
+    PID,
     debug::shell::process_characters,
     io::{SerialRead, SerialWrite},
     mem::MemoryManager,
-    PID,
 };
 
 /// UART virtual address.

--- a/kernel/src/platform/precursor/gdbuart.rs
+++ b/kernel/src/platform/precursor/gdbuart.rs
@@ -8,9 +8,9 @@ use utralib::generated::*;
 use xous_kernel::{MemoryFlags, MemoryType};
 
 use crate::{
+    PID,
     io::{SerialRead, SerialWrite},
     mem::MemoryManager,
-    PID,
 };
 
 static UART_CALLBACK_POINTER: AtomicUsize = AtomicUsize::new(0);

--- a/kernel/src/platform/precursor/uart.rs
+++ b/kernel/src/platform/precursor/uart.rs
@@ -6,10 +6,10 @@ use utralib::generated::*;
 use xous_kernel::{MemoryFlags, MemoryType};
 
 use crate::{
+    PID,
     debug::shell::process_characters,
     io::{SerialRead, SerialWrite},
     mem::MemoryManager,
-    PID,
 };
 
 /// UART virtual address.

--- a/kernel/src/services.rs
+++ b/kernel/src/services.rs
@@ -3,11 +3,11 @@
 
 use core::num::NonZeroU8;
 
-use xous_kernel::arch::ProcessStartup;
 use xous_kernel::MemoryRange;
+use xous_kernel::arch::ProcessStartup;
 // use core::mem;
 use xous_kernel::{
-    pid_from_usize, Error, MemoryAddress, Message, ProcessInit, ThreadInit, CID, PID, SID, TID,
+    CID, Error, MemoryAddress, Message, PID, ProcessInit, SID, TID, ThreadInit, pid_from_usize,
 };
 
 use crate::arch;

--- a/kernel/src/swap.rs
+++ b/kernel/src/swap.rs
@@ -6,11 +6,11 @@ use core::cmp::Ordering;
 use loader::swap::SWAP_FLG_WIRED;
 use loader::swap::SWAP_RPT_VADDR;
 use xous_kernel::SWAPPER_PID;
-use xous_kernel::{SysCallResult, PID, TID};
+use xous_kernel::{PID, SysCallResult, TID};
 
 use crate::arch::current_pid;
-use crate::arch::mem::MMUFlags;
 use crate::arch::mem::EXCEPTION_STACK_TOP;
+use crate::arch::mem::MMUFlags;
 use crate::arch::mem::PAGE_SIZE;
 use crate::mem::MemoryManager;
 use crate::services::SystemServices;

--- a/kernel/src/test.rs
+++ b/kernel/src/test.rs
@@ -6,8 +6,8 @@ use std::thread::JoinHandle;
 
 use crossbeam_channel::unbounded;
 #[cfg(feature = "report-memory")]
-use stats_alloc::{Region, Stats, StatsAlloc, INSTRUMENTED_SYSTEM};
-use xous_kernel::{rsyscall, SysCall};
+use stats_alloc::{INSTRUMENTED_SYSTEM, Region, Stats, StatsAlloc};
+use xous_kernel::{SysCall, rsyscall};
 
 use crate::kmain;
 #[cfg(feature = "report-memory")]
@@ -29,9 +29,9 @@ fn start_kernel(server_spec: &str) -> JoinHandle<()> {
         "XOUS_SERVER environment variable must be unset to run tests"
     );
 
+    use rand_chacha::ChaCha8Rng;
     use rand_chacha::rand_core::RngCore;
     use rand_chacha::rand_core::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
     let mut pid1_key = [0u8; 16];
     let mut rng = ChaCha8Rng::seed_from_u64(
         RNG_LOCAL_STATE.load(Ordering::SeqCst)

--- a/libs/chat/src/icontray.rs
+++ b/libs/chat/src/icontray.rs
@@ -2,7 +2,7 @@ use std::thread;
 
 use ime_plugin_api::*;
 use num_traits::*;
-use xous::{msg_scalar_unpack, CID};
+use xous::{CID, msg_scalar_unpack};
 use xous_ipc::Buffer;
 
 pub(crate) const SERVER_NAME_ICONTRAY: &'static str = "_chat icon tray plugin_";

--- a/libs/chat/src/lib.rs
+++ b/libs/chat/src/lib.rs
@@ -4,7 +4,7 @@ pub mod icontray;
 pub mod ui;
 
 use std::convert::TryInto;
-use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
+use std::sync::{Arc, atomic::AtomicBool, atomic::Ordering};
 use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -13,9 +13,9 @@ use gam::MenuItem;
 use graphics_server::api::GlyphStyle;
 use graphics_server::{Point, Rectangle, TextBounds, TextView};
 use num_traits::FromPrimitive;
-use ui::VisualProperties;
 pub use ui::BUSY_ANIMATION_RATE_MS;
-use xous::{msg_scalar_unpack, Error, CID, SID};
+use ui::VisualProperties;
+use xous::{CID, Error, SID, msg_scalar_unpack};
 use xous_ipc::Buffer;
 
 /// Create a TextView with the default properties common to all text bubbles.

--- a/libs/chat/src/main.rs
+++ b/libs/chat/src/main.rs
@@ -2,13 +2,13 @@
 #![cfg_attr(target_os = "none", no_main)]
 
 mod api;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
 use api::*;
 use num_traits::FromPrimitive;
-use xous::{Error, CID, SID};
+use xous::{CID, Error, SID};
 
 pub fn main() -> ! {
     let xns = xous_names::XousNames::new().unwrap();

--- a/libs/chat/src/ui.rs
+++ b/libs/chat/src/ui.rs
@@ -3,18 +3,18 @@ use std::convert::TryFrom;
 use std::fmt::Write as TextWrite;
 use std::io::{Error, ErrorKind, Read, Write};
 
-use dialogue::{post::Post, Dialogue};
-use gam::{menu_matic, MenuMatic, UxRegistration};
+use dialogue::{Dialogue, post::Post};
+use gam::{MenuMatic, UxRegistration, menu_matic};
 use graphics_server::api::GlyphStyle;
 use graphics_server::{DrawStyle, Gid, Line, PixelColor, Point, Rectangle, TextBounds, TextView};
 use locales::t;
 use modals::Modals;
-use rkyv::de::deserializers::AllocDeserializer;
-use rkyv::ser::serializers::WriteSerializer;
-use rkyv::ser::Serializer;
 use rkyv::Deserialize;
+use rkyv::de::deserializers::AllocDeserializer;
+use rkyv::ser::Serializer;
+use rkyv::ser::serializers::WriteSerializer;
 use ticktimer_server::Ticktimer;
-use xous::{MessageEnvelope, CID};
+use xous::{CID, MessageEnvelope};
 use xous_names::XousNames;
 
 use super::*;
@@ -707,15 +707,11 @@ impl Ui {
             self.gam
                 .draw_rectangle(
                     self.vp.canvas,
-                    Rectangle::new_with_style(
-                        Point::new(0, 0),
-                        self.vp.total_screensize,
-                        DrawStyle {
-                            fill_color: Some(PixelColor::Light),
-                            stroke_color: None,
-                            stroke_width: 0,
-                        },
-                    ),
+                    Rectangle::new_with_style(Point::new(0, 0), self.vp.total_screensize, DrawStyle {
+                        fill_color: Some(PixelColor::Light),
+                        stroke_color: None,
+                        stroke_width: 0,
+                    }),
                 )
                 .expect("can't clear canvas area");
 

--- a/libs/cramium-hal/src/ifram.rs
+++ b/libs/cramium-hal/src/ifram.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "std")]
 use xous::Result;
-use xous::{send_message, MemoryRange, Message};
+use xous::{MemoryRange, Message, send_message};
 
 pub enum IframBank {
     Bank0,

--- a/libs/cramium-hal/src/usb/driver.rs
+++ b/libs/cramium-hal/src/usb/driver.rs
@@ -2,7 +2,7 @@ use core::convert::TryFrom;
 use core::mem::size_of;
 #[cfg(feature = "std")]
 use core::sync::atomic::AtomicBool;
-use core::sync::atomic::{compiler_fence, AtomicPtr, Ordering};
+use core::sync::atomic::{AtomicPtr, Ordering, compiler_fence};
 #[cfg(feature = "std")]
 use std::sync::{Arc, Mutex};
 
@@ -10,7 +10,7 @@ use bitfield::bitfield;
 #[cfg(feature = "std")]
 use usb_device::bus::PollResult;
 #[cfg(feature = "std")]
-use usb_device::{class_prelude::*, Result, UsbDirection};
+use usb_device::{Result, UsbDirection, class_prelude::*};
 #[cfg(feature = "std")]
 use utralib::generated::*;
 

--- a/libs/perflib/src/lib.rs
+++ b/libs/perflib/src/lib.rs
@@ -1,4 +1,4 @@
-use core::num::{NonZeroU16, NonZeroU8};
+use core::num::{NonZeroU8, NonZeroU16};
 use std::cell::RefCell;
 
 use utralib::generated::*;

--- a/libs/tls/src/danger.rs
+++ b/libs/tls/src/danger.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use locales::t;
 use modals::Modals;
-use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::client::WebPkiServerVerifier;
-use rustls::crypto::{ring, verify_tls12_signature, verify_tls13_signature, WebPkiSupportedAlgorithms};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::{WebPkiSupportedAlgorithms, ring, verify_tls12_signature, verify_tls13_signature};
 use rustls::pki_types::{CertificateDer, Der, ServerName, TrustAnchor, UnixTime};
 use rustls::{CertificateError, DigitallySignedStruct, Error, RootCertStore, SignatureScheme};
 use xous_names::XousNames;

--- a/libs/tls/src/lib.rs
+++ b/libs/tls/src/lib.rs
@@ -12,13 +12,13 @@ use locales::t;
 use modals::Modals;
 use ota::OwnedTrustAnchor;
 use rkyv::{
-    de::deserializers::AllocDeserializer,
-    ser::{serializers::WriteSerializer, Serializer},
     Deserialize,
+    de::deserializers::AllocDeserializer,
+    ser::{Serializer, serializers::WriteSerializer},
 };
 use rustls::pki_types::{CertificateDer, TrustAnchor};
 use rustls::{ClientConfig, ClientConnection, RootCertStore};
-use x509_parser::prelude::{parse_x509_certificate, FromDer, X509Certificate};
+use x509_parser::prelude::{FromDer, X509Certificate, parse_x509_certificate};
 use xous_names::XousNames;
 
 /// PDDB Dict for tls trusted certificates keys

--- a/libs/userprefs/prefsgenerator/src/lib.rs
+++ b/libs/userprefs/prefsgenerator/src/lib.rs
@@ -1,8 +1,8 @@
 use proc_macro::{self, TokenStream};
-use proc_macro2::Ident;
 use proc_macro_error::{abort, proc_macro_error};
+use proc_macro2::Ident;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, DeriveInput, FieldsNamed};
+use syn::{DeriveInput, FieldsNamed, parse_macro_input};
 
 #[proc_macro_error]
 #[proc_macro_derive(GetterSetter)]

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -32,8 +32,8 @@ use bootconfig::BootConfig;
 use consts::*;
 pub use loader::*;
 use minielf::*;
-use phase1::{phase_1, InitialProcess};
-use phase2::{phase_2, ProgramDescription};
+use phase1::{InitialProcess, phase_1};
+use phase2::{ProgramDescription, phase_2};
 #[cfg(feature = "swap")]
 use platform::SwapHal;
 

--- a/loader/src/minielf.rs
+++ b/loader/src/minielf.rs
@@ -4,11 +4,11 @@ use core::{mem, slice};
 use armv7::structures::paging::TranslationTableMemory;
 #[cfg(all(feature = "atsama5d27", feature = "debug-print"))]
 use armv7::{
-    structures::paging::{
-        InMemoryRegister, PageTableDescriptor, Readable, TranslationTableDescriptor, TranslationTableType,
-        SMALL_PAGE_FLAGS,
-    },
     VirtualAddress,
+    structures::paging::{
+        InMemoryRegister, PageTableDescriptor, Readable, SMALL_PAGE_FLAGS, TranslationTableDescriptor,
+        TranslationTableType,
+    },
 };
 
 use crate::*;

--- a/loader/src/phase1.rs
+++ b/loader/src/phase1.rs
@@ -433,7 +433,7 @@ pub fn copy_args(cfg: &mut BootConfig) {
     // dead-reckoning to the offset
     assert!(merged_arg_slice[2] == xarg.data[0] as usize); // sanity checks the dead-reckoning
     merged_arg_slice[2] = arg_index;
-    use crc::{crc16, Hasher16};
+    use crc::{Hasher16, crc16};
     // compute the new CRC
     let mut digest = crc16::Digest::new(crc16::X25);
     // safe because we know the entire region can map into a u8 slice with no UB

--- a/loader/src/platform/atsama5d27/boot.rs
+++ b/loader/src/platform/atsama5d27/boot.rs
@@ -6,9 +6,9 @@ use core::mem;
 use core::num::NonZeroUsize;
 
 use armv7::structures::paging::{
-    PageTable as L2PageTable, PageTableDescriptor, PageTableMemory, PageTableType, TranslationTable,
-    TranslationTableDescriptor, TranslationTableMemory, TranslationTableType, PAGE_TABLE_FLAGS,
-    SMALL_PAGE_FLAGS,
+    PAGE_TABLE_FLAGS, PageTable as L2PageTable, PageTableDescriptor, PageTableMemory, PageTableType,
+    SMALL_PAGE_FLAGS, TranslationTable, TranslationTableDescriptor, TranslationTableMemory,
+    TranslationTableType,
 };
 use armv7::{PhysicalAddress, VirtualAddress};
 
@@ -17,7 +17,7 @@ use crate::consts::{
     KERNEL_ARGUMENT_OFFSET, KERNEL_STACK_PAGE_COUNT, LOADER_CODE_ADDRESS, PAGE_TABLE_OFFSET,
 };
 use crate::platform::atsama5d27::load::InitialProcess;
-use crate::{bzero, println, BootConfig, XousPid, PAGE_SIZE, WORD_SIZE};
+use crate::{BootConfig, PAGE_SIZE, WORD_SIZE, XousPid, bzero, println};
 
 const DEBUG_PAGE_MAPPING: bool = false;
 macro_rules! dprint {

--- a/loader/src/platform/atsama5d27/debug.rs
+++ b/loader/src/platform/atsama5d27/debug.rs
@@ -2,11 +2,11 @@
 // SPDX-FileCopyrightText: 2023 Foundation Devices, Inc <hello@foundationdevices.com>
 // SPDX-License-Identifier: Apache-2.0
 
+use armv7::PhysicalAddress;
 use armv7::structures::paging::{
     PageTable as L2PageTable, PageTableMemory, PageTableType, TranslationTable, TranslationTableMemory,
     TranslationTableType,
 };
-use armv7::PhysicalAddress;
 use atsama5d27::uart::{Uart as UartHw, Uart1};
 
 type UartType = UartHw<Uart1>;

--- a/loader/src/platform/atsama5d27/load.rs
+++ b/loader/src/platform/atsama5d27/load.rs
@@ -9,7 +9,7 @@ use crate::consts::{
     IRQ_STACK_TOP, KERNEL_LOAD_OFFSET, KERNEL_STACK_PAGE_COUNT, KERNEL_STACK_TOP, PAGE_TABLE_ROOT_OFFSET,
     USER_AREA_END, USER_STACK_TOP,
 };
-use crate::{println, BootConfig, ProgramDescription, XousPid, PAGE_SIZE, STACK_PAGE_COUNT, VDBG};
+use crate::{BootConfig, PAGE_SIZE, ProgramDescription, STACK_PAGE_COUNT, VDBG, XousPid, println};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/loader/src/platform/cramium/swap.rs
+++ b/loader/src/platform/cramium/swap.rs
@@ -5,11 +5,11 @@ use cramium_hal::ifram::IframRange;
 use cramium_hal::iox::*;
 use cramium_hal::sce;
 use cramium_hal::udma::*;
-use loader::swap::SPIM_RAM_IFRAM_ADDR;
 use loader::APP_UART_IFRAM_ADDR;
+use loader::swap::SPIM_RAM_IFRAM_ADDR;
+use rand_chacha::ChaCha8Rng;
 use rand_chacha::rand_core::RngCore;
 use rand_chacha::rand_core::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 
 use crate::bootconfig::BootConfig;
 use crate::swap::*;

--- a/loader/src/secboot.rs
+++ b/loader/src/secboot.rs
@@ -1,8 +1,8 @@
 use ed25519_dalek_loader::Digest;
 use sha2_loader::Sha512;
 
-use crate::println;
 use crate::SIGBLOCK_SIZE;
+use crate::println;
 
 const VERSION_STR: &'static str = "Xous OS Loader v0.9.6\n\r";
 // v0.9.0 -- initial version

--- a/loader/src/test.rs
+++ b/loader/src/test.rs
@@ -146,8 +146,8 @@ fn parse_args_bin() {
 
 #[test]
 fn read_initial_config() {
-    use crate::args::KernelArguments;
     use crate::BootConfig;
+    use crate::args::KernelArguments;
 
     let args = get_args_bin(0);
     #[allow(clippy::cast_ptr_alignment)] // This test only works on 32-bit systems

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -27,7 +27,10 @@ use_small_heuristics = "Max"
 
 # Unstable features below
 unstable_features = true
-version = "Two"
+
+# Use the sorting method defined in Rust 2024
+style_edition = "2024"
+
 # code can be 110 characters, why not comments?
 comment_width = 110
 # quicker manual lookup

--- a/services/aes/src/lib.rs
+++ b/services/aes/src/lib.rs
@@ -14,7 +14,7 @@
 mod soft;
 pub use cipher;
 use cipher::{
-    consts::{U16, U8},
+    consts::{U8, U16},
     generic_array::GenericArray,
 };
 pub use soft::{Aes128Soft, Aes192, Aes256Soft};

--- a/services/aes/src/soft.rs
+++ b/services/aes/src/soft.rs
@@ -15,10 +15,10 @@ pub(crate) mod fixslice;
 use core::fmt;
 
 use cipher::{
-    consts::{U16, U24, U32},
-    inout::InOut,
     AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, Key,
     KeyInit, KeySizeUser, ParBlocksSizeUser,
+    consts::{U16, U24, U32},
+    inout::InOut,
 };
 use fixslice::{BatchBlocks, FixsliceBlocks, FixsliceKeys128, FixsliceKeys192, FixsliceKeys256};
 

--- a/services/aes/src/soft/fixslice32.rs
+++ b/services/aes/src/soft/fixslice32.rs
@@ -1343,8 +1343,8 @@ fn rotate_rows_and_columns_2_2(x: u32) -> u32 {
 #[cfg(feature = "hazmat")]
 pub(crate) mod hazmat {
     use super::{
-        bitslice, inv_bitslice, inv_mix_columns_0, inv_shift_rows_1, inv_sub_bytes, mix_columns_0,
-        shift_rows_1, sub_bytes, sub_bytes_nots, State,
+        State, bitslice, inv_bitslice, inv_mix_columns_0, inv_shift_rows_1, inv_sub_bytes, mix_columns_0,
+        shift_rows_1, sub_bytes, sub_bytes_nots,
     };
     use crate::{Block, Block8};
 

--- a/services/aes/src/vex.rs
+++ b/services/aes/src/vex.rs
@@ -1,11 +1,11 @@
 #![cfg_attr(not(target_os = "none"), allow(dead_code))]
 
 use cipher::{
+    AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, Key,
+    KeyInit, KeySizeUser, ParBlocksSizeUser,
     consts::{U1, U16, U32},
     generic_array::GenericArray,
     inout::InOut,
-    AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, Key,
-    KeyInit, KeySizeUser, ParBlocksSizeUser,
 };
 
 use crate::Block;

--- a/services/codec/src/backend/tlv320aic3100.rs
+++ b/services/codec/src/backend/tlv320aic3100.rs
@@ -288,13 +288,10 @@ impl Codec {
             let code_right = analog_volume_db_to_code(gain_db_right);
             self.w(0, &[1]); // select page 1
             self.w(31, &[0b1_1_00011_0]); // headphones powered up
-            self.w(
-                36,
-                &[
-                    0b1_000_0000 | code_left,  // HPL
-                    0b1_000_0000 | code_right, // HPR
-                ],
-            );
+            self.w(36, &[
+                0b1_000_0000 | code_left,  // HPL
+                0b1_000_0000 | code_right, // HPR
+            ]);
         }
         self.i2c.i2c_mutex_release();
     }
@@ -408,34 +405,25 @@ impl Codec {
         // PLLP = 1, PLLR = 1, PLLJ = 7, PLLD = 1680, NDAC = *12*, MDAC = 7, DOSR = 128, MADC = 2 , NADC =
         // *42* ^^ from page 68 of datasheet, fs=48kHz/12MHz clkin line, with *bold* items multiplied
         // by 6 to get to 8kHz
-        self.w(
-            5,
-            &[
-                0b1001_0001,                // P, R = 1, 1 and pll powered up
-                7,                          // PLLJ = 7
-                ((1680 >> 8) & 0xFF) as u8, // D MSB of 1680
-                (1680 & 0xFF) as u8,        // D LSB of 1680
-            ],
-        );
+        self.w(5, &[
+            0b1001_0001,                // P, R = 1, 1 and pll powered up
+            7,                          // PLLJ = 7
+            ((1680 >> 8) & 0xFF) as u8, // D MSB of 1680
+            (1680 & 0xFF) as u8,        // D LSB of 1680
+        ]);
 
-        self.w(
-            11,
-            &[
-                0x80 | 12, // NADC = 12 (set to 2 for 48kHz)
-                0x80 | 7,  // MDAC = 7
-                0,         // DOSR = MSB of 128
-                128,       // DOSR = LSB of 128
-            ],
-        );
+        self.w(11, &[
+            0x80 | 12, // NADC = 12 (set to 2 for 48kHz)
+            0x80 | 7,  // MDAC = 7
+            0,         // DOSR = MSB of 128
+            128,       // DOSR = LSB of 128
+        ]);
 
-        self.w(
-            18,
-            &[
-                0x80 | 42, // NADC = 42 (set to 7 for 48kHz)
-                0x80 | 2,  // MADC = 2
-                128,       // AOSR = 128
-            ],
-        );
+        self.w(18, &[
+            0x80 | 42, // NADC = 42 (set to 7 for 48kHz)
+            0x80 | 2,  // MADC = 2
+            128,       // AOSR = 128
+        ]);
         self.i2c.i2c_mutex_release();
     }
 
@@ -449,16 +437,13 @@ impl Codec {
 
         // 32 bits/word * 2 channels * 8000 samples/s = 512_000 = BCLK
         // pick off of DAC_MOD_CLK = 1.024MHz
-        self.w(
-            27,
-            &[
-                0b00_00_1_1_0_1, /* I2S standard, 16 bits per sample, BCLK output, WCLK output, DOUT is
-                                  * Hi-Z when unused */
-                0b0,           // no offset on left justification
-                0b0000_0_1_01, // BDIV_CLKIN = DAC_MOD_CLK, BCLK active even when powered down
-                0b1000_0010,   // BCLK_N_VAL = 2, N divider is powered up
-            ],
-        );
+        self.w(27, &[
+            0b00_00_1_1_0_1, /* I2S standard, 16 bits per sample, BCLK output, WCLK output, DOUT is
+                              * Hi-Z when unused */
+            0b0,           // no offset on left justification
+            0b0000_0_1_01, // BDIV_CLKIN = DAC_MOD_CLK, BCLK active even when powered down
+            0b1000_0010,   // BCLK_N_VAL = 2, N divider is powered up
+        ]);
 
         // "word width" (WCLK) timing is implied based on the DAC fs computed
         // at the end of the clock tree, and WCLK simply toggles every other sample, so there is no
@@ -509,24 +494,18 @@ impl Codec {
         //self.w(35, &[0b01_0_1_01_1_0]);
 
         // internal volume control
-        self.w(
-            36,
-            &[
-                0b1_001_1110, // HPL channel control on, -15dB
-                0b1_001_1110, // HPR channel control on, -15dB
-                0b1_000_1100, // SPK control on, -6dB
-            ],
-        );
+        self.w(36, &[
+            0b1_001_1110, // HPL channel control on, -15dB
+            0b1_001_1110, // HPR channel control on, -15dB
+            0b1_000_1100, // SPK control on, -6dB
+        ]);
 
         // driver PGA control
-        self.w(
-            40,
-            &[
-                0b0_0011_111,   // HPL driver PGA = 3dB, not muted, all gains applied
-                0b0_0011_111,   // HPR driver PGA = 3dB, not muted, all gains applied
-                0b000_01_1_0_1, // SPK gain = 12 dB, driver not muted, all gains applied
-            ],
-        );
+        self.w(40, &[
+            0b0_0011_111,   // HPL driver PGA = 3dB, not muted, all gains applied
+            0b0_0011_111,   // HPR driver PGA = 3dB, not muted, all gains applied
+            0b000_01_1_0_1, // SPK gain = 12 dB, driver not muted, all gains applied
+        ]);
 
         // HP driver control -- 16us short circuit debounce, best DAC performance, HPL/HPR as headphone
         // drivers
@@ -563,18 +542,15 @@ impl Codec {
         // ADC digital volume control coarse adjust
         self.w(83, &[0b0]); // +0.0 dB
 
-        self.w(
-            86,
-            &[
-                0b1_011_0000, // AGC enabled, target level = -12dB
-                0b00_10101_0, // hysteresis 1dB, noise threshold = -((value-1)*2 + 30): 21 => -70dB
-                100,          // max gain = code/2 dB
-                0b_00010_000, // attack time = 0b_acode_mul = (acode*32*mul)/Fs
-                0b_01101_000, // decay time  = 0b_dcode_mul = (dcode*32*mul)/Fs
-                0x01,         // noise debounce time = code*4 / fs
-                0x01,         // signal debounce time = code*4 / fs
-            ],
-        );
+        self.w(86, &[
+            0b1_011_0000, // AGC enabled, target level = -12dB
+            0b00_10101_0, // hysteresis 1dB, noise threshold = -((value-1)*2 + 30): 21 => -70dB
+            100,          // max gain = code/2 dB
+            0b_00010_000, // attack time = 0b_acode_mul = (acode*32*mul)/Fs
+            0b_01101_000, // decay time  = 0b_dcode_mul = (dcode*32*mul)/Fs
+            0x01,         // noise debounce time = code*4 / fs
+            0x01,         // signal debounce time = code*4 / fs
+        ]);
         self.i2c.i2c_mutex_release();
     }
 

--- a/services/codec/src/lib.rs
+++ b/services/codec/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod api;
 pub use api::*;
 use num_traits::{FromPrimitive, ToPrimitive};
-use xous::{send_message, Message, CID};
+use xous::{CID, Message, send_message};
 use xous_ipc::Buffer;
 
 /// This is a keyword reserved for the "arg4" slot of a scalar callback, where args are numbered 1-4.

--- a/services/codec/src/main.rs
+++ b/services/codec/src/main.rs
@@ -7,7 +7,7 @@ use api::*;
 use backend::Codec;
 use log::info;
 use num_traits::{FromPrimitive, ToPrimitive};
-use xous::{msg_scalar_unpack, CID};
+use xous::{CID, msg_scalar_unpack};
 use xous_ipc::Buffer;
 
 #[derive(Copy, Clone, Debug)]

--- a/services/com/src/lib.rs
+++ b/services/com/src/lib.rs
@@ -11,7 +11,7 @@ pub use api::*;
 pub use com_rs::serdes::Ipv4Conf;
 use com_rs::{DhcpState, LinkState};
 use num_traits::{FromPrimitive, ToPrimitive};
-use xous::{msg_scalar_unpack, send_message, Error, Message, CID};
+use xous::{CID, Error, Message, msg_scalar_unpack, send_message};
 use xous_ipc::{Buffer, String};
 use xous_semver::SemVer;
 

--- a/services/com/src/main.rs
+++ b/services/com/src/main.rs
@@ -5,11 +5,11 @@ mod api;
 use core::convert::TryInto;
 
 use api::*;
-use com_rs::serdes::{Ipv4Conf, StringSer, STR_32_WORDS, STR_64_WORDS};
+use com_rs::serdes::{Ipv4Conf, STR_32_WORDS, STR_64_WORDS, StringSer};
 use com_rs::*;
 use log::{error, info, trace};
 use num_traits::{FromPrimitive, ToPrimitive};
-use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack, CID};
+use xous::{CID, msg_blocking_scalar_unpack, msg_scalar_unpack};
 use xous_ipc::{Buffer, String};
 
 const LEGACY_REV: u32 = 0x8b5b_8e50; // this is the git rev shipped before we went to version tagging
@@ -44,9 +44,9 @@ mod implementation {
     use susres::{RegManager, RegOrField, SuspendResume};
     use utralib::generated::*;
 
+    use crate::WorkRequest;
     use crate::api::BattStats;
     use crate::return_battstats;
-    use crate::WorkRequest;
 
     const STD_TIMEOUT: u32 = 100;
 
@@ -248,9 +248,9 @@ mod implementation {
     use com_rs::*;
     use log::error;
 
+    use crate::WorkRequest;
     use crate::api::BattStats;
     use crate::return_battstats;
-    use crate::WorkRequest;
 
     pub struct XousCom {
         pub workqueue: Vec<WorkRequest>,

--- a/services/content-plugin-api/src/lib.rs
+++ b/services/content-plugin-api/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(target_os = "none", no_std)]
 
-use xous::{send_message, Message, ScalarMessage, CID};
+use xous::{CID, Message, ScalarMessage, send_message};
 
 #[derive(Debug)]
 pub enum Opcode {

--- a/services/cram-console/src/appmenu.rs
+++ b/services/cram-console/src/appmenu.rs
@@ -2,7 +2,7 @@ use gam::*;
 use locales::t;
 use num_traits::*;
 
-use crate::{app_autogen, StatusOpcode};
+use crate::{StatusOpcode, app_autogen};
 
 pub fn create_app_menu(status_conn: xous::CID) {
     let mut menu_items = Vec::<MenuItem>::new();

--- a/services/cram-console/src/cmds/pddb_cmd.rs
+++ b/services/cram-console/src/cmds/pddb_cmd.rs
@@ -1330,10 +1330,9 @@ impl<'a> ShellCmdApi<'a> for PddbCmd {
                 #[cfg(not(target_os = "xous"))]
                 "rkyvtest" => {
                     use rkyv::{
-                        archived_value,
+                        AlignedVec, Deserialize, archived_value,
                         de::deserializers::AllocDeserializer,
-                        ser::{serializers::WriteSerializer, Serializer},
-                        AlignedVec, Deserialize,
+                        ser::{Serializer, serializers::WriteSerializer},
                     };
                     let test = pddb::PddbKeyRecord {
                         name: "test".to_string(),

--- a/services/cram-console/src/main.rs
+++ b/services/cram-console/src/main.rs
@@ -12,19 +12,19 @@ mod shell;
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
 };
 use std::thread;
 
 use cmds::*;
 use cram_hal_service::keyboard;
-use graphics_server::api::GlyphStyle;
 use graphics_server::Gid;
+use graphics_server::api::GlyphStyle;
 use graphics_server::*;
 use locales::t;
 use num_traits::*;
-use xous::{msg_scalar_unpack, send_message, Message, CID};
+use xous::{CID, Message, msg_scalar_unpack, send_message};
 
 const SERVER_NAME_STATUS_GID: &str = "_Status bar GID receiver_";
 const SERVER_NAME_STATUS: &str = "_Status_";

--- a/services/cram-console/src/repl.rs
+++ b/services/cram-console/src/repl.rs
@@ -168,11 +168,11 @@ impl Repl {
         self.gam
             .draw_rectangle(
                 self.content,
-                Rectangle::new_with_style(
-                    Point::new(0, 0),
-                    self.screensize,
-                    DrawStyle { fill_color: Some(PixelColor::Light), stroke_color: None, stroke_width: 0 },
-                ),
+                Rectangle::new_with_style(Point::new(0, 0), self.screensize, DrawStyle {
+                    fill_color: Some(PixelColor::Light),
+                    stroke_color: None,
+                    stroke_width: 0,
+                }),
             )
             .expect("can't clear content area");
     }

--- a/services/cram-console/src/shell.rs
+++ b/services/cram-console/src/shell.rs
@@ -1,4 +1,4 @@
-use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
+use std::sync::{Arc, atomic::AtomicBool, atomic::Ordering};
 
 use xous_ipc::Buffer;
 

--- a/services/cram-hal-service/src/hw/keyboard.rs
+++ b/services/cram-hal-service/src/hw/keyboard.rs
@@ -1,5 +1,5 @@
 use num_traits::*;
-use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack, MessageSender, CID};
+use xous::{CID, MessageSender, msg_blocking_scalar_unpack, msg_scalar_unpack};
 use xous_ipc::Buffer;
 
 use crate::api;

--- a/services/cram-hal-service/src/iox_lib.rs
+++ b/services/cram-hal-service/src/iox_lib.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::Ordering;
 use cramium_hal::iox::{IoxDir, IoxDriveStrength, IoxEnable, IoxFunction, IoxPort, IoxValue};
 use num_traits::*;
 
-use crate::{api::IoxConfigMessage, Opcode, SERVER_NAME_CRAM_HAL};
+use crate::{Opcode, SERVER_NAME_CRAM_HAL, api::IoxConfigMessage};
 
 pub struct IoxHal {
     conn: xous::CID,

--- a/services/cram-hal-service/src/keyboard.rs
+++ b/services/cram-hal-service/src/keyboard.rs
@@ -1,5 +1,5 @@
 use num_traits::*;
-use xous::{send_message, Message};
+use xous::{Message, send_message};
 use xous_ipc::{Buffer, String};
 
 use crate::api::keyboard::*;

--- a/services/cram-hal-service/src/main.rs
+++ b/services/cram-hal-service/src/main.rs
@@ -10,9 +10,9 @@ use cramium_hal::{
 use utralib::utra;
 #[cfg(feature = "quantum-timer")]
 use utralib::*;
-use xous::sender::Sender;
 #[cfg(feature = "swap")]
 use xous::SWAPPER_PID;
+use xous::sender::Sender;
 use xous_pio::*;
 
 struct PreemptionHw {

--- a/services/dns/src/time.rs
+++ b/services/dns/src/time.rs
@@ -1,7 +1,7 @@
 use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
 use std::num::ParseIntError;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 /// The `time_server` is unique is that it is written for exclusive use by `libstd` to extract time.
 ///
 /// It also has a single hook that is callable from the PDDB to initialize a time value once the
@@ -37,7 +37,7 @@ use num_traits::*;
 use pddb::PddbMountPoller;
 // ntp imports
 use sntpc::{Error, NtpContext, NtpTimestampGenerator, NtpUdpSocket, Result};
-use xous::{send_message, Message};
+use xous::{Message, send_message};
 
 /// This is a "well known name" used by `libstd` to connect to the time server
 /// Anyone who wants to check if time has been initialized would use this name.

--- a/services/early_settings/src/lib.rs
+++ b/services/early_settings/src/lib.rs
@@ -1,7 +1,7 @@
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use num_traits::*;
-use xous::{send_message, Message};
+use xous::{Message, send_message};
 
 pub const SERVER_NAME_ES: &str = "_EARLY_SETTINGS";
 

--- a/services/early_settings/src/main.rs
+++ b/services/early_settings/src/main.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use early_settings::{Opcode, SERVER_NAME_ES};
 use num_traits::FromPrimitive;
 use spinor::Spinor;
-use xous::{msg_blocking_scalar_unpack, MemoryRange};
+use xous::{MemoryRange, msg_blocking_scalar_unpack};
 
 /*
 !!!! EARLY SETTINGS ALLOCATED SLOTS !!!!

--- a/services/ffi-test/src/bindings.rs
+++ b/services/ffi-test/src/bindings.rs
@@ -16,7 +16,7 @@ pub type c_float = f32;
 pub type c_double = f64;
 pub type c_void = core::ffi::c_void;
 
-use xous::{send_message, Message};
+use xous::{Message, send_message};
 static mut KBD: Option<keyboard::Keyboard> = None;
 fn get_keys_blocking() -> Vec<char> {
     if unsafe { KBD.is_none() } {

--- a/services/gam/src/bitmap.rs
+++ b/services/gam/src/bitmap.rs
@@ -19,8 +19,8 @@ use std::convert::TryInto;
 use std::io::Read;
 use std::ops::Deref;
 
-use graphics_server::api::*;
 use graphics_server::PixelColor;
+use graphics_server::api::*;
 
 mod img;
 pub use img::*;

--- a/services/gam/src/bitmap/decode_png.rs
+++ b/services/gam/src/bitmap/decode_png.rs
@@ -32,7 +32,7 @@
 use std::convert::TryInto;
 use std::io::{Error, ErrorKind::InvalidData, Read, Result};
 
-use miniz_oxide::{inflate::stream::InflateState, DataFormat, MZFlush, MZStatus};
+use miniz_oxide::{DataFormat, MZFlush, MZStatus, inflate::stream::InflateState};
 //use pix::rgb::SRgb8;
 
 mod color_type;

--- a/services/gam/src/bitmap/dither.rs
+++ b/services/gam/src/bitmap/dither.rs
@@ -14,8 +14,8 @@
 use std::cmp::max;
 use std::convert::TryInto;
 
-use crate::bitmap::BITS_PER_WORD;
 use crate::PixelColor;
+use crate::bitmap::BITS_PER_WORD;
 
 /// Burkes dithering diffusion scheme was chosen for its modest resource
 /// requirements with impressive quality outcome.

--- a/services/gam/src/layouts/menu.rs
+++ b/services/gam/src/layouts/menu.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use cram_hal_service::trng;
 use graphics_server::*;
 
-use crate::contexts::MISC_CONTEXT_DEFAULT_TRUST;
 use crate::Canvas;
+use crate::contexts::MISC_CONTEXT_DEFAULT_TRUST;
 use crate::{LayoutApi, LayoutBehavior};
 const TRUST_OFFSET: u8 = 0;
 

--- a/services/gam/src/layouts/modal.rs
+++ b/services/gam/src/layouts/modal.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 use cram_hal_service::trng;
 use graphics_server::*;
 
+use crate::Canvas;
 use crate::api::CanvasType;
 use crate::contexts::MISC_CONTEXT_DEFAULT_TRUST;
-use crate::Canvas;
 use crate::{LayoutApi, LayoutBehavior};
 const TRUST_OFFSET: u8 = 16;
 

--- a/services/gam/src/lib.rs
+++ b/services/gam/src/lib.rs
@@ -24,7 +24,7 @@ pub use graphics_server::api::{Point, Rectangle};
 pub use graphics_server::api::{TextOp, TextView};
 use ime_plugin_api::{ApiToken, ImefCallback};
 use num_traits::*;
-use xous::{send_message, Message, CID};
+use xous::{CID, Message, send_message};
 use xous_ipc::{Buffer, String};
 
 #[doc = include_str!("../README.md")]

--- a/services/gam/src/menu.rs
+++ b/services/gam/src/menu.rs
@@ -7,9 +7,9 @@ use num_traits::*;
 use tts_frontend::TtsFrontend;
 use xous_ipc::{Buffer, String};
 
-use crate::api::*;
 use crate::Gam;
-use crate::{forwarding_thread, MsgForwarder};
+use crate::api::*;
+use crate::{MsgForwarder, forwarding_thread};
 #[derive(Debug)]
 pub struct Menu<'a> {
     pub sid: xous::SID,

--- a/services/gam/src/modal.rs
+++ b/services/gam/src/modal.rs
@@ -28,9 +28,9 @@ use graphics_server::api::*;
 use num_traits::*;
 use xous_ipc::{Buffer, String};
 
-use crate::api::*;
 use crate::Gam;
 use crate::MsgForwarder;
+use crate::api::*;
 
 pub const MAX_ITEMS: usize = 8;
 

--- a/services/graphics-server/src/api/blitstr2/cursor.rs
+++ b/services/graphics-server/src/api/blitstr2/cursor.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2022 Sam Blenny
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //
-use super::cliprect::ClipRect;
-use super::pt::Pt;
 use super::GlyphSprite;
 use super::TypesetWord;
+use super::cliprect::ClipRect;
+use super::pt::Pt;
 
 /// Cursor specifies a drawing position along a line of text. Lines of text can
 /// be different heights. Line_height is for keeping track of the tallest

--- a/services/graphics-server/src/backend/minifb.rs
+++ b/services/graphics-server/src/backend/minifb.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(target_os = "none"), allow(dead_code))]
 
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
 
 use minifb::{Key, Window, WindowOptions};
 
@@ -150,16 +150,11 @@ impl XousDisplay {
 
 impl MinifbThread {
     pub fn run_while(self, mut predicate: impl FnMut() -> bool) {
-        let mut window = Window::new(
-            "Precursor",
-            WIDTH as usize,
-            HEIGHT as usize,
-            WindowOptions {
-                scale_mode: minifb::ScaleMode::AspectRatioStretch,
-                resize: true,
-                ..WindowOptions::default()
-            },
-        )
+        let mut window = Window::new("Precursor", WIDTH as usize, HEIGHT as usize, WindowOptions {
+            scale_mode: minifb::ScaleMode::AspectRatioStretch,
+            resize: true,
+            ..WindowOptions::default()
+        })
         .unwrap_or_else(|e| {
             log::error!("{e:?}");
             std::process::abort();

--- a/services/graphics-server/src/blitstr2/blit.rs
+++ b/services/graphics-server/src/blitstr2/blit.rs
@@ -4,8 +4,8 @@
 use super::cliprect::ClipRect;
 #[allow(unused_imports)]
 use super::{FrBuf, LINES, WIDTH, WORDS_PER_LINE};
-use crate::api::Point;
 use crate::GlyphSprite;
+use crate::api::Point;
 
 /// Null glyph to use when everything else fails
 pub const NULL_GLYPH: [u32; 8] = [0, 0x5500AA, 0x5500AA, 0x5500AA, 0x5500AA, 0x5500AA, 0, 0];

--- a/services/graphics-server/src/lib.rs
+++ b/services/graphics-server/src/lib.rs
@@ -16,7 +16,7 @@ pub use api::BulkRead;
 use api::Opcode; // if you prefer to map the api into your local namespace
 pub use fontmap::*;
 use num_traits::ToPrimitive;
-use xous::{send_message, Message};
+use xous::{Message, send_message};
 use xous_ipc::Buffer;
 #[derive(Debug)]
 pub struct Gfx {

--- a/services/graphics-server/src/main.rs
+++ b/services/graphics-server/src/main.rs
@@ -25,7 +25,7 @@ mod wordwrap;
 mod style_macros;
 
 use num_traits::FromPrimitive;
-use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack, MemoryRange};
+use xous::{MemoryRange, msg_blocking_scalar_unpack, msg_scalar_unpack};
 use xous_ipc::Buffer;
 
 mod fontmap;

--- a/services/graphics-server/src/wordwrap.rs
+++ b/services/graphics-server/src/wordwrap.rs
@@ -1,4 +1,4 @@
-use crate::api::{glyph_to_height_hint, Cursor, GlyphSprite, GlyphStyle, Point, Pt, Rectangle, TypesetWord};
+use crate::api::{Cursor, GlyphSprite, GlyphStyle, Point, Pt, Rectangle, TypesetWord, glyph_to_height_hint};
 #[allow(unused_imports)]
 use crate::backend::{FB_LINES, FB_SIZE, FB_WIDTH_PIXELS};
 /// Wordwrap stratgey

--- a/services/ime-frontend/src/main.rs
+++ b/services/ime-frontend/src/main.rs
@@ -14,7 +14,7 @@ use log::{error, info};
 use num_traits::{FromPrimitive, ToPrimitive};
 #[cfg(feature = "tts")]
 use tts_frontend::*;
-use xous::{msg_scalar_unpack, CID};
+use xous::{CID, msg_scalar_unpack};
 use xous_ipc::Buffer;
 
 /// max number of prediction options to track/render
@@ -142,26 +142,22 @@ impl InputTracker {
             self.gam
                 .draw_rectangle(
                     pc,
-                    Rectangle::new_with_style(
-                        Point::new(0, 0),
-                        pc_bounds,
-                        DrawStyle {
-                            fill_color: Some(PixelColor::Light),
-                            stroke_color: None,
-                            stroke_width: 0,
-                        },
-                    ),
+                    Rectangle::new_with_style(Point::new(0, 0), pc_bounds, DrawStyle {
+                        fill_color: Some(PixelColor::Light),
+                        stroke_color: None,
+                        stroke_width: 0,
+                    }),
                 )
                 .expect("can't clear prediction area");
             // add the border line on top
             self.gam
                 .draw_line(
                     pc,
-                    Line::new_with_style(
-                        Point::new(0, 0),
-                        Point::new(pc_bounds.x, 0),
-                        DrawStyle { fill_color: None, stroke_color: Some(PixelColor::Dark), stroke_width: 1 },
-                    ),
+                    Line::new_with_style(Point::new(0, 0), Point::new(pc_bounds.x, 0), DrawStyle {
+                        fill_color: None,
+                        stroke_color: Some(PixelColor::Dark),
+                        stroke_width: 1,
+                    }),
                 )
                 .expect("can't draw prediction top border");
         }
@@ -171,15 +167,11 @@ impl InputTracker {
             self.gam
                 .draw_rectangle(
                     ic,
-                    Rectangle::new_with_style(
-                        Point::new(0, 0),
-                        ic_bounds,
-                        DrawStyle {
-                            fill_color: Some(PixelColor::Light),
-                            stroke_color: None,
-                            stroke_width: 0,
-                        },
-                    ),
+                    Rectangle::new_with_style(Point::new(0, 0), ic_bounds, DrawStyle {
+                        fill_color: Some(PixelColor::Light),
+                        stroke_color: None,
+                        stroke_width: 0,
+                    }),
                 )
                 .expect("can't clear input area");
 
@@ -187,11 +179,11 @@ impl InputTracker {
             self.gam
                 .draw_line(
                     ic,
-                    Line::new_with_style(
-                        Point::new(0, 0),
-                        Point::new(ic_bounds.x, 0),
-                        DrawStyle { fill_color: None, stroke_color: Some(PixelColor::Dark), stroke_width: 1 },
-                    ),
+                    Line::new_with_style(Point::new(0, 0), Point::new(ic_bounds.x, 0), DrawStyle {
+                        fill_color: None,
+                        stroke_color: Some(PixelColor::Dark),
+                        stroke_width: 1,
+                    }),
                 )
                 .expect("can't draw input top line border");
         }
@@ -688,11 +680,11 @@ impl InputTracker {
             }
             let pc_bounds: Point =
                 self.gam.get_canvas_bounds(pc).expect("Couldn't get prediction canvas bounds");
-            let pc_clip: Rectangle = Rectangle::new_with_style(
-                Point::new(0, 1),
-                pc_bounds,
-                DrawStyle { fill_color: Some(PixelColor::Light), stroke_color: None, stroke_width: 0 },
-            );
+            let pc_clip: Rectangle = Rectangle::new_with_style(Point::new(0, 1), pc_bounds, DrawStyle {
+                fill_color: Some(PixelColor::Light),
+                stroke_color: None,
+                stroke_width: 0,
+            });
             if debug1 {
                 info!("got pc_bound {:?}", pc_bounds);
             }

--- a/services/ime-plugin-api/src/lib.rs
+++ b/services/ime-plugin-api/src/lib.rs
@@ -3,7 +3,7 @@
 mod rkyv_enum;
 use num_traits::{FromPrimitive, ToPrimitive};
 pub use rkyv_enum::*;
-use xous::{send_message, Message, CID};
+use xous::{CID, Message, send_message};
 use xous_ipc::{Buffer, String};
 
 #[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]

--- a/services/jtag/src/lib.rs
+++ b/services/jtag/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod api;
 pub use api::*;
 use num_traits::*;
-use xous::{send_message, Message, CID};
+use xous::{CID, Message, send_message};
 use xous_ipc::Buffer;
 
 #[derive(Debug)]

--- a/services/keyboard/src/lib.rs
+++ b/services/keyboard/src/lib.rs
@@ -5,7 +5,7 @@ use num_traits::*;
 pub mod api;
 
 pub use api::*;
-use xous::{send_message, Message};
+use xous::{Message, send_message};
 use xous_ipc::{Buffer, String};
 
 #[derive(Debug)]

--- a/services/keyboard/src/main.rs
+++ b/services/keyboard/src/main.rs
@@ -10,7 +10,7 @@ use std::collections::VecDeque;
 
 use log::info;
 use num_traits::*;
-use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack, MessageSender, CID};
+use xous::{CID, MessageSender, msg_blocking_scalar_unpack, msg_scalar_unpack};
 use xous_ipc::Buffer;
 #[cfg(feature = "rawserial")]
 const BLOCKING_QUEUE_LEN: usize = 128;
@@ -26,7 +26,7 @@ mod implementation {
     use xous::CID;
 
     use crate::mappings::*;
-    use crate::{api::*, KeyRawStates, RowCol};
+    use crate::{KeyRawStates, RowCol, api::*};
 
     /// note: the code is structured to use at most 16 rows or 16 cols
     const KBD_ROWS: usize = 9;

--- a/services/llio/src/i2c/hardware.rs
+++ b/services/llio/src/i2c/hardware.rs
@@ -1,4 +1,4 @@
-use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
+use std::sync::{Arc, atomic::AtomicBool, atomic::Ordering};
 
 use num_traits::ToPrimitive;
 use susres::{RegManager, RegOrField, SuspendResume};

--- a/services/llio/src/i2c/hosted.rs
+++ b/services/llio/src/i2c/hosted.rs
@@ -1,4 +1,4 @@
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::{Arc, atomic::AtomicBool};
 
 use crate::api::*;
 

--- a/services/llio/src/llio_lib.rs
+++ b/services/llio/src/llio_lib.rs
@@ -2,7 +2,7 @@ use core::sync::atomic::AtomicU32;
 use core::sync::atomic::Ordering;
 
 use num_traits::{FromPrimitive, ToPrimitive};
-use xous::{msg_scalar_unpack, send_message, Message, CID};
+use xous::{CID, Message, msg_scalar_unpack, send_message};
 use xous_ipc::Buffer;
 use xous_semver::SemVer;
 

--- a/services/llio/src/main.rs
+++ b/services/llio/src/main.rs
@@ -11,15 +11,15 @@ use llio_hw::*;
 
 #[cfg(not(target_os = "xous"))]
 mod llio_hosted;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::thread;
 
 #[cfg(not(target_os = "xous"))]
 use llio_hosted::*;
 use num_traits::*;
 use xous::messages::sender::Sender;
-use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack, try_send_message, Message, CID};
+use xous::{CID, Message, msg_blocking_scalar_unpack, msg_scalar_unpack, try_send_message};
 use xous_ipc::Buffer;
 
 use crate::RTC_PWR_MODE;
@@ -579,12 +579,10 @@ fn main() -> ! {
                 i2c.i2c_mutex_acquire();
                 // set clock units to 1 second, output pulse length to ~218ms
                 // and program the elapsed time (TIMERB_CLK is followed by TIMERB)
-                i2c.i2c_write(
-                    ABRTCMC_I2C_ADR,
-                    ABRTCMC_TIMERB_CLK,
-                    &[(TimerClk::CLK_1_S | TimerClk::PULSE_218_MS).bits()],
-                )
-                .expect("RTC access error");
+                i2c.i2c_write(ABRTCMC_I2C_ADR, ABRTCMC_TIMERB_CLK, &[(TimerClk::CLK_1_S
+                    | TimerClk::PULSE_218_MS)
+                    .bits()])
+                    .expect("RTC access error");
                 // program elapsed time
                 i2c.i2c_write(ABRTCMC_I2C_ADR, ABRTCMC_TIMERB, &[seconds]).expect("RTC access error");
                 // enable timerb countdown interrupt, also clears any prior interrupt flag

--- a/services/modals/src/api.rs
+++ b/services/modals/src/api.rs
@@ -1,6 +1,6 @@
-use gam::modal::*;
 #[cfg(feature = "ditherpunk")]
 use gam::Tile;
+use gam::modal::*;
 
 pub(crate) const SERVER_NAME_MODALS: &str = "_Modal Dialog Server_";
 

--- a/services/modals/src/lib.rs
+++ b/services/modals/src/lib.rs
@@ -14,7 +14,7 @@ use std::convert::TryInto;
 use bit_field::BitField;
 use gam::*;
 use num_traits::*;
-use xous::{send_message, Message, CID};
+use xous::{CID, Message, send_message};
 use xous_ipc::Buffer;
 
 pub type TextValidationFn = fn(TextEntryPayload) -> Option<ValidatorErr>;

--- a/services/modals/src/main.rs
+++ b/services/modals/src/main.rs
@@ -29,13 +29,13 @@
 /// a `TextResponseValid` message which pumps the work queue.
 mod api;
 use api::*;
-use gam::modal::*;
 #[cfg(feature = "ditherpunk")]
 use gam::Bitmap;
+use gam::modal::*;
 use locales::t;
 #[cfg(feature = "tts")]
 use tts_frontend::TtsFrontend;
-use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack, send_message, Message};
+use xous::{Message, msg_blocking_scalar_unpack, msg_scalar_unpack, send_message};
 use xous_ipc::Buffer;
 #[cfg(feature = "tts")]
 const TICK_INTERVAL: u64 = 2500;

--- a/services/net/src/connection_manager.rs
+++ b/services/net/src/connection_manager.rs
@@ -8,11 +8,11 @@ use com::{SsidRecord, WlanStatus, WlanStatusIpc};
 use com_rs::{ConnectResult, LinkState};
 use net::MIN_EC_REV;
 use num_traits::*;
-use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack, send_message, try_send_message, Message};
+use xous::{Message, msg_blocking_scalar_unpack, msg_scalar_unpack, send_message, try_send_message};
 use xous_ipc::Buffer;
 
-use crate::api::*;
 use crate::ComIntSources;
+use crate::api::*;
 
 #[allow(dead_code)]
 const BOOT_POLL_INTERVAL_MS: usize = 4_758; // a slightly faster poll during boot so we acquire wifi faster once PDDB is mounted

--- a/services/net/src/device.rs
+++ b/services/net/src/device.rs
@@ -3,8 +3,8 @@ use std::collections::VecDeque;
 use std::convert::TryInto;
 use std::sync::{Arc, Mutex};
 
-use com::api::NET_MTU;
 use com::Com;
+use com::api::NET_MTU;
 use num_traits::*;
 use smoltcp::phy::{self, ChecksumCapabilities, DeviceCapabilities, Medium};
 use smoltcp::wire::{
@@ -64,16 +64,13 @@ impl phy::Device for NetPhy {
                 .wlan_fetch_loopback_packet(&mut self.rx_buffer[..rx_len as usize])
                 .expect("Couldn't call wlan_fetch_packet in device adapter");
 
-            Some((
-                NetPhyRxToken { buf: &mut self.rx_buffer[..rx_len as usize] },
-                NetPhyTxToken {
-                    buf: &mut self.tx_buffer[..],
-                    com: &self.com,
-                    loopback_conn: self.loopback_conn,
-                    loopback_count: self.loopback_pending.clone(),
-                    caps: csum_copy,
-                },
-            ))
+            Some((NetPhyRxToken { buf: &mut self.rx_buffer[..rx_len as usize] }, NetPhyTxToken {
+                buf: &mut self.tx_buffer[..],
+                com: &self.com,
+                loopback_conn: self.loopback_conn,
+                loopback_count: self.loopback_pending.clone(),
+                caps: csum_copy,
+            }))
         } else {
             if let Some(rx_len) = self.rx_avail.take() {
                 log::debug!("device rx of {} bytes", rx_len);
@@ -81,16 +78,13 @@ impl phy::Device for NetPhy {
                     .wlan_fetch_packet(&mut self.rx_buffer[..rx_len as usize])
                     .expect("Couldn't call wlan_fetch_packet in device adapter");
 
-                Some((
-                    NetPhyRxToken { buf: &mut self.rx_buffer[..rx_len as usize] },
-                    NetPhyTxToken {
-                        buf: &mut self.tx_buffer[..],
-                        com: &self.com,
-                        loopback_conn: self.loopback_conn,
-                        loopback_count: self.loopback_pending.clone(),
-                        caps: csum_copy,
-                    },
-                ))
+                Some((NetPhyRxToken { buf: &mut self.rx_buffer[..rx_len as usize] }, NetPhyTxToken {
+                    buf: &mut self.tx_buffer[..],
+                    com: &self.com,
+                    loopback_conn: self.loopback_conn,
+                    loopback_count: self.loopback_pending.clone(),
+                    caps: csum_copy,
+                }))
             } else {
                 log::trace!("nothing to rx");
                 None

--- a/services/net/src/lib.rs
+++ b/services/net/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod api;
 use com::{Ipv4Conf, SsidRecord};
 use num_traits::*;
-use xous::{send_message, Message, CID};
+use xous::{CID, Message, send_message};
 use xous_ipc::Buffer;
 
 pub mod protocols;

--- a/services/net/src/main.rs
+++ b/services/net/src/main.rs
@@ -25,8 +25,8 @@ use core::sync::atomic::{AtomicU16, AtomicU32, Ordering};
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::HashMap;
 use std::convert::TryInto;
-use std::sync::mpsc::{channel, Sender};
 use std::sync::Arc;
+use std::sync::mpsc::{Sender, channel};
 use std::thread;
 
 use byteorder::{ByteOrder, NetworkEndian};
@@ -37,7 +37,7 @@ use smoltcp::socket::{icmp, tcp, udp};
 use smoltcp::time::{Duration, Instant};
 use smoltcp::wire::{EthernetAddress, HardwareAddress, IpAddress, IpCidr, IpEndpoint, Ipv4Address};
 use smoltcp::wire::{Icmpv4Packet, Icmpv4Repr, Icmpv6Packet, Icmpv6Repr};
-use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack, try_send_message, Message, CID, SID};
+use xous::{CID, Message, SID, msg_blocking_scalar_unpack, msg_scalar_unpack, try_send_message};
 use xous_ipc::Buffer;
 
 // 0 indicates no address is currently assigned

--- a/services/net/src/protocols/dns.rs
+++ b/services/net/src/protocols/dns.rs
@@ -7,11 +7,11 @@ use std::thread::JoinHandle;
 
 //use crate::api::udp::*;
 use num_traits::*;
-use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack, Message, SID};
+use xous::{Message, SID, msg_blocking_scalar_unpack, msg_scalar_unpack};
 use xous_ipc::Buffer;
 
-use crate::api::*;
 use crate::NetConn;
+use crate::api::*;
 
 pub struct DnsServerManager {
     net: NetConn,

--- a/services/net/src/protocols/ping.rs
+++ b/services/net/src/protocols/ping.rs
@@ -5,11 +5,11 @@ use std::thread;
 use std::thread::JoinHandle;
 
 use num_traits::*;
-use xous::{msg_scalar_unpack, send_message, Message};
+use xous::{Message, msg_scalar_unpack, send_message};
 use xous_ipc::Buffer;
 
-use crate::api::*;
 use crate::NetConn;
+use crate::api::*;
 
 ///////// Ping implementation
 /// smoltcp's ICMP stack is a little weird. It's designed with an icmp packet

--- a/services/net/src/std_tcplistener.rs
+++ b/services/net/src/std_tcplistener.rs
@@ -147,15 +147,12 @@ pub(crate) fn std_tcp_accept(
     // Adding the message to the udp_rx_waiting list prevents it from going out of scope and
     // thus prevents the .drop() method from being called. Since messages are returned to the sender
     // in the .drop() method, this keeps the caller blocked for the lifetime of the message.
-    insert_or_append(
-        tcp_accept_waiting,
-        AcceptingSocket {
-            env: msg, /* <-- msg is inserted into the tcp_accept_waiting vector, thus preventing the
-                       * lend_mut from returning. */
-            handle: *handle,
-            fd,
-        },
-    );
+    insert_or_append(tcp_accept_waiting, AcceptingSocket {
+        env: msg, /* <-- msg is inserted into the tcp_accept_waiting vector, thus preventing the
+                   * lend_mut from returning. */
+        handle: *handle,
+        fd,
+    });
 }
 
 pub(crate) fn tcp_accept_success(buf: &mut [u8], fd: u16, ep: IpEndpoint) {

--- a/services/net/src/std_udp.rs
+++ b/services/net/src/std_udp.rs
@@ -169,15 +169,12 @@ pub(crate) fn std_udp_rx(
     // Adding the message to the udp_rx_waiting list prevents it from going out of scope and
     // thus prevents the .drop() method from being called. Since messages are returned to the sender
     // in the .drop() method, this keeps the caller blocked for the lifetime of the message.
-    insert_or_append(
-        udp_rx_waiting,
-        UdpStdState {
-            msg, /* <-- msg is inserted into the udp_rx_waiting vector, thus preventing the lend_mut from
-                  * returning. */
-            handle: *handle,
-            expiry,
-        },
-    );
+    insert_or_append(udp_rx_waiting, UdpStdState {
+        msg, /* <-- msg is inserted into the udp_rx_waiting vector, thus preventing the lend_mut from
+              * returning. */
+        handle: *handle,
+        expiry,
+    });
 }
 
 pub(crate) fn std_udp_tx(

--- a/services/pddb/src/backend/basis.rs
+++ b/services/pddb/src/backend/basis.rs
@@ -8,9 +8,9 @@ use std::convert::TryInto;
 use std::io::{Error, ErrorKind, Result};
 use std::iter::IntoIterator;
 
-use aes::cipher::generic_array::GenericArray;
 use aes::Aes256;
-use aes_gcm_siv::{aead::KeyInit, Aes256GcmSiv};
+use aes::cipher::generic_array::GenericArray;
+use aes_gcm_siv::{Aes256GcmSiv, aead::KeyInit};
 
 use super::*;
 /// # The Organization of Basis Data

--- a/services/pddb/src/backend/dictionary.rs
+++ b/services/pddb/src/backend/dictionary.rs
@@ -11,9 +11,9 @@ use bitfield::bitfield;
 use perflib::{PERFMETA_ENDBLOCK, PERFMETA_NONE, PERFMETA_STARTBLOCK};
 
 use super::*;
-use crate::api::*;
 #[cfg(feature = "perfcounter")]
 use crate::FILE_ID_SERVICES_PDDB_SRC_DICTIONARY;
+use crate::api::*;
 
 bitfield! {
     #[derive(Copy, Clone, PartialEq, Eq)]

--- a/services/pddb/src/backend/hosted.rs
+++ b/services/pddb/src/backend/hosted.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 use std::fs::File;
 use std::fs::OpenOptions;
-use std::io::prelude::*;
 use std::io::SeekFrom;
+use std::io::prelude::*;
 use std::mem::MaybeUninit;
 use std::sync::Once;
 

--- a/services/pddb/src/backend/hw.rs
+++ b/services/pddb/src/backend/hw.rs
@@ -10,8 +10,8 @@ use std::collections::HashSet;
 use std::convert::TryInto;
 use std::io::{Error, ErrorKind, Result};
 
-use aes::cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt};
-use aes::{Aes256, Block, BLOCK_SIZE};
+use aes::cipher::{BlockDecrypt, BlockEncrypt, generic_array::GenericArray};
+use aes::{Aes256, BLOCK_SIZE, Block};
 use aes_gcm_siv::aead::{Aead, Payload};
 use aes_gcm_siv::{Aes256GcmSiv, Nonce, Tag};
 use backend::bcrypt::*;
@@ -2503,16 +2503,13 @@ impl PddbOs {
                 let aad_local = self.data_aad(&name);
                 self.dna_mode = DnaMode::Migration;
                 let aad_incoming = self.data_aad(&name);
-                keymap.insert(
-                    &name,
-                    MigrationCiphers {
-                        pt_ecb,
-                        data_gcm_siv,
-                        aad_incoming,
-                        aad_local,
-                        data_key: basis_keys.data.into(),
-                    },
-                );
+                keymap.insert(&name, MigrationCiphers {
+                    pt_ecb,
+                    data_gcm_siv,
+                    aad_incoming,
+                    aad_local,
+                    data_key: basis_keys.data.into(),
+                });
                 modals.update_progress(index as u32 + 1).ok();
             }
 
@@ -2831,14 +2828,11 @@ impl PddbOs {
             self.tt.sleep_ms(SWAP_DELAY_MS).unwrap();
         }
         // done!
-        if self.yes_no_approval(
-            &modals,
-            match self.dna_mode {
-                DnaMode::Normal => t!("pddb.freespace.finished", locales::LANG),
-                DnaMode::Migration => t!("pddb.rekey.finished", locales::LANG),
-                DnaMode::Churn => t!("pddb.churn.finished", locales::LANG),
-            },
-        ) {
+        if self.yes_no_approval(&modals, match self.dna_mode {
+            DnaMode::Normal => t!("pddb.freespace.finished", locales::LANG),
+            DnaMode::Migration => t!("pddb.rekey.finished", locales::LANG),
+            DnaMode::Churn => t!("pddb.churn.finished", locales::LANG),
+        }) {
             Some(ret)
         } else {
             None

--- a/services/pddb/src/backend/pagetable.rs
+++ b/services/pddb/src/backend/pagetable.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use aes_gcm_siv::{Nonce, Tag};
 use bitflags::bitflags;
 
-use super::{murmur3_32, TrngPool, VirtAddr, PAGE_SIZE, VPAGE_SIZE};
+use super::{PAGE_SIZE, TrngPool, VPAGE_SIZE, VirtAddr, murmur3_32};
 
 bitflags! {
     /// flags used by the page table

--- a/services/pddb/src/frontend/pddbkey.rs
+++ b/services/pddb/src/frontend/pddbkey.rs
@@ -2,7 +2,7 @@ use std::io::{Error, ErrorKind, Result};
 use std::io::{Read, Seek, SeekFrom, Write};
 
 use num_traits::*;
-use xous::{send_message, Message, CID};
+use xous::{CID, Message, send_message};
 use xous_ipc::Buffer;
 
 use crate::*;

--- a/services/pddb/src/lib.rs
+++ b/services/pddb/src/lib.rs
@@ -12,7 +12,7 @@ use std::thread::JoinHandle;
 
 pub use frontend::*;
 use num_traits::*;
-use xous::{msg_scalar_unpack, send_message, Message, CID, SID};
+use xous::{CID, Message, SID, msg_scalar_unpack, send_message};
 use xous_ipc::Buffer;
 pub(crate) static REFCOUNT: AtomicU32 = AtomicU32::new(0);
 pub(crate) static POLLER_REFCOUNT: AtomicU32 = AtomicU32::new(0);
@@ -22,10 +22,9 @@ use std::cell::RefCell;
 use std::convert::TryInto;
 
 use rkyv::{
-    archived_value,
+    AlignedVec, Deserialize, archived_value,
     de::deserializers::AllocDeserializer,
-    ser::{serializers::WriteSerializer, Serializer},
-    AlignedVec, Deserialize,
+    ser::{Serializer, serializers::WriteSerializer},
 };
 
 #[derive(num_derive::FromPrimitive, num_derive::ToPrimitive, Debug)]

--- a/services/pddb/src/libstd/mod.rs
+++ b/services/pddb/src/libstd/mod.rs
@@ -3,9 +3,9 @@ mod utils;
 
 use senres::{Senres, SenresMut};
 
+use crate::FileHandle;
 use crate::backend::BasisCache;
 use crate::backend::PddbOs;
-use crate::FileHandle;
 
 #[repr(u8)]
 enum FileType {

--- a/services/pddb/src/main.rs
+++ b/services/pddb/src/main.rs
@@ -392,18 +392,18 @@ use core::ops::Deref;
 use std::collections::{BTreeSet, HashMap};
 use std::io::ErrorKind;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
 use locales::t;
 use num_traits::*;
 use rkyv::{
-    de::deserializers::AllocDeserializer,
-    ser::{serializers::BufferSerializer, Serializer},
     Deserialize,
+    de::deserializers::AllocDeserializer,
+    ser::{Serializer, serializers::BufferSerializer},
 };
-use xous::{msg_blocking_scalar_unpack, send_message, Message};
+use xous::{Message, msg_blocking_scalar_unpack, send_message};
 use xous_ipc::Buffer;
 
 #[cfg(feature = "perfcounter")]

--- a/services/pddb/src/tests.rs
+++ b/services/pddb/src/tests.rs
@@ -2,9 +2,9 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use std::collections::{BTreeSet, HashSet};
 use std::io::Result;
 
+use rand_chacha::ChaCha8Rng;
 use rand_chacha::rand_core::RngCore;
 use rand_chacha::rand_core::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 
 use crate::*;
 

--- a/services/root-keys/src/backups.rs
+++ b/services/root-keys/src/backups.rs
@@ -2,8 +2,8 @@ use core::mem::size_of;
 use core::ops::{Deref, DerefMut};
 
 use aes_gcm_siv::{
-    aead::{Aead, Payload},
     Aes256GcmSiv, Nonce, Tag,
+    aead::{Aead, Payload},
 };
 use rand_core::RngCore;
 use subtle::ConstantTimeEq;
@@ -189,10 +189,10 @@ pub(crate) fn restore_backup(key: &BackupKey, backup: &BackupDataCt) -> Option<B
 
     // Attempt decryption. This is None on failure
     let plaintext = cipher
-        .decrypt(
-            Nonce::from_slice(&backup.nonce),
-            Payload { aad: BACKUP_AAD.as_bytes(), msg: &backup.ct_plus_mac },
-        )
+        .decrypt(Nonce::from_slice(&backup.nonce), Payload {
+            aad: BACKUP_AAD.as_bytes(),
+            msg: &backup.ct_plus_mac,
+        })
         .ok();
 
     if kcom.0.ct_eq(&backup.commitment).into() {

--- a/services/root-keys/src/implementation.rs
+++ b/services/root-keys/src/implementation.rs
@@ -6,11 +6,11 @@ use core::convert::TryInto;
 use core::mem::size_of;
 use core::num::NonZeroUsize;
 
-use aes::cipher::{BlockDecrypt, BlockEncrypt};
 use aes::Aes256;
+use aes::cipher::{BlockDecrypt, BlockEncrypt};
 use cipher::generic_array::GenericArray;
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::{edwards::CompressedEdwardsY, EdwardsPoint};
+use curve25519_dalek::{EdwardsPoint, edwards::CompressedEdwardsY};
 use ed25519_dalek::{DigestSigner, Signature, Signer, SigningKey, VerifyingKey};
 use gam::modal::{ActionType, Modal, ProgressBar, Slider};
 use graphics_server::BulkRead;
@@ -20,7 +20,7 @@ use num_traits::*;
 pub use oracle::FpgaKeySource;
 use rand_core::RngCore;
 use root_keys::key2bits::*;
-use sha2::{Digest, Sha256, Sha512Hw, Sha512Sw, Sha512_256Sw};
+use sha2::{Digest, Sha256, Sha512_256Sw, Sha512Hw, Sha512Sw};
 use utralib::generated::*;
 use xous::KERNEL_BACKUP_OFFSET;
 use xous_semver::SemVer;
@@ -28,8 +28,8 @@ use xous_semver::SemVer;
 use crate::api::PasswordType;
 use crate::bcrypt::*;
 use crate::sha512_digest::Sha512Prehash;
-use crate::{api::*, backups};
 use crate::{GatewareRegion, MetadataInFlash, SignatureResult, UpdateType};
+use crate::{api::*, backups};
 
 // TODO: add hardware acceleration for BCRYPT so we can hit the OWASP target without excessive UX delay
 const BCRYPT_COST: u32 = 7; // 10 is the minimum recommended by OWASP; takes 5696 ms to verify @ 10 rounds; 804 ms to verify 7 rounds

--- a/services/root-keys/src/implementation/keywrap.rs
+++ b/services/root-keys/src/implementation/keywrap.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+use aes::Aes256;
 /// this code is vendored in from https://github.com/jedisct1/rust-aes-keywrap
 /// From its original README:
 /// AES Key Wrap for Rust
@@ -35,7 +36,6 @@
 /// not compliant, so, we should migrate away from it!
 use aes::cipher::generic_array::GenericArray;
 use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
-use aes::Aes256;
 use byteorder::{BigEndian, ByteOrder};
 
 use crate::api::KeywrapError;

--- a/services/root-keys/src/implementation/oracle.rs
+++ b/services/root-keys/src/implementation/oracle.rs
@@ -1,7 +1,7 @@
 use core::convert::TryInto;
 
-use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 use aes::Aes256;
+use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 use cipher::generic_array::GenericArray;
 
 use crate::api::*;

--- a/services/root-keys/src/lib.rs
+++ b/services/root-keys/src/lib.rs
@@ -9,11 +9,11 @@ pub mod key2bits;
 use std::convert::TryInto;
 
 pub use cipher::{
-    consts::U16, generic_array::GenericArray, inout::InOut, BlockBackend, BlockCipher, BlockClosure,
-    BlockDecrypt, BlockEncrypt, BlockSizeUser, ParBlocksSizeUser,
+    BlockBackend, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, ParBlocksSizeUser,
+    consts::U16, generic_array::GenericArray, inout::InOut,
 };
 use num_traits::*;
-use xous::{send_message, Message, CID};
+use xous::{CID, Message, send_message};
 use xous_ipc::Buffer;
 use xous_semver::SemVer;
 pub(crate) type BatchBlocks = GenericArray<Block, U16>;
@@ -658,13 +658,10 @@ mod tests {
 
         crate::bcrypt::bcrypt(5, &salt, pw, &mut output);
 
-        assert_eq!(
-            output,
-            [
-                22, 80, 102, 192, 193, 204, 118, 167, 41, 102, 241, 75, 103, 49, 4, 245, 194, 145, 85, 104,
-                179, 60, 88, 53
-            ]
-        );
+        assert_eq!(output, [
+            22, 80, 102, 192, 193, 204, 118, 167, 41, 102, 241, 75, 103, 49, 4, 245, 194, 145, 85, 104, 179,
+            60, 88, 53
+        ]);
     }
 
     #[test]
@@ -673,13 +670,10 @@ mod tests {
         let mut output: [u8; 24] = [0; 24];
         let pw = "this is a test of a very long password that is exactly 72 characters lon";
         crate::bcrypt::bcrypt(10, &salt, pw, &mut output);
-        assert_eq!(
-            output,
-            [
-                46, 39, 41, 217, 39, 103, 62, 189, 120, 3, 248, 84, 175, 40, 134, 190, 76, 43, 232, 147, 129,
-                237, 116, 61
-            ]
-        );
+        assert_eq!(output, [
+            46, 39, 41, 217, 39, 103, 62, 189, 120, 3, 248, 84, 175, 40, 134, 190, 76, 43, 232, 147, 129,
+            237, 116, 61
+        ]);
     }
 
     #[test]
@@ -688,12 +682,9 @@ mod tests {
         let mut output: [u8; 24] = [0; 24];
         let pw = "this is a test of a very long password that is exactly 72 characters long, but this one is even longer";
         crate::bcrypt::bcrypt(10, &salt, pw, &mut output);
-        assert_eq!(
-            output,
-            [
-                46, 39, 41, 217, 39, 103, 62, 189, 120, 3, 248, 84, 175, 40, 134, 190, 76, 43, 232, 147, 129,
-                237, 116, 61
-            ]
-        );
+        assert_eq!(output, [
+            46, 39, 41, 217, 39, 103, 62, 189, 120, 3, 248, 84, 175, 40, 134, 190, 76, 43, 232, 147, 129,
+            237, 116, 61
+        ]);
     }
 }

--- a/services/root-keys/src/main.rs
+++ b/services/root-keys/src/main.rs
@@ -97,8 +97,8 @@ pub struct MetadataInFlash {
 mod implementation {
     use std::convert::TryInto;
 
-    use aes::cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, KeyInit};
     use aes::Aes256;
+    use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit, generic_array::GenericArray};
     use ed25519_dalek::VerifyingKey;
     use gam::modal::{Modal, Slider};
     use gam::{ActionType, ProgressBar};
@@ -106,11 +106,11 @@ mod implementation {
     use num_traits::*;
     use xous_semver::SemVer;
 
-    use crate::api::*;
-    use crate::backups;
     use crate::PasswordRetentionPolicy;
     use crate::PasswordType;
     use crate::UpdateType;
+    use crate::api::*;
+    use crate::backups;
     use crate::{GatewareRegion, MetadataInFlash, SignatureResult};
 
     #[derive(Debug, Copy, Clone)]

--- a/services/root-keys/src/sha512_digest.rs
+++ b/services/root-keys/src/sha512_digest.rs
@@ -1,13 +1,13 @@
 use core::fmt;
 
 use digest::{
+    FixedOutput, HashMarker, InvalidOutputSize, Output, Update,
     block_buffer::Eager,
     core_api::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, OutputSizeUser, TruncSide, UpdateCore,
         VariableOutputCore,
     },
-    typenum::{U128, U64},
-    FixedOutput, HashMarker, InvalidOutputSize, Output, Update,
+    typenum::{U64, U128},
 };
 
 /// Wrap a pre-hash value in a Digest trait

--- a/services/shellchat/src/cmds/aes_cmd.rs
+++ b/services/shellchat/src/cmds/aes_cmd.rs
@@ -8,7 +8,7 @@ macro_rules! block_cipher_test {
     ($name:ident, $test_name:expr, $test_case_name:ident, $cipher:ty) => {
         fn $name() -> String<1024> {
             use aes::cipher::{
-                consts::U16, generic_array::GenericArray, BlockDecryptMut, BlockEncryptMut, KeyInit,
+                BlockDecryptMut, BlockEncryptMut, KeyInit, consts::U16, generic_array::GenericArray,
             };
 
             fn run_test(key: &[u8], pt: &[u8], ct: &[u8]) -> (bool, GenericArray<u8, U16>) {

--- a/services/shellchat/src/cmds/net_cmd.rs
+++ b/services/shellchat/src/cmds/net_cmd.rs
@@ -19,7 +19,7 @@ use {gam::DecodePng, std::str::FromStr};
 #[cfg(feature = "websocket")]
 use {
     tls::Tls,
-    tungstenite::{stream::MaybeTlsStream, WebSocket},
+    tungstenite::{WebSocket, stream::MaybeTlsStream},
 };
 
 use crate::{CommonEnv, ShellCmdApi};
@@ -645,9 +645,9 @@ impl<'a> ShellCmdApi<'a> for NetCmd {
                     // this starts the performance counter
                     pm.start();
 
+                    use aes::Aes256;
                     use aes::cipher::generic_array::GenericArray;
                     use aes::cipher::{BlockEncrypt, KeyInit};
-                    use aes::Aes256;
 
                     let mut key_array: [u8; 32];
                     let mut data_array: [u8; 16];

--- a/services/shellchat/src/cmds/pddb_cmd.rs
+++ b/services/shellchat/src/cmds/pddb_cmd.rs
@@ -1330,10 +1330,9 @@ impl<'a> ShellCmdApi<'a> for PddbCmd {
                 #[cfg(not(target_os = "xous"))]
                 "rkyvtest" => {
                     use rkyv::{
-                        archived_value,
+                        AlignedVec, Deserialize, archived_value,
                         de::deserializers::AllocDeserializer,
-                        ser::{serializers::WriteSerializer, Serializer},
-                        AlignedVec, Deserialize,
+                        ser::{Serializer, serializers::WriteSerializer},
                     };
                     let test = pddb::PddbKeyRecord {
                         name: "test".to_string(),

--- a/services/shellchat/src/cmds/test.rs
+++ b/services/shellchat/src/cmds/test.rs
@@ -178,8 +178,8 @@ impl<'a> ShellCmdApi<'a> for Test {
                 "frob" => {
                     const N: u32 = 10;
                     const M: usize = if cfg!(miri) { 10000 } else { 100000 };
-                    use std::sync::mpsc::channel;
                     use std::sync::RwLock;
+                    use std::sync::mpsc::channel;
                     use std::thread;
 
                     use rand::Rng;

--- a/services/shellchat/src/cmds/trng_cmd.rs
+++ b/services/shellchat/src/cmds/trng_cmd.rs
@@ -87,8 +87,8 @@ impl<'a> ShellCmdApi<'a> for TrngCmd {
                 "api" => {
                     // the purpose of these tests is to check the edge-case code because
                     // the trng fetch is u32, but rand_core allows u8
-                    use rand::rngs::OsRng;
                     use rand::RngCore;
+                    use rand::rngs::OsRng;
                     let mut test1 = [0u8; 1];
                     OsRng.fill_bytes(&mut test1);
                     log::info!("test 1: {:?}", test1);

--- a/services/shellchat/src/main.rs
+++ b/services/shellchat/src/main.rs
@@ -289,11 +289,11 @@ impl Repl {
         self.gam
             .draw_rectangle(
                 self.content,
-                Rectangle::new_with_style(
-                    Point::new(0, 0),
-                    self.screensize,
-                    DrawStyle { fill_color: Some(PixelColor::Light), stroke_color: None, stroke_width: 0 },
-                ),
+                Rectangle::new_with_style(Point::new(0, 0), self.screensize, DrawStyle {
+                    fill_color: Some(PixelColor::Light),
+                    stroke_color: None,
+                    stroke_width: 0,
+                }),
             )
             .expect("can't clear content area");
     }

--- a/services/spinor/src/lib.rs
+++ b/services/spinor/src/lib.rs
@@ -15,7 +15,7 @@ lazy_static! {
 pub mod api;
 pub use api::*;
 use num_traits::*;
-use xous::{send_message, Message, CID};
+use xous::{CID, Message, send_message};
 use xous_ipc::Buffer;
 
 #[derive(Debug)]

--- a/services/status/src/appmenu.rs
+++ b/services/status/src/appmenu.rs
@@ -2,7 +2,7 @@ use gam::*;
 use locales::t;
 use num_traits::*;
 
-use crate::{app_autogen, StatusOpcode};
+use crate::{StatusOpcode, app_autogen};
 
 pub fn create_app_menu(status_conn: xous::CID) {
     let mut menu_items = Vec::<MenuItem>::new();

--- a/services/status/src/main.rs
+++ b/services/status/src/main.rs
@@ -21,16 +21,16 @@ use std::thread;
 
 use chrono::prelude::*;
 use com::api::*;
-use crossbeam::channel::{at, select, unbounded, Receiver, Sender};
+use crossbeam::channel::{Receiver, Sender, at, select, unbounded};
 use gam::{GamObjectList, GamObjectType};
 use graphics_server::api::GlyphStyle;
 use graphics_server::*;
 use locales::t;
 use num_traits::*;
 use root_keys::api::{BackupKeyboardLayout, BackupOp};
-use xous::{msg_scalar_unpack, send_message, Message, CID};
+use xous::{CID, Message, msg_scalar_unpack, send_message};
 
-use crate::preferences::{percentage_to_db, PrefsMenuUpdateOp};
+use crate::preferences::{PrefsMenuUpdateOp, percentage_to_db};
 
 const SERVER_NAME_STATUS_GID: &str = "_Status bar GID receiver_";
 const SERVER_NAME_STATUS: &str = "_Status_";

--- a/services/trng/src/lib.rs
+++ b/services/trng/src/lib.rs
@@ -1,11 +1,11 @@
 #![cfg_attr(target_os = "none", no_std)]
 
 pub mod api;
-use api::{TrngTestMode, TRNG_TEST_BUF_LEN};
+use api::{TRNG_TEST_BUF_LEN, TrngTestMode};
 use num_traits::*;
 // the 0.5.1 API is necessary for compatibility with curve25519-dalek crates
 use rand_core::{CryptoRng, RngCore};
-use xous::{send_message, CID};
+use xous::{CID, send_message};
 use xous_ipc::Buffer;
 
 #[derive(Debug)]

--- a/services/trng/src/main.rs
+++ b/services/trng/src/main.rs
@@ -24,11 +24,11 @@ mod implementation {
     use susres::{RegManager, RegOrField, SuspendResume};
     use utralib::generated::*;
 
-    use crate::api::{
-        ExcursionTest, HealthTests, MiniRunsTest, NistTests, TrngBuf, TrngErrors, TrngTestBuf, TrngTestMode,
-        TRNG_TEST_BUF_LEN,
-    };
     use crate::TEST_CACHE_LEN;
+    use crate::api::{
+        ExcursionTest, HealthTests, MiniRunsTest, NistTests, TRNG_TEST_BUF_LEN, TrngBuf, TrngErrors,
+        TrngTestBuf, TrngTestMode,
+    };
 
     pub struct Trng {
         csr: utralib::CSR<u32>,
@@ -520,11 +520,11 @@ mod implementation {
 // a stub to try to avoid breaking hosted mode for as long as possible.
 #[cfg(not(target_os = "xous"))]
 mod implementation {
+    use rand_chacha::ChaCha8Rng;
     use rand_chacha::rand_core::RngCore;
     use rand_chacha::rand_core::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
-    use crate::api::{HealthTests, TrngBuf, TrngErrors, TrngTestBuf, TrngTestMode, TRNG_TEST_BUF_LEN};
+    use crate::api::{HealthTests, TRNG_TEST_BUF_LEN, TrngBuf, TrngErrors, TrngTestBuf, TrngTestMode};
 
     pub struct Trng {
         rng: ChaCha8Rng,

--- a/services/tts/src/lib.rs
+++ b/services/tts/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod api;
 pub use api::*;
 use num_traits::ToPrimitive;
-use xous::{send_message, Message, CID};
+use xous::{CID, Message, send_message};
 use xous_ipc::Buffer;
 
 #[derive(Debug)]

--- a/services/tts/src/main.rs
+++ b/services/tts/src/main.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use api::*;
 use codec::{FrameRing, VolumeOps, ZERO_PCM};
 use num_traits::*;
-use xous::{msg_scalar_unpack, send_message, Message};
+use xous::{Message, msg_scalar_unpack, send_message};
 use xous_ipc::Buffer;
 use xous_tts_backend::*;
 

--- a/services/usb-device-xous/src/hid.rs
+++ b/services/usb-device-xous/src/hid.rs
@@ -5,19 +5,19 @@ use frunk_core::hlist::{HCons, HNil};
 use fugit::ExtU32;
 use usb_device::device::UsbDeviceBuilder;
 use usb_device::{
+    UsbError,
     class_prelude::{UsbBus, UsbBusAllocator},
     device::{UsbDevice, UsbVidPid},
-    UsbError,
 };
 use usb_device_xous::UsbDeviceState;
 use xous_usb_hid::{
+    UsbHidError,
     device::DeviceClass,
     interface::{
         HeapInterface, HeapInterfaceBuilder, HeapInterfaceConfig, InBytes64, OutBytes64, ReportSingle,
         UsbAllocatable,
     },
     usb_class::{UsbHidClass, UsbHidClassBuilder},
-    UsbHidError,
 };
 
 use crate::api::HIDReport;

--- a/services/usb-device-xous/src/hw.rs
+++ b/services/usb-device-xous/src/hw.rs
@@ -7,7 +7,7 @@ use std::convert::TryInto;
 use std::sync::{Arc, Mutex};
 
 use usb_device::bus::PollResult;
-use usb_device::{class_prelude::*, Result, UsbDirection};
+use usb_device::{Result, UsbDirection, class_prelude::*};
 use utralib::generated::*;
 use xous::MemoryRange;
 

--- a/services/usb-device-xous/src/lib.rs
+++ b/services/usb-device-xous/src/lib.rs
@@ -9,7 +9,7 @@ use num_traits::*;
 use packed_struct::PackedStruct;
 use trng::api::TrngTestMode;
 pub use usb_device::device::UsbDeviceState;
-use xous::{send_message, Message, CID};
+use xous::{CID, Message, send_message};
 use xous_ipc::Buffer;
 pub use xous_usb_hid::device::fido::RawFidoReport;
 pub use xous_usb_hid::device::keyboard::KeyboardLedsReport;

--- a/services/usb-device-xous/src/main.rs
+++ b/services/usb-device-xous/src/main.rs
@@ -97,9 +97,9 @@ mod tests {
     use super::*;
     #[test]
     fn test_alloc() {
+        use rand_chacha::ChaCha8Rng;
         use rand_chacha::rand_core::RngCore;
         use rand_chacha::rand_core::SeedableRng;
-        use rand_chacha::ChaCha8Rng;
         let mut rng = ChaCha8Rng::seed_from_u64(0);
 
         let mut allocs = BTreeMap::<u32, u32>::new();

--- a/services/usb-device-xous/src/main_hw.rs
+++ b/services/usb-device-xous/src/main_hw.rs
@@ -21,19 +21,19 @@ use usb_device::prelude::*;
 use usb_device_xous::KeyboardLedsReport;
 use usb_device_xous::UsbDeviceType;
 use usbd_serial::SerialPort;
-#[cfg(any(feature = "precursor", feature = "renode"))]
-use utralib::generated::*;
 #[cfg(feature = "cramium-soc")]
 use utralib::AtomicCsr;
+#[cfg(any(feature = "precursor", feature = "renode"))]
+use utralib::generated::*;
 use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack};
 use xous_ipc::Buffer;
 #[cfg(all(not(feature = "minimal"), any(feature = "precursor", feature = "renode")))]
 use xous_semver::SemVer;
+use xous_usb_hid::device::DeviceClass;
 use xous_usb_hid::device::fido::RawFido;
 use xous_usb_hid::device::fido::RawFidoConfig;
 use xous_usb_hid::device::fido::RawFidoReport;
 use xous_usb_hid::device::keyboard::{NKROBootKeyboard, NKROBootKeyboardConfig};
-use xous_usb_hid::device::DeviceClass;
 use xous_usb_hid::page::Keyboard;
 use xous_usb_hid::prelude::*;
 

--- a/services/usb-test/src/hw.rs
+++ b/services/usb-test/src/hw.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use susres::{ManagedMem, SuspendResume};
 use usb_device::bus::PollResult;
-use usb_device::{class_prelude::*, Result, UsbDirection};
+use usb_device::{Result, UsbDirection, class_prelude::*};
 use utralib::generated::*;
 
 use crate::*;

--- a/services/usb-test/src/main.rs
+++ b/services/usb-test/src/main.rs
@@ -26,7 +26,7 @@ use hosted::*;
 use num_traits::*;
 use usb_device::class_prelude::*;
 use usb_device::prelude::*;
-use xous::{msg_scalar_unpack, send_message, Message, CID};
+use xous::{CID, Message, msg_scalar_unpack, send_message};
 use xous_usb_hid::device::keyboard::NKROBootKeyboard;
 use xous_usb_hid::page::Keyboard;
 use xous_usb_hid::prelude::*;
@@ -267,9 +267,9 @@ mod tests {
     use super::*;
     #[test]
     fn test_alloc() {
+        use rand_chacha::ChaCha8Rng;
         use rand_chacha::rand_core::RngCore;
         use rand_chacha::rand_core::SeedableRng;
-        use rand_chacha::ChaCha8Rng;
         let mut rng = ChaCha8Rng::seed_from_u64(0);
 
         let mut allocs = BTreeMap::<u32, u32>::new();

--- a/services/xous-log/src/platform/atsama5d2/console.rs
+++ b/services/xous-log/src/platform/atsama5d2/console.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::{Error, Write};
 
-use atsama5d27::uart::{Uart as UartHw, Uart1, UART_BASE_ADDRESS};
+use atsama5d27::uart::{UART_BASE_ADDRESS, Uart as UartHw, Uart1};
 #[cfg(feature = "lcd-console")]
 use atsama5d27::{console::DisplayAndUartConsole, display::FramebufDisplay, lcdc::Lcdc};
 #[cfg(feature = "lcd-console")]

--- a/services/xous-log/src/platform/hosted/implementation.rs
+++ b/services/xous-log/src/platform/hosted/implementation.rs
@@ -1,5 +1,5 @@
 use core::fmt::{Error, Write};
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::{Receiver, Sender, channel};
 
 enum ControlMessage {
     Text(String),

--- a/services/xous-names/src/main.rs
+++ b/services/xous-names/src/main.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use log::{error, info};
 use num_traits::FromPrimitive;
-use xous::{msg_blocking_scalar_unpack, MessageEnvelope};
+use xous::{MessageEnvelope, msg_blocking_scalar_unpack};
 use xous_api_names::api::*;
 use xous_api_names::*;
 use xous_ipc::{Buffer, String};
@@ -135,17 +135,14 @@ impl CheckedHashMap {
                     .expect("couldn't create token")
                     .to_array(),
             );
-        self.map.insert(
-            name,
-            Connection {
-                sid,
-                current_conns: 0,
-                max_conns,
-                _allow_authenticate: false, // for now, we don't support authenticated connections
-                _auth_conns: 0,
-                token,
-            },
-        );
+        self.map.insert(name, Connection {
+            sid,
+            current_conns: 0,
+            max_conns,
+            _allow_authenticate: false, // for now, we don't support authenticated connections
+            _auth_conns: 0,
+            token,
+        });
         Ok(())
     }
 

--- a/services/xous-susres/src/main.rs
+++ b/services/xous-susres/src/main.rs
@@ -8,7 +8,7 @@ use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use num_traits::{FromPrimitive, ToPrimitive};
 use xous::messages::sender::Sender;
-use xous::{msg_blocking_scalar_unpack, msg_scalar_unpack, send_message, Message, CID};
+use xous::{CID, Message, msg_blocking_scalar_unpack, msg_scalar_unpack, send_message};
 use xous_api_susres::*;
 use xous_ipc::Buffer;
 
@@ -31,8 +31,8 @@ mod implementation {
     use num_traits::ToPrimitive;
     use utralib::generated::*;
 
-    use crate::murmur3::murmur3_32;
     use crate::SHOULD_RESUME;
+    use crate::murmur3::murmur3_32;
 
     const SYSTEM_CLOCK_FREQUENCY: u32 = 12_000_000; // timer0 is now in the always-on domain
     const SYSTEM_TICK_INTERVAL_MS: u32 = xous::BASE_QUANTA_MS;

--- a/services/xous-swapper/src/main.rs
+++ b/services/xous-swapper/src/main.rs
@@ -55,10 +55,10 @@ use std::collections::BinaryHeap;
 use std::fmt::Debug;
 
 use debug::*;
-use loader::swap::{SwapAlloc, SwapSpec, SWAP_CFG_VADDR, SWAP_COUNT_VADDR, SWAP_PT_VADDR, SWAP_RPT_VADDR};
+use loader::swap::{SWAP_CFG_VADDR, SWAP_COUNT_VADDR, SWAP_PT_VADDR, SWAP_RPT_VADDR, SwapAlloc, SwapSpec};
 use num_traits::*;
-use platform::{SwapHal, PAGE_SIZE};
-use xous::{MemoryFlags, MemoryRange, Result, PID};
+use platform::{PAGE_SIZE, SwapHal};
+use xous::{MemoryFlags, MemoryRange, PID, Result};
 use xous_swapper::Opcode;
 
 /// Target of pages to free in case of a Hard OOM. Note that the PAGE_TARGET numbers

--- a/services/xous-swapper/src/platform/cramium/hw.rs
+++ b/services/xous-swapper/src/platform/cramium/hw.rs
@@ -4,7 +4,7 @@ use core::mem::size_of;
 use aes_gcm_siv::{AeadInPlace, Aes256GcmSiv, Error, KeyInit, Nonce, Tag};
 use cramium_hal::ifram::IframRange;
 use cramium_hal::udma::*;
-use loader::swap::{SwapSpec, SPIM_RAM_IFRAM_ADDR, SWAP_HAL_VADDR};
+use loader::swap::{SPIM_RAM_IFRAM_ADDR, SWAP_HAL_VADDR, SwapSpec};
 
 use crate::debug::*;
 

--- a/services/xous-swapper/src/platform/precursor/hw.rs
+++ b/services/xous-swapper/src/platform/precursor/hw.rs
@@ -2,7 +2,7 @@ use core::mem::size_of;
 use std::fmt::Write;
 
 use aes_gcm_siv::{AeadInPlace, Aes256GcmSiv, Error, KeyInit, Nonce, Tag};
-use loader::swap::{SwapSpec, SWAP_HAL_VADDR};
+use loader::swap::{SWAP_HAL_VADDR, SwapSpec};
 
 use crate::debug::DebugUart;
 

--- a/svd2repl/src/generate.rs
+++ b/svd2repl/src/generate.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 
+use quick_xml::Reader;
 use quick_xml::events::Event;
 use quick_xml::name::QName;
-use quick_xml::Reader;
 
 #[derive(Debug)]
 pub enum ParseError {

--- a/svd2utra/src/generate.rs
+++ b/svd2utra/src/generate.rs
@@ -4,7 +4,7 @@
 
 use std::io::{BufRead, BufReader, Read, Write};
 
-use quick_xml::events::{attributes::Attribute, Event};
+use quick_xml::events::{Event, attributes::Attribute};
 use quick_xml::name::QName;
 use quick_xml::reader::Reader;
 

--- a/tools/src/bin/create-image.rs
+++ b/tools/src/bin/create-image.rs
@@ -260,21 +260,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     ((csr_top - region.base) & !(PAGE_SIZE - 1)) + PAGE_SIZE
                 } + PAGE_SIZE;
-                map.insert(
-                    region.name.to_lowercase(),
-                    tools::utils::CsrMemoryRegion {
-                        start: region.base.try_into().unwrap(),
-                        length: length.try_into().unwrap(),
-                    },
-                );
+                map.insert(region.name.to_lowercase(), tools::utils::CsrMemoryRegion {
+                    start: region.base.try_into().unwrap(),
+                    length: length.try_into().unwrap(),
+                });
             } else {
-                map.insert(
-                    region.name.to_lowercase(),
-                    tools::utils::CsrMemoryRegion {
-                        start: region.base.try_into().unwrap(),
-                        length: region.size.try_into().unwrap(),
-                    },
-                );
+                map.insert(region.name.to_lowercase(), tools::utils::CsrMemoryRegion {
+                    start: region.base.try_into().unwrap(),
+                    length: region.size.try_into().unwrap(),
+                });
             }
         }
         // insert additional regions from core.svd, if specified
@@ -302,13 +296,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         break;
                     }
                     println!("{}: {:x}", region.name, region.base);
-                    map.insert(
-                        region.name.to_lowercase(),
-                        tools::utils::CsrMemoryRegion {
-                            start: region.base.try_into().unwrap(),
-                            length: region.size.try_into().unwrap(),
-                        },
-                    );
+                    map.insert(region.name.to_lowercase(), tools::utils::CsrMemoryRegion {
+                        start: region.base.try_into().unwrap(),
+                        length: region.size.try_into().unwrap(),
+                    });
                 }
             }
         }

--- a/tools/src/bin/make-renode-boot.rs
+++ b/tools/src/bin/make-renode-boot.rs
@@ -90,21 +90,15 @@ fn create_image(init_programs: &[String]) -> std::io::Result<Vec<u8>> {
             } else {
                 ((csr_top - region.base) & !(PAGE_SIZE - 1)) + PAGE_SIZE
             } + PAGE_SIZE;
-            map.insert(
-                region.name.to_lowercase(),
-                tools::utils::CsrMemoryRegion {
-                    start: region.base.try_into().unwrap(),
-                    length: length.try_into().unwrap(),
-                },
-            );
+            map.insert(region.name.to_lowercase(), tools::utils::CsrMemoryRegion {
+                start: region.base.try_into().unwrap(),
+                length: length.try_into().unwrap(),
+            });
         } else {
-            map.insert(
-                region.name.to_lowercase(),
-                tools::utils::CsrMemoryRegion {
-                    start: region.base.try_into().unwrap(),
-                    length: region.size.try_into().unwrap(),
-                },
-            );
+            map.insert(region.name.to_lowercase(), tools::utils::CsrMemoryRegion {
+                start: region.base.try_into().unwrap(),
+                length: region.size.try_into().unwrap(),
+            });
         }
     }
     csr_to_config(tools::utils::CsrConfig { regions: map }, &mut ram_config);

--- a/tools/src/bin/read-tags.rs
+++ b/tools/src/bin/read-tags.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::process;
 use std::slice;
 
-use crc::{crc16, Hasher16};
+use crc::{Hasher16, crc16};
 
 fn read_u32_from_ptr(p: *const u8) -> u32 {
     let sl = unsafe { slice::from_raw_parts(p, 4) };

--- a/tools/src/bin/sign-image.rs
+++ b/tools/src/bin/sign-image.rs
@@ -1,6 +1,6 @@
 use std::io::{Error, ErrorKind};
 
-use clap::{crate_version, App, Arg};
+use clap::{App, Arg, crate_version};
 use tools::sign_image::{load_pem, sign_file};
 
 const DEVKEY_PATH: &str = "devkey/dev.key";

--- a/tools/src/elf.rs
+++ b/tools/src/elf.rs
@@ -5,11 +5,11 @@ use std::path::Path;
 
 use bitflags::bitflags;
 use log::debug;
+use xmas_elf::ElfFile;
 use xmas_elf::program::Type as ProgramType;
 use xmas_elf::sections::ShType;
 // Normal ELF flags
 use xmas_elf::sections::{SHF_ALLOC, SHF_EXECINSTR, SHF_WRITE};
-use xmas_elf::ElfFile;
 
 bitflags! {
     pub struct MiniElfFlags: u8 {

--- a/tools/src/sign_image.rs
+++ b/tools/src/sign_image.rs
@@ -2,8 +2,8 @@ use std::io::{Read, Write};
 use std::path::Path;
 
 use ed25519_dalek::{DigestSigner, SigningKey};
-use pkcs8::der::Decodable;
 use pkcs8::PrivateKeyInfo;
+use pkcs8::der::Decodable;
 use ring::signature::Ed25519KeyPair;
 use sha2::{Digest, Sha512};
 

--- a/tools/src/swap_writer.rs
+++ b/tools/src/swap_writer.rs
@@ -3,8 +3,8 @@ use std::io::{Cursor, Result, Seek, SeekFrom, Write};
 use std::process::Command;
 
 use aes_gcm_siv::{
-    aead::{Aead, KeyInit, Payload},
     Aes256GcmSiv, Nonce,
+    aead::{Aead, KeyInit, Payload},
 };
 
 const SWAP_VERSION: u32 = 0x01_01_0000;

--- a/tools/src/utils.rs
+++ b/tools/src/utils.rs
@@ -85,10 +85,10 @@ pub fn parse_csr_csv(filename: &str) -> Result<CsrConfig, ConfigError> {
                     if region_name == "csr" {
                         csr_base = base_addr;
                     } else {
-                        map.insert(
-                            region_name.to_string().to_lowercase(),
-                            CsrMemoryRegion { start: base_addr, length },
-                        );
+                        map.insert(region_name.to_string().to_lowercase(), CsrMemoryRegion {
+                            start: base_addr,
+                            length,
+                        });
                     }
                 }
                 _ => (),

--- a/tools/src/xous_arguments.rs
+++ b/tools/src/xous_arguments.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::io::{Cursor, Result, Seek, Write};
 pub type XousArgumentCode = u32;
 pub type XousSize = u32;
-use crc::{crc16, Hasher16};
+use crc::{Hasher16, crc16};
 
 #[macro_export]
 macro_rules! make_type {

--- a/tools/wycheproof-import/src/main.rs
+++ b/tools/wycheproof-import/src/main.rs
@@ -4,7 +4,7 @@ use std::ops::AddAssign;
 use std::path::Path;
 use std::process::exit;
 
-use eyre::{bail, Result, WrapErr};
+use eyre::{Result, WrapErr, bail};
 use serde::Deserialize;
 
 #[derive(Deserialize)]

--- a/xous-ipc/src/buffer.rs
+++ b/xous-ipc/src/buffer.rs
@@ -1,9 +1,9 @@
 use core::convert::TryInto;
 
-use rkyv::{ser::Serializer, Fallible};
+use rkyv::{Fallible, ser::Serializer};
 use xous::{
-    map_memory, send_message, unmap_memory, Error, MemoryAddress, MemoryFlags, MemoryMessage, MemoryRange,
-    MemorySize, Message, Result, CID,
+    CID, Error, MemoryAddress, MemoryFlags, MemoryMessage, MemoryRange, MemorySize, Message, Result,
+    map_memory, send_message, unmap_memory,
 };
 
 #[derive(Debug)]

--- a/xous-ipc/src/string.rs
+++ b/xous-ipc/src/string.rs
@@ -1,10 +1,10 @@
 use core::pin::Pin;
 
-use rkyv::archived_value;
-use rkyv::ser::Serializer;
 use rkyv::ArchiveUnsized;
 use rkyv::SerializeUnsized;
-use xous::{Error, MemoryMessage, Result, CID};
+use rkyv::archived_value;
+use rkyv::ser::Serializer;
+use xous::{CID, Error, MemoryMessage, Result};
 
 #[derive(Copy, Clone)]
 pub struct String<const N: usize> {

--- a/xous-rs/src/arch/arm/mod.rs
+++ b/xous-rs/src/arch/arm/mod.rs
@@ -1,8 +1,8 @@
-use crate::definitions::SysCallResult;
 use crate::MemoryAddress;
 use crate::MemoryFlags;
 use crate::MemoryRange;
 use crate::TID;
+use crate::definitions::SysCallResult;
 
 pub mod irq;
 mod syscall;

--- a/xous-rs/src/arch/hosted/mem.rs
+++ b/xous-rs/src/arch/hosted/mem.rs
@@ -2,7 +2,7 @@ use crate::{Error, MemoryAddress, MemoryFlags, MemoryRange};
 const PAGE_SIZE: usize = 4096;
 
 extern crate alloc;
-use alloc::alloc::{alloc, dealloc, Layout};
+use alloc::alloc::{Layout, alloc, dealloc};
 
 pub fn map_memory_pre(
     _phys: &Option<MemoryAddress>,

--- a/xous-rs/src/arch/test/mem.rs
+++ b/xous-rs/src/arch/test/mem.rs
@@ -1,7 +1,7 @@
 use crate::{Error, MemoryAddress, MemoryFlags, MemoryRange};
 
 extern crate alloc;
-use alloc::alloc::{alloc, dealloc, Layout};
+use alloc::alloc::{Layout, alloc, dealloc};
 
 pub fn map_memory_pre(
     _phys: &Option<MemoryAddress>,

--- a/xous-rs/src/arch/test/mod.rs
+++ b/xous-rs/src/arch/test/mod.rs
@@ -7,7 +7,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream, ToSocketAddrs};
 use std::sync::{Arc, Mutex};
 use std::thread_local;
 
-use crate::{Result, SysCall, SysCallResult, PID, TID};
+use crate::{PID, Result, SysCall, SysCallResult, TID};
 
 mod mem;
 pub use mem::*;

--- a/xous-rs/src/carton.rs
+++ b/xous-rs/src/carton.rs
@@ -1,7 +1,7 @@
 //! A Carton is an object that wraps another object for shipping across the kernel
 //! boundary. Structs that are stored in Cartons can be sent as messages.
 
-use crate::{Error, MemoryMessage, MemoryRange, Message, CID};
+use crate::{CID, Error, MemoryMessage, MemoryRange, Message};
 
 #[derive(Debug)]
 pub struct Carton<'a> {

--- a/xous-rs/src/stringbuffer.rs
+++ b/xous-rs/src/stringbuffer.rs
@@ -1,6 +1,6 @@
 use crate::{
-    map_memory, send_message, unmap_memory, Error, MemoryMessage, MemoryRange, MemorySize, Message, Result,
-    CID,
+    CID, Error, MemoryMessage, MemoryRange, MemorySize, Message, Result, map_memory, send_message,
+    unmap_memory,
 };
 
 /// A buffered String suitable for sending across as a message

--- a/xous-rs/src/syscall.rs
+++ b/xous-rs/src/syscall.rs
@@ -8,9 +8,9 @@ use crate::Exception
 #[cfg(feature = "processes-as-threads")]
 pub use crate::arch::ProcessArgsAsThread;
 use crate::{
-    pid_from_usize, CpuID, Error, MemoryAddress, MemoryFlags, MemoryMessage, MemoryRange, MemorySize,
-    MemoryType, Message, MessageEnvelope, MessageSender, ProcessArgs, ProcessInit, Result, ScalarMessage,
-    SysCallResult, ThreadInit, CID, PID, SID, TID,
+    CID, CpuID, Error, MemoryAddress, MemoryFlags, MemoryMessage, MemoryRange, MemorySize, MemoryType,
+    Message, MessageEnvelope, MessageSender, PID, ProcessArgs, ProcessInit, Result, SID, ScalarMessage,
+    SysCallResult, TID, ThreadInit, pid_from_usize,
 };
 
 #[derive(Debug, PartialEq)]

--- a/xtask/src/builder.rs
+++ b/xtask/src/builder.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use crate::{app_manifest::generate_app_menus, DynError};
+use crate::{DynError, app_manifest::generate_app_menus};
 
 #[allow(dead_code)]
 #[derive(Copy, Clone, Debug)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -70,46 +70,40 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ]
     .to_vec();
     // minimal set of packages to do bare-iron graphical I/O
-    let gfx_base_pkgs = [
-        &base_pkgs[..],
-        &[
-            "graphics-server", // raw (unprotected) frame buffer primitives
-            "early_settings",  // required by keyboard
-            "keyboard",        // required by graphics-server
-            "spinor",          // required by keyboard - to save key mapping
-            "llio",            // required by spinor
-        ],
-    ]
+    let gfx_base_pkgs = [&base_pkgs[..], &[
+        "graphics-server", // raw (unprotected) frame buffer primitives
+        "early_settings",  // required by keyboard
+        "keyboard",        // required by graphics-server
+        "spinor",          // required by keyboard - to save key mapping
+        "llio",            // required by spinor
+    ]]
     .concat();
     // packages in the user image - most of the services at this layer have cross-dependencies
-    let user_pkgs = [
-        &gfx_base_pkgs[..],
-        &[
-            // net services
-            "com",
-            "net",
-            "dns",
-            // UX abstractions
-            "gam",
-            "ime-frontend",
-            "ime-plugin-shell",
-            "codec",
-            "modals",
-            // security
-            "root-keys",
-            "trng",
-            "sha2",
-            // "engine-25519",
-            "jtag",
-            // GUI front end
-            "status",
-            "shellchat",
-            // filesystem
-            "pddb",
-            // usb services
-            "usb-device-xous",
-        ],
-    ]
+    let user_pkgs = [&gfx_base_pkgs[..], &[
+        // net services
+        "com",
+        "net",
+        "dns",
+        // UX abstractions
+        "gam",
+        "ime-frontend",
+        "ime-plugin-shell",
+        "codec",
+        "modals",
+        // security
+        "root-keys",
+        "trng",
+        "sha2",
+        // "engine-25519",
+        "jtag",
+        // GUI front end
+        "status",
+        "shellchat",
+        // filesystem
+        "pddb",
+        // usb services
+        "usb-device-xous",
+    ]]
     .concat();
     // for fast testing of compilation targets of the PDDB to real hardware
     let pddb_dev_pkgs = [&base_pkgs[..], &["pddb", "sha2"]].concat();

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -8,8 +8,8 @@ use std::{
 
 use lazy_static::lazy_static;
 
-use crate::{cargo, project_root};
 use crate::{TARGET_TRIPLE_ARM, TARGET_TRIPLE_RISCV32};
+use crate::{cargo, project_root};
 
 const TOOLCHAIN_RELEASE_URL_RISCV32: &str = "https://api.github.com/repos/betrusted-io/rust/releases";
 const TOOLCHAIN_RELEASE_URL_ARM: &str = "https://api.github.com/repos/Foundation-Devices/rust/releases";

--- a/xtask/src/verifier.rs
+++ b/xtask/src/verifier.rs
@@ -4,8 +4,8 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
 
-use crate::builder::CrateSpec;
 use crate::DynError;
+use crate::builder::CrateSpec;
 
 pub fn check_project_consistency() -> Result<(), DynError> {
     // note: implementations no longer published as crates: just APIs as of March 2023


### PR DESCRIPTION
Rust 2024 rules have changed. Since we use the nightly version and use unstable rules, these have changed in the latest version. Mostly with respect to ordering of imports alphabetically.