### PR TITLE
Biobdma timing

### DIFF
--- a/libs/xous-bio-bdma/Cargo.toml
+++ b/libs/xous-bio-bdma/Cargo.toml
@@ -23,6 +23,9 @@ hosted = []
 renode = []
 # may be activated in conjunction with "cramium-soc", "rp2040" targets when not running Xous
 baremetal = []
+std = []
+arty = []
+bio-mul = []
 
 tests = []
 default = ["tests", "cramium-soc"]

--- a/libs/xous-bio-bdma/src/bio_tests/units.rs
+++ b/libs/xous-bio-bdma/src/bio_tests/units.rs
@@ -1032,8 +1032,9 @@ pub fn aclk_tests() -> usize {
         print!("{}: {} cycles\r", i, r);
     }
     assert!(results[1] - results[0] == 3);
-    assert!(results[2] - results[1] == 3);
-    assert!(results[3] - results[2] == 6);
+    // variability is due to option for REGISTER_MEM or not
+    assert!((results[2] - results[1] == 3) || (results[2] - results[1] == 4));
+    assert!((results[3] - results[2] == 6) || (results[3] - results[2] == 7));
     assert!(results[4] - results[3] == 3);
 
     assert!(results[6] - results[5] == 10); // related to the clock divider


### PR DESCRIPTION
some patches for improved BIO block tests and configs. In particular we're including the single-cycle multiplier so that generated code can be rv32-imc target.
