### PR TITLE
Add Dockerfiles to build dabao apps & bao1x boot1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*.uf2
+.direnv
+.github
+.vscode
+.envrc
+.gitattributes
+.gitignore
+*.nix

--- a/apps-dabao/Dockerfile
+++ b/apps-dabao/Dockerfile
@@ -1,0 +1,28 @@
+FROM rust:1.92-slim AS toolchain
+ARG RUST_VERSION="1.92.0"
+ARG EXTRA="1"
+
+RUN set -eux; \
+    apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && download_url="https://github.com/betrusted-io/rust/releases/download"; \
+    zipfile="riscv32imac-unknown-xous_${RUST_VERSION}.zip"; \
+    curl -L -O "${download_url}/${RUST_VERSION}.${EXTRA}/${zipfile}"; \
+    unzip "${zipfile}" -d "$(rustc --print sysroot)"; \
+    rm "${zipfile}"
+
+RUN rustup target add riscv32imac-unknown-none-elf
+
+FROM toolchain AS builder
+ARG app="helloworld"
+WORKDIR /usr/src/xous-core
+COPY . .
+RUN --mount=type=cache,target=/root/.cargo/registry cargo xtask dabao ${app}
+
+FROM scratch
+COPY --from=builder /usr/src/xous-core/target/riscv32imac-unknown-xous-elf/release/apps.uf2 /
+COPY --from=builder /usr/src/xous-core/target/riscv32imac-unknown-xous-elf/release/loader.uf2 /
+COPY --from=builder /usr/src/xous-core/target/riscv32imac-unknown-xous-elf/release/xous.uf2 /

--- a/apps-dabao/README.md
+++ b/apps-dabao/README.md
@@ -1,3 +1,12 @@
 # Apps for Dabao
 
 These are applications targeting a minimal set of Xous services for hardware configurations that are basically "just the chip".
+
+## Building with Docker
+From the root of the repository, run:
+
+```shell
+mkdir -p target && docker build --file apps-dabao/Dockerfile --build-arg app=helloworld --output target .
+```
+
+The `uf2` files will be under `target/`.

--- a/bao1x-boot/Dockerfile
+++ b/bao1x-boot/Dockerfile
@@ -1,0 +1,30 @@
+FROM rust:1.92-slim AS toolchain
+
+ARG RUST_VERSION="1.92.0"
+ARG EXTRA="1"
+
+RUN set -eux; \
+    apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && download_url="https://github.com/betrusted-io/rust/releases/download"; \
+    zipfile="riscv32imac-unknown-xous_${RUST_VERSION}.zip"; \
+    curl -L -O "${download_url}/${RUST_VERSION}.${EXTRA}/${zipfile}"; \
+    unzip "${zipfile}" -d "$(rustc --print sysroot)"; \
+    rm "${zipfile}"
+
+RUN rustup target add riscv32imac-unknown-none-elf
+
+
+FROM toolchain AS builder
+WORKDIR /usr/src/xous-core
+COPY . .
+RUN --mount=type=cache,target=/root/.cargo/registry cargo xtask bao1x-alt-boot1
+RUN --mount=type=cache,target=/root/.cargo/registry cargo xtask bao1x-boot1
+
+
+FROM scratch
+COPY --from=builder /usr/src/xous-core/target/riscv32imac-unknown-none-elf/release/bao1x-boot1.uf2 /
+COPY --from=builder /usr/src/xous-core/target/riscv32imac-unknown-none-elf/release/bao1x-alt-boot1.uf2 /

--- a/bao1x-boot/README.md
+++ b/bao1x-boot/README.md
@@ -105,3 +105,12 @@ The baremetal or loader stage are both located at the exact same offset. One can
 Because much of the hardware initialization is done by boot0/boot1, baremetal and loader *should* shed much of the hardware initializations it does. The only re-init that needs to happen are for parameters unique or different to the environments.
 
 Documentation of the baremetal or loader stages is deferred to the respective crates, which are located outside of this subdirectory.
+
+## Building boot1 with Docker
+From the root of the repository, run:
+
+```shell
+mkdir -p target && docker build --file bao1x-boot/Dockerfile --output target .
+```
+
+The `uf2` files will be under `target/`.


### PR DESCRIPTION
This PR adds:

* A `Dockerfile` to build the uf2 files for dabao apps
* A `Dockerfile` to build bao1x boot1 uf2 files
* Some brief instructions in respective README files
* ~~A github workflow to build the uf2 artifacts, which can then be downloaded and loaded on dabao boards~~ moved to #776 