### PR TITLE
fix feature tree for dabao build

### DIFF
--- a/apps-dabao/dabao-console/Cargo.toml
+++ b/apps-dabao/dabao-console/Cargo.toml
@@ -38,4 +38,4 @@ board-dabao = [
 ctap-bringup = []
 usb = []
 aestests = ["aes"]
-default = []
+default = ["usb"]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -791,7 +791,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             builder.add_loader_feature("debug-print");
             builder.add_kernel_feature("v2p");
-            builder.add_detached_app_feature("usb");
             match task.as_deref() {
                 Some("dabao") => builder.target_bao1x_soc(),
                 _ => panic!("should be unreachable"),


### PR DESCRIPTION
"usb" is now default for dabao-console, should not be passed as a universal feature to all apps as not all apps have that feature

merging as this breaks the CI build