### PR TITLE
add a test target with limited scope

### DIFF
--- a/libs/cramium-hal/Cargo.toml
+++ b/libs/cramium-hal/Cargo.toml
@@ -39,7 +39,8 @@ board-baosec = [
     "utralib/cramium-soc",
     "ux-api/board-baosec",
 ] # USB form factor token
-loader-baosec = ["camera-ov2640", "display-sh1107", "axp2101", "ux-api"]
+loader-baosec = ["camera-ov2640", "display-sh1107", "axp2101", "ux-api/loader-baosec"]
+test-baosec = ["ux-api/loader-baosec", "camera-ov2640"]
 hosted-baosec = [] # emulated hardware on x86 platform
 board-baosor = [
     "camera-ov2640",

--- a/libs/cramium-hal/src/board/mod.rs
+++ b/libs/cramium-hal/src/board/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(any(feature = "board-baosec", feature = "loader-baosec"))]
+#[cfg(any(feature = "board-baosec", feature = "loader-baosec", feature = "test-baosec"))]
 pub mod baosec;
-#[cfg(any(feature = "board-baosec", feature = "loader-baosec"))]
+#[cfg(any(feature = "board-baosec", feature = "loader-baosec", feature = "test-baosec"))]
 pub use baosec::*;
 #[cfg(any(feature = "board-baosor", feature = "loader-baosor"))]
 pub mod baosor;


### PR DESCRIPTION
this is for SoC testing with i.e. no peripherals or simulated peripherals in a simulated environment