### PR TITLE
base64 should be an optional dependency in std

### DIFF
--- a/libs/ux-api/Cargo.toml
+++ b/libs/ux-api/Cargo.toml
@@ -28,7 +28,7 @@ hex = { version = "0.4.3", default-features = false, features = [
 ], optional = true }
 sha2 = { version = "0.10.8", optional = true }
 digest = { version = "0.9.0", optional = true }
-base64 = "0.5.2"
+base64 = { version = "0.5.2", optional = true }
 
 [features]
 # various feature gates - recommended to be selective about these because
@@ -76,6 +76,7 @@ std = [
     "hex",
     "sha2",
     "digest",
+    "base64",
     "xous-names",
 ]
 default = ["std", "default-widgets"]


### PR DESCRIPTION
otherwise the loader breaks