### PR TITLE
add back in the reading part of `i2c_read`

### DIFF
--- a/services/cram-hal-service/src/i2c_lib.rs
+++ b/services/cram-hal-service/src/i2c_lib.rs
@@ -49,6 +49,7 @@ impl I2cApi for I2c {
         if result.transactions[0].result == I2cResult::InternalError {
             Err(xous::Error::InternalError)
         } else {
+            buf.copy_from_slice(&result.transactions[0].data);
             Ok(result.transactions[0].result)
         }
     }


### PR DESCRIPTION
See issue #659 

## Test Plan
Build `main` with `--feature "battery-readout"`. Observe that the values are 0 on console.

`git checkout sam.i2c-fix` and build again. Observe that the values are no longer 0.