### PR TITLE
UI cleanup

### DIFF
--- a/libs/blitstr2/src/blit.rs
+++ b/libs/blitstr2/src/blit.rs
@@ -111,10 +111,13 @@ pub fn xor_glyph(fb: &mut FrBuf, p: (isize, isize), gs: &GlyphSprite, xor: bool,
                             0xffff_ffff ^ ((pattern >> px_in_dest_low_word) & partial_mask_hi);
                     }
                 }
+                #[cfg(any(feature = "hosted", feature = "renode", feature = "precursor"))]
+                {
+                    fb[(row_base as usize + WORDS_PER_LINE - 1) as usize] |= 0x1_0000; // set the dirty bit on the line
+                }
             } else {
                 log::trace!("absolute x/y fail");
             }
-            fb[(row_base as usize + WORDS_PER_LINE - 1) as usize] |= 0x1_0000; // set the dirty bit on the line
         } else {
             log::trace!("off the top");
         }
@@ -205,6 +208,10 @@ pub fn xor_glyph_large(fb: &mut FrBuf, p: (isize, isize), gs: &GlyphSprite, xor:
                         fb[(row_base + dest_high_word) as usize] &=
                             0xffff_ffff ^ ((src >> px_in_dest_low_word) & partial_mask_hi);
                     }
+                }
+                #[cfg(any(feature = "hosted", feature = "renode", feature = "precursor"))]
+                {
+                    fb[(row_base as usize + WORDS_PER_LINE - 1) as usize] |= 0x1_0000; // set the dirty bit on the line
                 }
             }
         }
@@ -306,6 +313,10 @@ pub fn xor_glyph_2x(fb: &mut FrBuf, p: (isize, isize), gs: &GlyphSprite, xor: bo
                         fb[(row_base + dest_high_word) as usize] &=
                             0xffff_ffff ^ ((src >> px_in_dest_low_word) & partial_mask_hi);
                     }
+                }
+                #[cfg(any(feature = "hosted", feature = "renode", feature = "precursor"))]
+                {
+                    fb[(row_base as usize + WORDS_PER_LINE - 1) as usize] |= 0x1_0000; // set the dirty bit on the line
                 }
             }
         }

--- a/libs/ux-api/src/minigfx/handlers.rs
+++ b/libs/ux-api/src/minigfx/handlers.rs
@@ -196,7 +196,7 @@ pub fn draw_text_view<T: FrameBuffer>(display: &mut T, msg: &mut xous::envelope:
     if tv.clip_rect.is_none() {
         if cfg!(feature = "hosted-baosec") || cfg!(feature = "cramium-soc") || cfg!(feature = "board-baosec")
         {
-            tv.clip_rect = Some(Rectangle::new(Point::new(0, 0), display.dimensions()));
+            tv.clip_rect = Some(Rectangle::new(Point::new(0, 0), display.dimensions() - Point::new(1, 1)));
         } else {
             return;
         }

--- a/libs/ux-api/src/service/gfx.rs
+++ b/libs/ux-api/src/service/gfx.rs
@@ -721,7 +721,7 @@ impl Gfx {
         let buf = match Buffer::into_buf(list) {
             Ok(b) => b,
             Err(e) => {
-                log::info!("size {}", size);
+                log::info!("Size {} won't fit", size);
                 log::error!("err: {:?}", e);
                 panic!("error")
             }

--- a/libs/ux-api/src/service/gfx.rs
+++ b/libs/ux-api/src/service/gfx.rs
@@ -715,10 +715,13 @@ impl Gfx {
     }
 
     /// V2-only API
-    pub fn draw_object_list(&self, list: ObjectList) -> Result<(), xous::Error> {
+    pub fn draw_object_list(&self, mut list: ObjectList) -> Result<(), xous::Error> {
+        list.list.shrink_to_fit();
+        let size = list.list.capacity() * size_of::<ClipObjectType>() + size_of::<Vec<ClipObjectType>>();
         let buf = match Buffer::into_buf(list) {
             Ok(b) => b,
             Err(e) => {
+                log::info!("size {}", size);
                 log::error!("err: {:?}", e);
                 panic!("error")
             }

--- a/libs/ux-api/src/widgets/modal.rs
+++ b/libs/ux-api/src/widgets/modal.rs
@@ -111,6 +111,7 @@ impl<'a> Modal<'a> {
             self.gfx.clear().unwrap();
         }
         let mut cur_height = self.margin;
+        log::debug!("start {}", cur_height);
         if let Some(mut tv) = self.top_text.as_mut() {
             if do_redraw {
                 self.gfx.draw_textview(&mut tv).expect("couldn't draw text");
@@ -123,7 +124,7 @@ impl<'a> Modal<'a> {
                         y
                     };
                     cur_height += y_clip;
-                    log::trace!("top_tv height: {}", y_clip);
+                    log::debug!("  top_tv height: {}", y_clip);
                     self.top_memoized_height = Some(y_clip);
                 } else {
                     log::warn!("text bounds didn't compute setting to max");
@@ -138,6 +139,7 @@ impl<'a> Modal<'a> {
             self.top_dirty = false;
         }
 
+        log::debug!("  action @ {}", self.line_height);
         let action_height = self.action.height(self.line_height, self.margin, &self);
 
         let action_resolver: Box<&dyn ActionApi> = Box::new(&self.action);

--- a/libs/ux-api/src/widgets/slider.rs
+++ b/libs/ux-api/src/widgets/slider.rs
@@ -91,6 +91,7 @@ impl ActionApi for Slider {
     fn set_action_opcode(&mut self, op: u32) { self.action_opcode = op }
 
     fn redraw(&self, at_height: isize, modal: &Modal) {
+        log::debug!("    slider @ {}", at_height);
         let color = PixelColor::Light;
         let fill_color = PixelColor::Dark;
 
@@ -130,7 +131,7 @@ impl ActionApi for Slider {
             // render current setting
             tv.bounds_computed = None;
             tv.bounds_hint = TextBounds::GrowableFromTl(
-                Point::new(offset, at_height + modal.margin + modal.line_height * 2 + modal.margin),
+                Point::new(offset, at_height + modal.margin + modal.line_height * 1),
                 maxwidth,
             );
             modal.gfx.draw_textview(&mut tv).expect("couldn't draw legend");
@@ -139,10 +140,10 @@ impl ActionApi for Slider {
         // the actual slider
         let mut draw_list = ObjectList::new();
         let outer_rect = Rectangle::new_with_style(
-            Point::new(modal.margin * 2, modal.margin + modal.line_height + at_height),
+            Point::new(modal.margin * 2, modal.margin + modal.line_height * 0 + at_height),
             Point::new(
                 modal.canvas_width - modal.margin * 2,
-                modal.margin + modal.line_height * 2 + at_height,
+                modal.margin + modal.line_height * 1 + at_height,
             ),
             DrawStyle::new(fill_color, color, 2),
         );
@@ -151,8 +152,8 @@ impl ActionApi for Slider {
         let slider_point =
             (total_width * (self.action_payload - self.min) as isize) / (self.max - self.min) as isize;
         let inner_rect = Rectangle::new_with_style(
-            Point::new(modal.margin * 2, modal.margin + modal.line_height + at_height),
-            Point::new(modal.margin * 2 + slider_point, modal.margin + modal.line_height * 2 + at_height),
+            Point::new(modal.margin * 2, modal.margin + modal.line_height * 0 + at_height),
+            Point::new(modal.margin * 2 + slider_point, modal.margin + modal.line_height * 1 + at_height),
             DrawStyle::new(color, color, 1),
         );
         draw_list.push(ClipObjectType::Rect(inner_rect)).unwrap();

--- a/services/bao-console/src/main.rs
+++ b/services/bao-console/src/main.rs
@@ -102,14 +102,12 @@ fn main() {
         tt.sleep_ms(500).ok();
     }
 
-    // why is this feature not being de-activated when it is not selected???
-    /*
     #[cfg(feature = "modal-testing")]
     {
         log::set_max_level(log::LevelFilter::Debug);
         modals::tests::spawn_test();
     }
-    */
+
     #[cfg(not(feature = "hosted-baosec"))]
     {
         use cramium_api::I2cApi;

--- a/services/bao-console/src/repl.rs
+++ b/services/bao-console/src/repl.rs
@@ -55,11 +55,18 @@ impl Repl {
 
     // An index of -1 gives the most recent command.
     // -2 would give the second most recent command
-    pub(crate) fn get_history(&mut self, index: isize) -> &str {
-        &self.history[(self.history.len() as isize + index)
-            .max(0)
-            .min(self.history.len().saturating_sub(1) as isize) as usize]
-            .text
+    pub(crate) fn get_history(&mut self, index: isize) -> Option<&str> {
+        if self.history.len() != 0 {
+            Some(
+                &self.history[(self.history.len() as isize + index)
+                    .max(0)
+                    .min(self.history.len().saturating_sub(1) as isize)
+                    as usize]
+                    .text,
+            )
+        } else {
+            None
+        }
     }
 
     /// update the loop, in response to various inputs

--- a/services/bao-console/src/shell.rs
+++ b/services/bao-console/src/shell.rs
@@ -69,9 +69,11 @@ fn shell() {
                         print!("\r{}", spaces);
                     }
                     input.clear();
-                    input.push_str(repl.get_history(history_index));
-                    // print the new input
-                    println!("{}", &input);
+                    if let Some(s) = repl.get_history(history_index) {
+                        input.push_str(s);
+                        // print the new input
+                        println!("{}", &input);
+                    }
                 } else if k != '\u{0000}' && k != '\n' && k != '\r' {
                     input.push(k);
                 } else if k == '\n' || k == '\r' {

--- a/services/pddb/src/main.rs
+++ b/services/pddb/src/main.rs
@@ -704,6 +704,7 @@ fn wrapped_main() -> ! {
 
     // track processes that want a notification of a mount event
     let mut mount_notifications = Vec::<xous::MessageSender>::new();
+    #[cfg(target_os = "xous")]
     let mut attempt_notifications = Vec::<xous::MessageSender>::new();
 
     // track the basis monitor requester.

--- a/services/usb-device-xous/src/hid.rs
+++ b/services/usb-device-xous/src/hid.rs
@@ -61,7 +61,6 @@ pub struct AppHIDConfig<'a> {
 }
 
 impl<'a> Default for AppHIDConfig<'a> {
-    #[must_use]
     fn default() -> Self {
         let iface = HeapInterfaceBuilder::new(vec![0])
             .unwrap()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -382,6 +382,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .target_hosted_baosec()
                 .add_services(&bao_pkgs)
                 .add_apps(&get_cratespecs());
+
+            // builder.add_feature("modal-testing");
         }
         Some("pddb-ci") => {
             builder
@@ -653,6 +655,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             for service in bao_swap_pkgs {
                 builder.add_service(service, LoaderRegion::Swap);
             }
+            // builder.add_feature("modal-testing");
         }
 
         // ------ ARM hardware image configs ------


### PR DESCRIPTION
Various improvements to front end UI aesthetics

- fixed slider spacing
- fixed bug in size checks for draw list creation
- removed "mystery line" on right hand side of screen (this is the dirty bit being applied from precursor targets to the wrong target; checked on renode and the fix seems to not affect legacy systems)
- cleanup some warnings and feature flags
