### PR TITLE
xtask: exit after printing help

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -709,7 +709,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some("generate-locales") => generate_locales()?,
         Some("wycheproof-import") => wycheproof_import()?,
         Some("dummy-template") => generate_app_menus(&Vec::new()),
-        _ => print_help(),
+        task => {
+            if let Some(task) = task {
+                eprintln!("error: task {task:?} not recognized");
+            }
+
+            print_help();
+            std::process::exit(1);
+        }
     }
     builder.build()?;
 


### PR DESCRIPTION
Causes the xtask build to print an error and exit if it doesn't recognize the task argument. Just ran into this as a result of the cramsoc -> bao1x rename in 1255bf1 -- the build wasn't recognizing `baremetal-cramsoc` anymore but was proceeding with the compile anyway, without setting the target or loader features.