### PR TITLE
Autostatics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5742,6 +5742,7 @@ name = "tools"
 version = "0.1.0"
 dependencies = [
  "aes-gcm-siv",
+ "bao1x-api",
  "base64 0.20.0",
  "bitflags 1.3.2",
  "clap 2.34.0",

--- a/baremetal/src/platform/bao1x/link.x
+++ b/baremetal/src/platform/bao1x/link.x
@@ -1,7 +1,8 @@
 /* bottom 256k reserved for copying code into RAM for JTAG-booting targets */
 MEMORY
 {
-  FLASH : ORIGIN = 0x60000000, LENGTH = 256k
+  /* Note: ORIGIN is updated by xtask for baremetal targets */
+  FLASH : ORIGIN = 0x60000100, LENGTH = 256k - 256
   RAM : ORIGIN = 0x61000000, LENGTH = 2048k
 }
 

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -142,15 +142,11 @@ pub enum IniType {
 /// This function is safe to call exactly once.
 #[export_name = "rust_entry"]
 pub unsafe extern "C" fn rust_entry(signed_buffer: *const usize, signature: u32) -> ! {
-    #[cfg(all(feature = "bao1x", not(feature = "verilator-only")))]
     let perclk_freq = crate::platform::early_init(); // sets up PLLs so we're not running at 16MHz...
     // need to make this "official" for bao1x, the feature flag combo below works around some simulation
     // config conflicts.
     #[cfg(all(feature = "verilator-only", not(feature = "bao1x-mpw")))]
     platform::coreuser_config();
-
-    #[cfg(not(all(feature = "bao1x", not(feature = "verilator-only"))))]
-    let perclk_freq = 0;
 
     #[cfg(all(feature = "bao1x", feature = "updates"))]
     crate::platform::process_update(perclk_freq);

--- a/loader/src/platform/bao1x/link.x
+++ b/loader/src/platform/bao1x/link.x
@@ -1,9 +1,8 @@
 MEMORY
 {
-  /* we are using an unsigned loader, so the offset is not 1k offset */
   /* if the font location is adjusted, this needs to be updated in libs/blitstr2 codegen templates.go FONT_BASE value */
   FONTS : ORIGIN = 0x60040000, LENGTH = 128k
-  FLASH : ORIGIN = 0x60001000, LENGTH = 252k
+  FLASH : ORIGIN = 0x60001100, LENGTH = 252k - 256
   RAM : ORIGIN = 0x61000000, LENGTH = 2M
 }
 

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -26,6 +26,7 @@ pkcs8 = { version = "0.8.0", features = ["pem"] }
 base64 = "0.20.0"
 rand = "0.8.5"
 aes-gcm-siv = "0.11.1"
+bao1x-api = { path = "../libs/bao1x-api" }
 
 [[bin]]
 name = "copy-object"

--- a/tools/src/bin/copy-object.rs
+++ b/tools/src/bin/copy-object.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs::File;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process;
 
 use tools::elf;
@@ -10,16 +10,34 @@ fn main() {
     env_logger::init();
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        println!("Usage: {} input.elf [output.bin]", args.get(0).unwrap_or(&"copy-object".to_owned()));
+        println!(
+            "Usage: {} input.elf [output.bin] [--bao1x]",
+            args.get(0).unwrap_or(&"copy-object".to_owned())
+        );
         return;
     }
 
     let input_filename = Path::new(args.get(1).unwrap()).to_path_buf();
-    let output_filename = args.get(2).map(|x| Path::new(x).to_path_buf()).unwrap_or_else(|| {
+
+    // Parse remaining arguments
+    let mut output_filename: Option<PathBuf> = None;
+    let mut bao1x_flag = false;
+
+    for arg in args.iter().skip(2) {
+        if arg == "--bao1x" {
+            bao1x_flag = true;
+        } else if output_filename.is_none() {
+            output_filename = Some(Path::new(arg).to_path_buf());
+        }
+    }
+
+    // Set default output filename if none provided
+    let output_filename = output_filename.unwrap_or_else(|| {
         let mut output_filename = input_filename.clone();
         output_filename.set_extension("bin");
         output_filename
     });
+
     if output_filename == input_filename {
         eprintln!("Input and output filename are the same: {}", output_filename.display());
         eprintln!("Specify an output path, or change the suffix of your input file from \".bin\"");
@@ -33,6 +51,26 @@ fn main() {
         eprintln!("Couldn't create output file {}: {}", output_filename.display(), e);
         process::exit(1);
     });
+    if bao1x_flag {
+        let mut statics = bao1x_api::StaticsInRom {
+            jump_instruction: bao1x_api::JUMP_INSTRUCTION,
+            version: bao1x_api::STATICS_IN_ROM_VERSION,
+            valid_pokes: 0,
+            data_origin: 0,
+            data_size_bytes: 0,
+            poke_table: [(0u32, 0u32); 30],
+        };
+        statics.data_origin = pd.data_offset;
+        statics.data_size_bytes = pd.clear_size;
+        statics.valid_pokes = pd.poke_table.len() as u16;
+        for (&entry, dest) in pd.poke_table.iter().zip(statics.poke_table.iter_mut()) {
+            *dest = entry;
+        }
+        f.write(statics.as_bytes()).unwrap_or_else(|e| {
+            eprintln!("Couldn't write data to {}: {}", output_filename.display(), e);
+            process::exit(1);
+        });
+    }
     f.write_all(&pd.program).unwrap_or_else(|e| {
         eprintln!("Couldn't write data to {}: {}", output_filename.display(), e);
         process::exit(1);

--- a/xtask/src/builder.rs
+++ b/xtask/src/builder.rs
@@ -825,6 +825,7 @@ impl Builder {
             if self.change_target {
                 std::fs::remove_file(&svd_spec_path).ok(); // don't fail if the file does not exist
             }
+            let is_bao = if self.utra_target == "bao1x" { "--bao1x" } else { "" };
 
             // ------ build the loader ------
             // stash any LTO settings applied to the kernel; proper layout of the loader
@@ -875,6 +876,7 @@ impl Builder {
                         "--",
                         &loader[0],
                         output_file.as_os_str().to_str().unwrap(),
+                        is_bao,
                     ])
                     .status()?;
                 if !status.success() {
@@ -947,6 +949,7 @@ impl Builder {
                     "--",
                     &loader[0],
                     loader_presign.as_os_str().to_str().unwrap(),
+                    is_bao,
                 ])
                 .status()?;
             if !status.success() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -600,13 +600,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         Some("baremetal-bao1x") => {
             builder.set_baremetal(true);
-            update_flash_origin("baremetal/src/platform/bao1x/link.x", 0x6000_0000)?;
+            update_flash_origin("baremetal/src/platform/bao1x/link.x", 0x6000_0100)?;
             builder.target_baremetal_bao1x();
         }
 
         Some("baremetal-bao1x-evb") => {
             builder.set_baremetal(true);
-            update_flash_origin("baremetal/src/platform/bao1x/link.x", 0x6100_0000)?;
+            update_flash_origin("baremetal/src/platform/bao1x/link.x", 0x6100_0100)?;
             builder.add_loader_feature("bao1x-evb");
             builder.target_baremetal_bao1x();
         }


### PR DESCRIPTION
@samchin @mammothbane 

I am removing one pain point in the baremetal build process which is having to update the static data initialization with some copypaste code that can change on every build configuration. The original theory was that this didn't change often but as the build has become more featureful that theory went out the door.

This PR incorporates a 256-byte header record on the executables that contains a poke table and other metadata that allows a baremetal system to set up its runtime environment to match what Rust expects. This should hopefully also eliminate some compatibility bugs that could be the cause of the USB serial problems you are having.