### PR TITLE
fix keyboard scan configuration

### DIFF
--- a/services/bao1x-hal-service/src/servers/keyboard.rs
+++ b/services/bao1x-hal-service/src/servers/keyboard.rs
@@ -181,6 +181,10 @@ fn keyboard_service() {
     {
         let iox = crate::iox::IoxHal::new();
         let (_row, _col) = bao1x_hal::board::setup_kpc_pins(&iox);
+        // for baosec-lite: this needs to be set to low for prstn to be de-asserted
+        // use bao1x_api::IoGpio;
+        // iox.set_gpio_pin_dir(bao1x_api::IoxPort::PA, 1, bao1x_api::IoxDir::Output);
+        // iox.set_gpio_pin_value(bao1x_api::IoxPort::PA, 1, bao1x_api::IoxValue::Low);
     }
     #[cfg(feature = "board-baosec")]
     let mut kpc_aoint = bao1x_hal::kpc_aoint::KpcAoInt::new(Some(handler));
@@ -194,8 +198,8 @@ fn keyboard_service() {
         // KPOE0 defines OE state in phase 0 - here we set it to drive
         // KPOE1 defines OE state in phase 1 - here we set it to drive
         let cfg0 = kpc_aoint.kpc.ms(utra::dkpc::SFR_CFG0_KPOPO0, 1)
-            // | kpc_aoint.kpc.ms(utra::dkpc::SFR_CFG0_KPOPO1, 1)
-            | kpc_aoint.kpc.ms(utra::dkpc::SFR_CFG0_KPOOE0, 1)
+            | kpc_aoint.kpc.ms(utra::dkpc::SFR_CFG0_KPOPO1, 0)
+            | kpc_aoint.kpc.ms(utra::dkpc::SFR_CFG0_KPOOE0, 0) // tri-state instead of drive for high
             | kpc_aoint.kpc.ms(utra::dkpc::SFR_CFG0_KPOOE1, 1)
             | kpc_aoint.kpc.ms(utra::dkpc::SFR_CFG0_DKPCEN, 1);
         kpc_aoint.kpc.wo(utra::dkpc::SFR_CFG0, cfg0);


### PR DESCRIPTION
turns out that when the keyboard is activated, *all* the keyboard lines take over the GPIOs - and this will fight with the the doubled-up PF7_PA2/PF8_PA1/PF9_PA0 I/Os.

Using the keyboard controller means that *all* of the PF2-PF9 pins are now driven by the keyboard controller, regardless of the GPIO setting.

This is because when the core is powered off, the GPIO output mappings are lost (they are in the core domain, not always on), and the KPC was implemented without the ability to selectively demux unused rows/cols.

In particular on baosec this can lead to high power consumption on the 24MHz clock when driving the camera, because the KPC fights with the clock.

The mitigation for the current baosec hardware is to configure the KPC such that the internal pull-up is responsible for the "high" level, and it's only driven when "low". This reduces the amount of fighting with the oscillator.

A future rev of hardware will move the osc to the PA3 pin, where there is a PWM output but no muxing with the KPC, eliminating the conflict entirely.