### PR TITLE
remove some redundant mmu flush commands

### DIFF
--- a/kernel/src/arch/riscv/mem.rs
+++ b/kernel/src/arch/riscv/mem.rs
@@ -258,7 +258,7 @@ impl MemoryMapping {
     /// As such, this will only have an observable effect once code returns
     /// to userspace.
     pub fn activate(self) -> Result<(), xous_kernel::Error> {
-        unsafe { flush_mmu() };
+        // unsafe { flush_mmu() }; // redundant - adds 9% time to context switch benchmark when present!
         satp::write(self.satp);
         unsafe { flush_mmu() };
         Ok(())

--- a/kernel/src/swap.rs
+++ b/kernel/src/swap.rs
@@ -431,7 +431,7 @@ impl Swap {
                             true,
                         )
                         .ok();
-                        unsafe { crate::arch::mem::flush_mmu() };
+                        // unsafe { crate::arch::mem::flush_mmu() }; // redundant?
                     } else {
                         already_mapped = true;
                     }


### PR DESCRIPTION
The double-flush in activate() has a big impact on performance, and I'm pretty sure it only needs to happen after the SATP update not before, at least architecturally. Eliminating the extra flush improves the fast message passing benchmark time by 9%.