### PR TITLE
add build flags to bao-console

### DIFF
--- a/services/bao-console/Cargo.toml
+++ b/services/bao-console/Cargo.toml
@@ -50,7 +50,9 @@ hosted-baosec = [
     "cramium-hal/hosted-baosec",
 ]
 usb = []
-pddbtest = []
+battery-readout = []
+with-pddb = []
+pddbtest = ["with-pddb"]
 test-rekey = []
 autobasis = ["rand_chacha", "rand"]
 modal-testing = ["ux-api", "modals/modal-testing"]

--- a/services/bao-console/src/cmds.rs
+++ b/services/bao-console/src/cmds.rs
@@ -87,7 +87,9 @@ use trng_cmd::*;
 mod usb;
 #[cfg(feature = "usb")]
 use usb::*;
+#[cfg(feature = "with-pddb")]
 mod pddb;
+#[cfg(feature = "with-pddb")]
 use pddb::*;
 
 pub struct CmdEnv {
@@ -97,6 +99,7 @@ pub struct CmdEnv {
     trng_cmd: TrngCmd,
     #[cfg(feature = "usb")]
     usb: Usb,
+    #[cfg(feature = "with-pddb")]
     pddb_cmd: PddbCmd,
 }
 impl CmdEnv {
@@ -120,6 +123,7 @@ impl CmdEnv {
             },
             #[cfg(feature = "usb")]
             usb: Usb::new(),
+            #[cfg(feature = "with-pddb")]
             pddb_cmd: PddbCmd::new(),
         }
     }
@@ -142,6 +146,7 @@ impl CmdEnv {
             &mut console_cmd,
             #[cfg(feature = "usb")]
             &mut self.usb,
+            #[cfg(feature = "with-pddb")]
             &mut self.pddb_cmd,
         ];
 

--- a/services/bao-console/src/main.rs
+++ b/services/bao-console/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
         modals::tests::spawn_test();
     }
 
-    #[cfg(not(feature = "hosted-baosec"))]
+    #[cfg(feature = "battery-readout")]
     {
         use cramium_api::I2cApi;
         let mut i2c = cram_hal_service::I2c::new();
@@ -126,7 +126,7 @@ fn main() {
             }
         }
     }
-    #[cfg(feature = "hosted-baosec")]
+    #[cfg(any(feature = "hosted-baosec", not(feature = "battery-readout")))]
     loop {
         tt.sleep_ms(2_000).ok();
     }


### PR DESCRIPTION
This time with _rebasing_.

two flags are added:

    with-pddb - puts the PDDB commands into the console
    battery-readout - turns on the periodic battery readout

I bet this has conflicts with your branch @samchin. Please let me know if some changes on my side would reduce merge conflicts.
