### PR TITLE
fix dabao target - keyboard server

### DIFF
--- a/services/bao1x-hal-service/src/main.rs
+++ b/services/bao1x-hal-service/src/main.rs
@@ -256,7 +256,6 @@ fn main() {
     // The index of the array corresponds to the slot.
     let mut irq_table: [Option<IrqLocalRegistration>; 8] = [None; 8];
 
-    #[cfg(feature = "board-baosec")]
     servers::keyboard::start_keyboard_service();
 
     // claim BIO

--- a/services/bao1x-hal-service/src/servers.rs
+++ b/services/bao1x-hal-service/src/servers.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "board-baosec")]
 pub mod keyboard;
 
 // TRNG server is only needed for baosec; dabao can cheat and use the kernel TRNG port


### PR DESCRIPTION
dabao needs to have a vestigial keyboard server which handles forwarding USB/serial key events to listeners. otherwise, there is no input interface.

First bug score for the CI system - good job, Jenkins!
