### PR TITLE
revert statics clearing routine

### DIFF
--- a/loader/src/asm.rs
+++ b/loader/src/asm.rs
@@ -15,14 +15,9 @@ pub extern "C" fn _start(_kernel_args: usize, loader_sig: usize) {
     unsafe {
         #[rustfmt::skip]
         asm! (
-            "mv          t0, {ram_base}",
-            "li          t1, 0x10000",
-            "add         t2, t0, t1",
-
-        "900:", // clear 64k base data for statics
-            "sw          x0, 0(t0)",
-            "addi        t0, t0, 4",
-            "bltu        t0, t2, 900b",
+            "li          t0, 0xffffffff",
+            "csrw        mideleg, t0",
+            "csrw        medeleg, t0",
 
             // decorate our stack area with a canary pattern
             "li          t1, 0xACE0BACE",
@@ -37,10 +32,6 @@ pub extern "C" fn _start(_kernel_args: usize, loader_sig: usize) {
             "mv          sp, {ram_top}",
             // subtract four from sp to make room for a DMA "gutter"
             "addi        sp, sp, -4",
-
-            "li          t0, 0xffffffff",
-            "csrw        mideleg, t0",
-            "csrw        medeleg, t0",
 
             // Install a machine mode trap handler
             "la          t0, abort",
@@ -57,7 +48,6 @@ pub extern "C" fn _start(_kernel_args: usize, loader_sig: usize) {
             ram_top = in(reg) (platform::RAM_BASE + platform::RAM_SIZE),
             // On Precursor - 0x40FFE01C: currently allowed stack extent - 8k - (7 words). 7 words are for kernel backup args - see bootloader in betrusted-soc
             stack_limit = in(reg) (platform::RAM_BASE + platform::RAM_SIZE - 8192 + 7 * core::mem::size_of::<usize>()),
-            ram_base = in(reg) (platform::RAM_BASE),
             options(noreturn)
         );
     }


### PR DESCRIPTION
this turns out to be a bad idea because it corrupts systems that have suspend/resume. Revert this commit.

And this is why we have CI.