### PR TITLE
remap PROG pin to effectively reset for alt-boot mode

### DIFF
--- a/bao1x-boot/boot1/src/main.rs
+++ b/bao1x-boot/boot1/src/main.rs
@@ -306,6 +306,13 @@ pub fn boot(iox: &Iox, mut oled: Option<Oled128x128>, se0_port: bao1x_api::IoxPo
         }
     });
 
+    // reset instead of boot
+    #[cfg(feature = "alt-boot1")]
+    {
+        let mut rcurst = CSR::new(utra::sysctrl::HW_SYSCTRL_BASE as *mut u32);
+        rcurst.wo(utra::sysctrl::SFR_RCURST0, 0x55AA);
+    }
+
     // when we get to this point, there's only two options...
     try_boot(true);
     unreachable!("`or_die = true` means this should be unreachable");


### PR DESCRIPTION
this makes it a little easier to explain the procedure in exiting alt-boot mode

Tagging @rowr111  specifically because this improves the work flow for any alt-boot tasks. I don't think we have any pending at the moment but in case you incorporated this into any docs, insntead of hitting "reset" to exit alt-boot mode, you hit "prog" like the normal boot mode.
