### PR TITLE
Add nix flake for baochip targets

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,98 @@
+name: Nix Build baochip firmware
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  # TODO: re-enable if cachix is setup
+  #warmup-cache:
+  #  name: Build and cache shared dependencies
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - name: Checkout sources
+  #      uses: actions/checkout@v4
+
+  #    - name: Install Nix
+  #      uses: DeterminateSystems/determinate-nix-action@v3
+
+  #    - name: Setup cache
+  #      uses: cachix/cachix-action@v15
+  #      with:
+  #        name: xous-core
+  #        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+  #    - name: Build shared dependencies
+  #      run: nix build .#ci-deps --print-build-logs
+
+  build:
+    name: Nix build ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    # TODO: re-enable if cachix is setup
+    #needs: warmup-cache
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - bao1x-boot0
+          - bao1x-boot1
+          - bao1x-alt-boot1
+          - bao1x-baremetal-dabao
+          - dabao-helloworld
+          - baosec
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Setup cache
+        uses: cachix/cachix-action@v15
+        with:
+          name: xous-core
+          # TODO: re-enable if cachix is setup
+          #authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build ${{ matrix.package }}
+        run: nix build .#${{ matrix.package }} --print-build-logs --out-link result-first
+
+      - name: Is Build Deterministic?
+        id: determistic-build-check
+        continue-on-error: true
+        run: nix build --rebuild --keep-failed .#${{ matrix.package }} --print-build-logs
+
+      - name: Debug non-reproducibility
+        if: failure() && steps.determistic-build-check.outcome == 'failure'
+        run: |
+          nix run nixpkgs#diffoscope -- \
+            /nix/store/*-${{ matrix.package }}* \
+            /nix/store/*-${{ matrix.package }}*.check || true
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.package }}
+          path: result/
+          if-no-files-found: error
+
+  flake-check:
+    name: Flake check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Run flake check
+        run: nix flake check
+
+      - name: Show flake outputs
+        run: nix flake show

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,7 @@ tools-bao/.venv/
 # Zig artifacts
 .zig-cache/
 zig-out/
+
+# Nix-generated vendor config (developer-specific nix store paths)
+.cargo/vendor-config.toml
+locales/.cargo/vendor-config.toml

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,163 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1769287525,
+        "narHash": "sha256-gABuYA6BzoRMLuPaeO5p7SLrpd4qExgkwEmYaYQY4bM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0314e365877a85c9e5758f9ea77a9972afbb4c21",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0314e365877a85c9e5758f9ea77a9972afbb4c21",
+        "type": "github"
+      }
+    },
+    "crane_2": {
+      "locked": {
+        "lastModified": 1769287525,
+        "narHash": "sha256-gABuYA6BzoRMLuPaeO5p7SLrpd4qExgkwEmYaYQY4bM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0314e365877a85c9e5758f9ea77a9972afbb4c21",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0314e365877a85c9e5758f9ea77a9972afbb4c21",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769089682,
+        "narHash": "sha256-9yA/LIuAVQq0lXelrZPjLuLVuZdm03p8tfmHhnDIkms=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "078d69f03934859a181e81ba987c2bb033eebfc5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "078d69f03934859a181e81ba987c2bb033eebfc5",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "rust-xous": "rust-xous"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769396217,
+        "narHash": "sha256-YNzh46h8fby49yOIB40lNoQ9ucVoXe1bHVwkZ4AwGe0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e9bcd12156a577ac4e47d131c14dc0293cc9c8c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e9bcd12156a577ac4e47d131c14dc0293cc9c8c2",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "rust-xous",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769396217,
+        "narHash": "sha256-YNzh46h8fby49yOIB40lNoQ9ucVoXe1bHVwkZ4AwGe0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e9bcd12156a577ac4e47d131c14dc0293cc9c8c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e9bcd12156a577ac4e47d131c14dc0293cc9c8c2",
+        "type": "github"
+      }
+    },
+    "rust-xous": {
+      "inputs": {
+        "crane": "crane_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1769418887,
+        "narHash": "sha256-xfZMgJ1Pm4mJTVi9LPbprzH+et1aqzxlAC+UlXKZ4GY=",
+        "owner": "sbellem",
+        "repo": "rust-xous-flake",
+        "rev": "24959275c25e5bc903c85979a9794e1937495ec6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sbellem",
+        "repo": "rust-xous-flake",
+        "rev": "24959275c25e5bc903c85979a9794e1937495ec6",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -32,22 +32,21 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -67,10 +66,25 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
         "rust-xous": "rust-xous"
@@ -139,21 +153,6 @@
         "owner": "sbellem",
         "repo": "rust-xous-flake",
         "rev": "24959275c25e5bc903c85979a9794e1937495ec6",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -94,14 +94,39 @@
                            'std::env::var("GIT_REV").map(|s| std::process::Output { status: std::process::ExitStatus::default(), stdout: s.into_bytes(), stderr: vec![] }).unwrap_or_else(|_| Command::new("git").args(&["rev-parse", "HEAD"]).output().expect("Failed to execute command"))'
         '';
 
+        # Merge vendor directories so a single config covers both the root
+        # and locales Cargo.lock files.
+        mergedVendor = pkgs.runCommand "merged-vendor-cargo-deps" {} ''
+          # Recreate directory structure with real dirs, symlinking crates
+          for dir in ${vendoredDeps}/*/; do
+            name=$(basename "$dir")
+            mkdir -p "$out/$name"
+            for crate in "$dir"/*; do
+              ln -s "$crate" "$out/$name/$(basename "$crate")"
+            done
+          done
+
+          # Add locales-only crates into matching source dirs
+          for dir in ${vendoredLocalesDeps}/*/; do
+            name=$(basename "$dir")
+            mkdir -p "$out/$name"
+            for crate in "$dir"/*; do
+              crate_name=$(basename "$crate")
+              if [ ! -e "$out/$name/$crate_name" ]; then
+                ln -s "$crate" "$out/$name/$crate_name"
+              fi
+            done
+          done
+
+          # Generate config.toml pointing to merged paths
+          sed "s|${vendoredDeps}|$out|g" ${vendoredDeps}/config.toml > $out/config.toml
+        '';
+
         # Configure cargo to use vendored deps (separate file, merged via --config)
         configureVendoring = ''
           mkdir -p .cargo
-          cat ${vendoredDeps}/config.toml > .cargo/vendor-config.toml
+          cat ${mergedVendor}/config.toml > .cargo/vendor-config.toml
           printf '\n[net]\noffline = true\n' >> .cargo/vendor-config.toml
-          mkdir -p locales/.cargo
-          cat ${vendoredLocalesDeps}/config.toml > locales/.cargo/vendor-config.toml
-          printf '\n[net]\noffline = true\n' >> locales/.cargo/vendor-config.toml
         '';
 
         # Common environment for reproducible Rust builds
@@ -183,17 +208,10 @@
 
           mkdir -p .cargo
 
-          # Write vendor config as a separate file (gitignored)
-          cat ${vendoredDeps}/config.toml > .cargo/vendor-config.toml
+          # Write merged vendor config covering both root and locales deps
+          cat ${mergedVendor}/config.toml > .cargo/vendor-config.toml
           printf '\n[net]\noffline = true\n' >> .cargo/vendor-config.toml
-          echo "Wrote .cargo/vendor-config.toml"
-
-          if [ -d "locales" ]; then
-            mkdir -p locales/.cargo
-            cat ${vendoredLocalesDeps}/config.toml > locales/.cargo/vendor-config.toml
-            printf '\n[net]\noffline = true\n' >> locales/.cargo/vendor-config.toml
-            echo "Wrote locales/.cargo/vendor-config.toml"
-          fi
+          echo "Wrote .cargo/vendor-config.toml (merged root + locales deps)"
         '';
 
         nightlyRustToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain:

--- a/flake.nix
+++ b/flake.nix
@@ -217,6 +217,15 @@
             echo "Wrote .cargo/vendor-config.toml (merged root + locales deps)"
           '';
 
+          # Wrapper that injects --git-describe and --git-rev so builds work
+          # without git tags (containers, shallow clones, CI).
+          xousBuild = pkgs.writeShellScriptBin "xous-build" ''
+            exec cargo xtask "$@" \
+              --config .cargo/vendor-config.toml \
+              --git-describe "${xousVersion}" \
+              --git-rev "${gitRevFull}"
+          '';
+
           nightlyRustToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain:
             toolchain.default.override {
               extensions = [ "rustfmt" ];
@@ -289,6 +298,30 @@
                 echo "──────────────────────────────────────────────────────────────"
               '';
             };
+
+          # For containerized / sandboxed environments without git tags
+          container = pkgs.mkShell {
+            packages = [ pkgs.rustToolchainXous vendorSetup xousBuild ];
+            env = {
+              XOUS_VERSION = xousVersion;
+              GIT_REV = gitRevFull;
+            };
+            shellHook = ''
+              # Generate vendor config for offline builds
+              xous-vendor-setup
+
+              echo "──────────────────────────────────────────────────────────────"
+              echo "Xous container development environment"
+              echo "  $(rustc --version)"
+              echo "  xous-core ${xousVersion}"
+              echo ""
+              echo "Use xous-build instead of cargo xtask to inject version info:"
+              echo "  • xous-build dabao"
+              echo "  • xous-build baosec"
+              echo "  • xous-build bao1x-boot0"
+              echo "──────────────────────────────────────────────────────────────"
+            '';
+          };
 
             nightly = pkgs.mkShell {
               packages = [ nightlyRustToolchain ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,290 @@
+{
+  description = "Xous development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/078d69f03934859a181e81ba987c2bb033eebfc5";
+    flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
+    crane.url = "github:ipetkov/crane/0314e365877a85c9e5758f9ea77a9972afbb4c21";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay/e9bcd12156a577ac4e47d131c14dc0293cc9c8c2";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    rust-xous = {
+      url = "github:sbellem/rust-xous-flake/24959275c25e5bc903c85979a9794e1937495ec6";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-xous,
+      rust-overlay,
+      crane,
+    }:
+    let
+      gitTag = "0.9.16"; # git describe --abbrev=0
+      gitTagRevCount = 7276; # git rev-list --count $(git describe --abbrev=0)
+
+      # for swap_writer
+      gitRevFull = if self ? rev
+        then self.rev
+        else "0000000000000000000000000000000000000000";
+
+      gitHash = builtins.substring 0 9 gitRevFull;
+
+      sinceTagRevCount = if self ? revCount
+        then toString (self.revCount - gitTagRevCount)
+        else "0";
+
+      xousVersion = "v${gitTag}-${sinceTagRevCount}-g${gitHash}";
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            rust-overlay.overlays.default
+            rust-xous.overlays.default
+          ];
+        };
+        craneLib = (crane.mkLib pkgs).overrideToolchain pkgs.rustToolchainXous;
+
+        # Clean source to only include cargo-relevant files
+        src = craneLib.cleanCargoSource self;
+
+        # Vendor all dependencies (including git deps) - this runs in a FOD with network access
+        vendoredDeps = craneLib.vendorCargoDeps {
+          inherit src;
+        };
+
+        # Vendor locales dependencies separately (it has its own Cargo.lock)
+        localesSrc = pkgs.lib.cleanSourceWith {
+          src = self;
+          filter = path: type:
+            (pkgs.lib.hasInfix "/locales/" path) ||
+            (pkgs.lib.hasSuffix "/locales" path) ||
+            (baseNameOf path == "Cargo.toml" && dirOf path == toString self + "/locales") ||
+            (baseNameOf path == "Cargo.lock" && dirOf path == toString self + "/locales");
+        };
+
+        vendoredLocalesDeps = craneLib.vendorCargoDeps {
+          src = self + "/locales";
+        };
+
+        # Common postPatch to replace SemVer::from_git() with hardcoded version
+        patchSemver = ''
+          substituteInPlace tools/src/sign_image.rs \
+            --replace-fail 'SemVer::from_git()?.into()' '"${xousVersion}".parse::<SemVer>().unwrap().into()'
+        '';
+
+        # Patch versioning.rs to use XOUS_VERSION env var instead of git describe
+        patchVersioning = ''
+          substituteInPlace xtask/src/versioning.rs \
+            --replace-fail 'let gitver = output.stdout;' \
+                           'let gitver = std::env::var("XOUS_VERSION").map(|s| s.into_bytes()).unwrap_or(output.stdout);'
+        '';
+
+        # Patch swap_writer.rs to use GIT_REV env var instead of running git
+        patchSwapWriter = ''
+          substituteInPlace tools/src/swap_writer.rs \
+            --replace-fail 'Command::new("git").args(&["rev-parse", "HEAD"]).output().expect("Failed to execute command")' \
+                           'std::env::var("GIT_REV").map(|s| std::process::Output { status: std::process::ExitStatus::default(), stdout: s.into_bytes(), stderr: vec![] }).unwrap_or_else(|_| Command::new("git").args(&["rev-parse", "HEAD"]).output().expect("Failed to execute command"))'
+        '';
+
+        # Configure cargo to use vendored deps (separate file, merged via --config)
+        configureVendoring = ''
+          mkdir -p .cargo
+          cat ${vendoredDeps}/config.toml > .cargo/vendor-config.toml
+          printf '\n[net]\noffline = true\n' >> .cargo/vendor-config.toml
+          mkdir -p locales/.cargo
+          cat ${vendoredLocalesDeps}/config.toml > locales/.cargo/vendor-config.toml
+          printf '\n[net]\noffline = true\n' >> locales/.cargo/vendor-config.toml
+        '';
+
+        # Common environment for reproducible Rust builds
+        reproducibleRustEnv = ''
+          export HOME=$PWD
+          export CARGO_HOME=$PWD/.cargo
+          mkdir -p $CARGO_HOME
+          export XOUS_VERSION="${xousVersion}"
+          # Git revision for swap_writer.rs (uses last 16 hex chars of full hash)
+          export GIT_REV="${gitRevFull}"
+          export CARGO_INCREMENTAL=0
+          export RUSTFLAGS="-C codegen-units=1 --remap-path-prefix=$PWD=/build"
+          export SOURCE_DATE_EPOCH=1
+        '';
+
+        # Helper to create build derivations
+        mkXousBuild = { pname, xtaskCmd, targetDir ? "riscv32imac-unknown-none-elf" }:
+          pkgs.stdenv.mkDerivation {
+            inherit pname;
+            version = "0.1.0";
+            src = self;  # Use full source for xtask builds
+            nativeBuildInputs = [ pkgs.rustToolchainXous ];
+
+            postPatch = patchSemver + patchVersioning + patchSwapWriter;
+
+            configurePhase = configureVendoring;
+
+            buildPhase = ''
+              ${reproducibleRustEnv}
+              cargo xtask ${xtaskCmd} --config .cargo/vendor-config.toml --no-verify
+            '';
+
+            installPhase = ''
+              mkdir -p $out
+              cp target/${targetDir}/release/*.uf2 $out/ || true
+              cp target/${targetDir}/release/*.img $out/ || true
+              cp target/${targetDir}/release/*.bin $out/ || true
+            '';
+          };
+
+        dabao-helloworld = mkXousBuild {
+          pname = "dabao-helloworld";
+          xtaskCmd = "dabao helloworld";
+          targetDir = "riscv32imac-unknown-xous-elf";
+        };
+
+        bao1x-boot0 = mkXousBuild {
+          pname = "bao1x-boot0";
+          xtaskCmd = "bao1x-boot0";
+        };
+
+        bao1x-alt-boot1 = mkXousBuild {
+          pname = "bao1x-alt-boot1";
+          xtaskCmd = "bao1x-alt-boot1";
+        };
+
+        bao1x-boot1 = mkXousBuild {
+          pname = "bao1x-boot1";
+          xtaskCmd = "bao1x-boot1";
+        };
+
+        bao1x-baremetal-dabao = mkXousBuild {
+          pname = "bao1x-baremetal-dabao";
+          xtaskCmd = "bao1x-baremetal-dabao";
+        };
+
+        baosec = mkXousBuild {
+          pname = "baosec";
+          xtaskCmd = "baosec";
+          targetDir = "riscv32imac-unknown-xous-elf";
+        };
+
+        # Script to configure cargo vendoring in the current project directory
+        vendorSetup = pkgs.writeShellScriptBin "xous-vendor-setup" ''
+          if [ ! -f "Cargo.toml" ]; then
+            echo "Error: not in xous-core project root" >&2
+            exit 1
+          fi
+
+          mkdir -p .cargo
+
+          # Write vendor config as a separate file (gitignored)
+          cat ${vendoredDeps}/config.toml > .cargo/vendor-config.toml
+          printf '\n[net]\noffline = true\n' >> .cargo/vendor-config.toml
+          echo "Wrote .cargo/vendor-config.toml"
+
+          if [ -d "locales" ]; then
+            mkdir -p locales/.cargo
+            cat ${vendoredLocalesDeps}/config.toml > locales/.cargo/vendor-config.toml
+            printf '\n[net]\noffline = true\n' >> locales/.cargo/vendor-config.toml
+            echo "Wrote locales/.cargo/vendor-config.toml"
+          fi
+        '';
+
+        nightlyRustToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain:
+          toolchain.default.override {
+            extensions = [ "rustfmt" ];
+          }
+        );
+      in
+      {
+        packages = {
+          # Main packages
+          inherit dabao-helloworld bao1x-boot0 bao1x-alt-boot1 bao1x-boot1 bao1x-baremetal-dabao baosec;
+
+          # bootloader stage 1
+          boot1 = pkgs.runCommand "boot1" {} ''
+            mkdir -p $out
+            cp -r ${bao1x-boot1}/* ${bao1x-alt-boot1}/* $out
+          '';
+
+          # Combined bootloader package (boot0 + boot1)
+          bootloader = pkgs.runCommand "bootloader" {} ''
+            mkdir -p $out
+            cp -r ${bao1x-boot0}/* ${bao1x-boot1}/* ${bao1x-alt-boot1}/* $out
+          '';
+
+          # CI dependency caching - bundles shared dependencies
+          ci-deps = pkgs.symlinkJoin {
+            name = "xous-ci-deps";
+            paths = [
+              pkgs.rustToolchainXous
+              vendoredDeps
+            ];
+          };
+
+          # Aliases
+          dabao = dabao-helloworld;
+          baremetal = bao1x-baremetal-dabao;
+
+          default = dabao-helloworld;
+        };
+
+        devShells = {
+          default = pkgs.mkShell {
+            packages = [ pkgs.rustToolchainXous vendorSetup ];
+            shellHook = ''
+              # Generate vendor config for offline builds
+              xous-vendor-setup
+
+              echo "──────────────────────────────────────────────────────────────"
+              echo "Xous development environment"
+              echo "  $(rustc --version)"
+              echo "  xous-core ${xousVersion}"
+              echo ""
+              echo "Installed Rust targets:"
+              ls "$(rustc --print sysroot)/lib/rustlib" | grep -v -E '^(etc|src)$' | sed 's/^/  • /'
+              echo ""
+              echo "Build commands:"
+              echo "  • nix build .#dabao-helloworld"
+              echo "  • nix build .#baosec"
+              echo "  • nix build .#bao1x-baremetal-dabao"
+              echo "  • nix build .#bao1x-boot0"
+              echo "  • nix build .#bao1x-boot1"
+              echo "  • nix build .#bao1x-alt-boot1"
+              echo ""
+              echo "Aliases:"
+              echo "  • nix build .#dabao       (dabao-helloworld)"
+              echo "  • nix build .#baremetal   (bao1x-baremetal-dabao)"
+              echo "  • nix build .#boot1       (bao1x-boot1 + bao1x-alt-boot1)"
+              echo "  • nix build .#bootloader  (bao1x-boot0 bao1x-boot1 + bao1x-alt-boot1)""
+              echo ""
+              echo "For formatting checks, use: nix develop .#nightly"
+              echo "──────────────────────────────────────────────────────────────"
+            '';
+          };
+
+          nightly = pkgs.mkShell {
+            packages = [ nightlyRustToolchain ];
+            shellHook = ''
+              echo "──────────────────────────────────────────────────────────────"
+              echo "Xous nightly development environment"
+              echo "  $(rustc --version)"
+              echo "  $(cargo --version)"
+              echo "  xous-core ${xousVersion}"
+              echo ""
+              echo "Formatting commands:"
+              echo "  • cargo fmt --check"
+              echo "  • cargo fmt"
+              echo "──────────────────────────────────────────────────────────────"
+            '';
+          };
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/078d69f03934859a181e81ba987c2bb033eebfc5";
-    flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
+    flake-parts.url = "github:hercules-ci/flake-parts";
     crane.url = "github:ipetkov/crane/0314e365877a85c9e5758f9ea77a9972afbb4c21";
     rust-overlay = {
       url = "github:oxalica/rust-overlay/e9bcd12156a577ac4e47d131c14dc0293cc9c8c2";
@@ -16,10 +16,10 @@
   };
 
   outputs =
-    {
+    inputs@{
       self,
       nixpkgs,
-      flake-utils,
+      flake-parts,
       rust-xous,
       rust-overlay,
       crane,
@@ -41,268 +41,271 @@
 
       xousVersion = "v${gitTag}-${sinceTagRevCount}-g${gitHash}";
     in
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [
-            rust-overlay.overlays.default
-            rust-xous.overlays.default
-          ];
-        };
-        craneLib = (crane.mkLib pkgs).overrideToolchain pkgs.rustToolchainXous;
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
 
-        # Clean source to only include cargo-relevant files
-        src = craneLib.cleanCargoSource self;
-
-        # Vendor all dependencies (including git deps) - this runs in a FOD with network access
-        vendoredDeps = craneLib.vendorCargoDeps {
-          inherit src;
-        };
-
-        # Vendor locales dependencies separately (it has its own Cargo.lock)
-        localesSrc = pkgs.lib.cleanSourceWith {
-          src = self;
-          filter = path: type:
-            (pkgs.lib.hasInfix "/locales/" path) ||
-            (pkgs.lib.hasSuffix "/locales" path) ||
-            (baseNameOf path == "Cargo.toml" && dirOf path == toString self + "/locales") ||
-            (baseNameOf path == "Cargo.lock" && dirOf path == toString self + "/locales");
-        };
-
-        vendoredLocalesDeps = craneLib.vendorCargoDeps {
-          src = self + "/locales";
-        };
-
-        # Common postPatch to replace SemVer::from_git() with hardcoded version
-        patchSemver = ''
-          substituteInPlace tools/src/sign_image.rs \
-            --replace-fail 'SemVer::from_git()?.into()' '"${xousVersion}".parse::<SemVer>().unwrap().into()'
-        '';
-
-        # Patch versioning.rs to use XOUS_VERSION env var instead of git describe
-        patchVersioning = ''
-          substituteInPlace xtask/src/versioning.rs \
-            --replace-fail 'let gitver = output.stdout;' \
-                           'let gitver = std::env::var("XOUS_VERSION").map(|s| s.into_bytes()).unwrap_or(output.stdout);'
-        '';
-
-        # Patch swap_writer.rs to use GIT_REV env var instead of running git
-        patchSwapWriter = ''
-          substituteInPlace tools/src/swap_writer.rs \
-            --replace-fail 'Command::new("git").args(&["rev-parse", "HEAD"]).output().expect("Failed to execute command")' \
-                           'std::env::var("GIT_REV").map(|s| std::process::Output { status: std::process::ExitStatus::default(), stdout: s.into_bytes(), stderr: vec![] }).unwrap_or_else(|_| Command::new("git").args(&["rev-parse", "HEAD"]).output().expect("Failed to execute command"))'
-        '';
-
-        # Merge vendor directories so a single config covers both the root
-        # and locales Cargo.lock files.
-        mergedVendor = pkgs.runCommand "merged-vendor-cargo-deps" {} ''
-          # Recreate directory structure with real dirs, symlinking crates
-          for dir in ${vendoredDeps}/*/; do
-            name=$(basename "$dir")
-            mkdir -p "$out/$name"
-            for crate in "$dir"/*; do
-              ln -s "$crate" "$out/$name/$(basename "$crate")"
-            done
-          done
-
-          # Add locales-only crates into matching source dirs
-          for dir in ${vendoredLocalesDeps}/*/; do
-            name=$(basename "$dir")
-            mkdir -p "$out/$name"
-            for crate in "$dir"/*; do
-              crate_name=$(basename "$crate")
-              if [ ! -e "$out/$name/$crate_name" ]; then
-                ln -s "$crate" "$out/$name/$crate_name"
-              fi
-            done
-          done
-
-          # Generate config.toml pointing to merged paths
-          sed "s|${vendoredDeps}|$out|g" ${vendoredDeps}/config.toml > $out/config.toml
-        '';
-
-        # Configure cargo to use vendored deps (separate file, merged via --config)
-        configureVendoring = ''
-          mkdir -p .cargo
-          cat ${mergedVendor}/config.toml > .cargo/vendor-config.toml
-          printf '\n[net]\noffline = true\n' >> .cargo/vendor-config.toml
-        '';
-
-        # Common environment for reproducible Rust builds
-        reproducibleRustEnv = ''
-          export HOME=$PWD
-          export CARGO_HOME=$PWD/.cargo
-          mkdir -p $CARGO_HOME
-          export XOUS_VERSION="${xousVersion}"
-          # Git revision for swap_writer.rs (uses last 16 hex chars of full hash)
-          export GIT_REV="${gitRevFull}"
-          export CARGO_INCREMENTAL=0
-          export RUSTFLAGS="-C codegen-units=1 --remap-path-prefix=$PWD=/build"
-          export SOURCE_DATE_EPOCH=1
-        '';
-
-        # Helper to create build derivations
-        mkXousBuild = { pname, xtaskCmd, targetDir ? "riscv32imac-unknown-none-elf" }:
-          pkgs.stdenv.mkDerivation {
-            inherit pname;
-            version = "0.1.0";
-            src = self;  # Use full source for xtask builds
-            nativeBuildInputs = [ pkgs.rustToolchainXous ];
-
-            postPatch = patchSemver + patchVersioning + patchSwapWriter;
-
-            configurePhase = configureVendoring;
-
-            buildPhase = ''
-              ${reproducibleRustEnv}
-              cargo xtask ${xtaskCmd} --config .cargo/vendor-config.toml --no-verify
-            '';
-
-            installPhase = ''
-              mkdir -p $out
-              cp target/${targetDir}/release/*.uf2 $out/ || true
-              cp target/${targetDir}/release/*.img $out/ || true
-              cp target/${targetDir}/release/*.bin $out/ || true
-            '';
-          };
-
-        dabao-helloworld = mkXousBuild {
-          pname = "dabao-helloworld";
-          xtaskCmd = "dabao helloworld";
-          targetDir = "riscv32imac-unknown-xous-elf";
-        };
-
-        bao1x-boot0 = mkXousBuild {
-          pname = "bao1x-boot0";
-          xtaskCmd = "bao1x-boot0";
-        };
-
-        bao1x-alt-boot1 = mkXousBuild {
-          pname = "bao1x-alt-boot1";
-          xtaskCmd = "bao1x-alt-boot1";
-        };
-
-        bao1x-boot1 = mkXousBuild {
-          pname = "bao1x-boot1";
-          xtaskCmd = "bao1x-boot1";
-        };
-
-        bao1x-baremetal-dabao = mkXousBuild {
-          pname = "bao1x-baremetal-dabao";
-          xtaskCmd = "bao1x-baremetal-dabao";
-        };
-
-        baosec = mkXousBuild {
-          pname = "baosec";
-          xtaskCmd = "baosec";
-          targetDir = "riscv32imac-unknown-xous-elf";
-        };
-
-        # Script to configure cargo vendoring in the current project directory
-        vendorSetup = pkgs.writeShellScriptBin "xous-vendor-setup" ''
-          if [ ! -f "Cargo.toml" ]; then
-            echo "Error: not in xous-core project root" >&2
-            exit 1
-          fi
-
-          mkdir -p .cargo
-
-          # Write merged vendor config covering both root and locales deps
-          cat ${mergedVendor}/config.toml > .cargo/vendor-config.toml
-          printf '\n[net]\noffline = true\n' >> .cargo/vendor-config.toml
-          echo "Wrote .cargo/vendor-config.toml (merged root + locales deps)"
-        '';
-
-        nightlyRustToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain:
-          toolchain.default.override {
-            extensions = [ "rustfmt" ];
-          }
-        );
-      in
-      {
-        packages = {
-          # Main packages
-          inherit dabao-helloworld bao1x-boot0 bao1x-alt-boot1 bao1x-boot1 bao1x-baremetal-dabao baosec;
-
-          # bootloader stage 1
-          boot1 = pkgs.runCommand "boot1" {} ''
-            mkdir -p $out
-            cp -r ${bao1x-boot1}/* ${bao1x-alt-boot1}/* $out
-          '';
-
-          # Combined bootloader package (boot0 + boot1)
-          bootloader = pkgs.runCommand "bootloader" {} ''
-            mkdir -p $out
-            cp -r ${bao1x-boot0}/* ${bao1x-boot1}/* ${bao1x-alt-boot1}/* $out
-          '';
-
-          # CI dependency caching - bundles shared dependencies
-          ci-deps = pkgs.symlinkJoin {
-            name = "xous-ci-deps";
-            paths = [
-              pkgs.rustToolchainXous
-              vendoredDeps
+      perSystem = { system, ... }:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              rust-overlay.overlays.default
+              rust-xous.overlays.default
             ];
           };
+          craneLib = (crane.mkLib pkgs).overrideToolchain pkgs.rustToolchainXous;
 
-          # Aliases
-          dabao = dabao-helloworld;
-          baremetal = bao1x-baremetal-dabao;
+          # Clean source to only include cargo-relevant files
+          src = craneLib.cleanCargoSource self;
 
-          default = dabao-helloworld;
-        };
-
-        devShells = {
-          default = pkgs.mkShell {
-            packages = [ pkgs.rustToolchainXous vendorSetup ];
-            shellHook = ''
-              # Generate vendor config for offline builds
-              xous-vendor-setup
-
-              echo "──────────────────────────────────────────────────────────────"
-              echo "Xous development environment"
-              echo "  $(rustc --version)"
-              echo "  xous-core ${xousVersion}"
-              echo ""
-              echo "Installed Rust targets:"
-              ls "$(rustc --print sysroot)/lib/rustlib" | grep -v -E '^(etc|src)$' | sed 's/^/  • /'
-              echo ""
-              echo "Build commands:"
-              echo "  • nix build .#dabao-helloworld"
-              echo "  • nix build .#baosec"
-              echo "  • nix build .#bao1x-baremetal-dabao"
-              echo "  • nix build .#bao1x-boot0"
-              echo "  • nix build .#bao1x-boot1"
-              echo "  • nix build .#bao1x-alt-boot1"
-              echo ""
-              echo "Aliases:"
-              echo "  • nix build .#dabao       (dabao-helloworld)"
-              echo "  • nix build .#baremetal   (bao1x-baremetal-dabao)"
-              echo "  • nix build .#boot1       (bao1x-boot1 + bao1x-alt-boot1)"
-              echo "  • nix build .#bootloader  (bao1x-boot0 bao1x-boot1 + bao1x-alt-boot1)""
-              echo ""
-              echo "For formatting checks, use: nix develop .#nightly"
-              echo "──────────────────────────────────────────────────────────────"
-            '';
+          # Vendor all dependencies (including git deps) - this runs in a FOD with network access
+          vendoredDeps = craneLib.vendorCargoDeps {
+            inherit src;
           };
 
-          nightly = pkgs.mkShell {
-            packages = [ nightlyRustToolchain ];
-            shellHook = ''
-              echo "──────────────────────────────────────────────────────────────"
-              echo "Xous nightly development environment"
-              echo "  $(rustc --version)"
-              echo "  $(cargo --version)"
-              echo "  xous-core ${xousVersion}"
-              echo ""
-              echo "Formatting commands:"
-              echo "  • cargo fmt --check"
-              echo "  • cargo fmt"
-              echo "──────────────────────────────────────────────────────────────"
+          # Vendor locales dependencies separately (it has its own Cargo.lock)
+          localesSrc = pkgs.lib.cleanSourceWith {
+            src = self;
+            filter = path: type:
+              (pkgs.lib.hasInfix "/locales/" path) ||
+              (pkgs.lib.hasSuffix "/locales" path) ||
+              (baseNameOf path == "Cargo.toml" && dirOf path == toString self + "/locales") ||
+              (baseNameOf path == "Cargo.lock" && dirOf path == toString self + "/locales");
+          };
+
+          vendoredLocalesDeps = craneLib.vendorCargoDeps {
+            src = self + "/locales";
+          };
+
+          # Common postPatch to replace SemVer::from_git() with hardcoded version
+          patchSemver = ''
+            substituteInPlace tools/src/sign_image.rs \
+              --replace-fail 'SemVer::from_git()?.into()' '"${xousVersion}".parse::<SemVer>().unwrap().into()'
+          '';
+
+          # Patch versioning.rs to use XOUS_VERSION env var instead of git describe
+          patchVersioning = ''
+            substituteInPlace xtask/src/versioning.rs \
+              --replace-fail 'let gitver = output.stdout;' \
+                             'let gitver = std::env::var("XOUS_VERSION").map(|s| s.into_bytes()).unwrap_or(output.stdout);'
+          '';
+
+          # Patch swap_writer.rs to use GIT_REV env var instead of running git
+          patchSwapWriter = ''
+            substituteInPlace tools/src/swap_writer.rs \
+              --replace-fail 'Command::new("git").args(&["rev-parse", "HEAD"]).output().expect("Failed to execute command")' \
+                             'std::env::var("GIT_REV").map(|s| std::process::Output { status: std::process::ExitStatus::default(), stdout: s.into_bytes(), stderr: vec![] }).unwrap_or_else(|_| Command::new("git").args(&["rev-parse", "HEAD"]).output().expect("Failed to execute command"))'
+          '';
+
+          # Merge vendor directories so a single config covers both the root
+          # and locales Cargo.lock files.
+          mergedVendor = pkgs.runCommand "merged-vendor-cargo-deps" {} ''
+            # Recreate directory structure with real dirs, symlinking crates
+            for dir in ${vendoredDeps}/*/; do
+              name=$(basename "$dir")
+              mkdir -p "$out/$name"
+              for crate in "$dir"/*; do
+                ln -s "$crate" "$out/$name/$(basename "$crate")"
+              done
+            done
+
+            # Add locales-only crates into matching source dirs
+            for dir in ${vendoredLocalesDeps}/*/; do
+              name=$(basename "$dir")
+              mkdir -p "$out/$name"
+              for crate in "$dir"/*; do
+                crate_name=$(basename "$crate")
+                if [ ! -e "$out/$name/$crate_name" ]; then
+                  ln -s "$crate" "$out/$name/$crate_name"
+                fi
+              done
+            done
+
+            # Generate config.toml pointing to merged paths
+            sed "s|${vendoredDeps}|$out|g" ${vendoredDeps}/config.toml > $out/config.toml
+          '';
+
+          # Configure cargo to use vendored deps (separate file, merged via --config)
+          configureVendoring = ''
+            mkdir -p .cargo
+            cat ${mergedVendor}/config.toml > .cargo/vendor-config.toml
+            printf '\n[net]\noffline = true\n' >> .cargo/vendor-config.toml
+          '';
+
+          # Common environment for reproducible Rust builds
+          reproducibleRustEnv = ''
+            export HOME=$PWD
+            export CARGO_HOME=$PWD/.cargo
+            mkdir -p $CARGO_HOME
+            export XOUS_VERSION="${xousVersion}"
+            # Git revision for swap_writer.rs (uses last 16 hex chars of full hash)
+            export GIT_REV="${gitRevFull}"
+            export CARGO_INCREMENTAL=0
+            export RUSTFLAGS="-C codegen-units=1 --remap-path-prefix=$PWD=/build"
+            export SOURCE_DATE_EPOCH=1
+          '';
+
+          # Helper to create build derivations
+          mkXousBuild = { pname, xtaskCmd, targetDir ? "riscv32imac-unknown-none-elf" }:
+            pkgs.stdenv.mkDerivation {
+              inherit pname;
+              version = "0.1.0";
+              src = self;  # Use full source for xtask builds
+              nativeBuildInputs = [ pkgs.rustToolchainXous ];
+
+              postPatch = patchSemver + patchVersioning + patchSwapWriter;
+
+              configurePhase = configureVendoring;
+
+              buildPhase = ''
+                ${reproducibleRustEnv}
+                cargo xtask ${xtaskCmd} --config .cargo/vendor-config.toml --no-verify
+              '';
+
+              installPhase = ''
+                mkdir -p $out
+                cp target/${targetDir}/release/*.uf2 $out/ || true
+                cp target/${targetDir}/release/*.img $out/ || true
+                cp target/${targetDir}/release/*.bin $out/ || true
+              '';
+            };
+
+          dabao-helloworld = mkXousBuild {
+            pname = "dabao-helloworld";
+            xtaskCmd = "dabao helloworld";
+            targetDir = "riscv32imac-unknown-xous-elf";
+          };
+
+          bao1x-boot0 = mkXousBuild {
+            pname = "bao1x-boot0";
+            xtaskCmd = "bao1x-boot0";
+          };
+
+          bao1x-alt-boot1 = mkXousBuild {
+            pname = "bao1x-alt-boot1";
+            xtaskCmd = "bao1x-alt-boot1";
+          };
+
+          bao1x-boot1 = mkXousBuild {
+            pname = "bao1x-boot1";
+            xtaskCmd = "bao1x-boot1";
+          };
+
+          bao1x-baremetal-dabao = mkXousBuild {
+            pname = "bao1x-baremetal-dabao";
+            xtaskCmd = "bao1x-baremetal-dabao";
+          };
+
+          baosec = mkXousBuild {
+            pname = "baosec";
+            xtaskCmd = "baosec";
+            targetDir = "riscv32imac-unknown-xous-elf";
+          };
+
+          # Script to configure cargo vendoring in the current project directory
+          vendorSetup = pkgs.writeShellScriptBin "xous-vendor-setup" ''
+            if [ ! -f "Cargo.toml" ]; then
+              echo "Error: not in xous-core project root" >&2
+              exit 1
+            fi
+
+            mkdir -p .cargo
+
+            # Write merged vendor config covering both root and locales deps
+            cat ${mergedVendor}/config.toml > .cargo/vendor-config.toml
+            printf '\n[net]\noffline = true\n' >> .cargo/vendor-config.toml
+            echo "Wrote .cargo/vendor-config.toml (merged root + locales deps)"
+          '';
+
+          nightlyRustToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain:
+            toolchain.default.override {
+              extensions = [ "rustfmt" ];
+            }
+          );
+        in
+        {
+          packages = {
+            # Main packages
+            inherit dabao-helloworld bao1x-boot0 bao1x-alt-boot1 bao1x-boot1 bao1x-baremetal-dabao baosec;
+
+            # bootloader stage 1
+            boot1 = pkgs.runCommand "boot1" {} ''
+              mkdir -p $out
+              cp -r ${bao1x-boot1}/* ${bao1x-alt-boot1}/* $out
             '';
+
+            # Combined bootloader package (boot0 + boot1)
+            bootloader = pkgs.runCommand "bootloader" {} ''
+              mkdir -p $out
+              cp -r ${bao1x-boot0}/* ${bao1x-boot1}/* ${bao1x-alt-boot1}/* $out
+            '';
+
+            # CI dependency caching - bundles shared dependencies
+            ci-deps = pkgs.symlinkJoin {
+              name = "xous-ci-deps";
+              paths = [
+                pkgs.rustToolchainXous
+                vendoredDeps
+              ];
+            };
+
+            # Aliases
+            dabao = dabao-helloworld;
+            baremetal = bao1x-baremetal-dabao;
+
+            default = dabao-helloworld;
+          };
+
+          devShells = {
+            default = pkgs.mkShell {
+              packages = [ pkgs.rustToolchainXous vendorSetup ];
+              shellHook = ''
+                # Generate vendor config for offline builds
+                xous-vendor-setup
+
+                echo "──────────────────────────────────────────────────────────────"
+                echo "Xous development environment"
+                echo "  $(rustc --version)"
+                echo "  xous-core ${xousVersion}"
+                echo ""
+                echo "Installed Rust targets:"
+                ls "$(rustc --print sysroot)/lib/rustlib" | grep -v -E '^(etc|src)$' | sed 's/^/  • /'
+                echo ""
+                echo "Build commands:"
+                echo "  • nix build .#dabao-helloworld"
+                echo "  • nix build .#baosec"
+                echo "  • nix build .#bao1x-baremetal-dabao"
+                echo "  • nix build .#bao1x-boot0"
+                echo "  • nix build .#bao1x-boot1"
+                echo "  • nix build .#bao1x-alt-boot1"
+                echo ""
+                echo "Aliases:"
+                echo "  • nix build .#dabao       (dabao-helloworld)"
+                echo "  • nix build .#baremetal   (bao1x-baremetal-dabao)"
+                echo "  • nix build .#boot1       (bao1x-boot1 + bao1x-alt-boot1)"
+                echo "  • nix build .#bootloader  (bao1x-boot0 bao1x-boot1 + bao1x-alt-boot1)""
+                echo ""
+                echo "For formatting checks, use: nix develop .#nightly"
+                echo "──────────────────────────────────────────────────────────────"
+              '';
+            };
+
+            nightly = pkgs.mkShell {
+              packages = [ nightlyRustToolchain ];
+              shellHook = ''
+                echo "──────────────────────────────────────────────────────────────"
+                echo "Xous nightly development environment"
+                echo "  $(rustc --version)"
+                echo "  $(cargo --version)"
+                echo "  xous-core ${xousVersion}"
+                echo ""
+                echo "Formatting commands:"
+                echo "  • cargo fmt --check"
+                echo "  • cargo fmt"
+                echo "──────────────────────────────────────────────────────────────"
+              '';
+            };
           };
         };
-      }
-    );
+    };
 }


### PR DESCRIPTION
# Nix Flake for Reproducible Builds for Baochip targets

This PR adds Nix-based reproducible builds for Baochip firmware artifacts (dabao, baosec, bootloader, baremetal). Related to #57.

**TODO**:
- [x] Rebase against latest `dev` branch


## What is Nix?

[Nix](https://nixos.org/) is a package manager that provides reproducible builds by isolating dependencies and pinning exact versions. This ensures builds are identical across different machines and over time.

## What's Included

- `flake.nix` with build derivations for all targets
- Custom Rust toolchain (~~1.92.0~~ 1.93.0) with Xous targets built via [rust-xous-flake](https://github.com/sbellem/rust-xous-flake)
- `nix develop` shell with toolchains (riscv32imac-unknown-xous-elf & riscv32imac-unknown-none-elf)
- `nix develop .#nightly` shell with Rust nightly for `cargo fmt`
- GitHub Actions CI workflow (`.github/workflows/nix.yml`) — [example run](https://github.com/betrusted-io/xous-core/actions/runs/21177684818)
- Deterministic build verification (`nix build --rebuild`)

## Installing Nix

```bash
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
```

This installs Nix with flakes enabled. For other options, see [Determinate Systems Nix Installer](https://github.com/DeterminateSystems/nix-installer).

## Building Packages

```bash
# Build the default package (dabao-helloworld)
nix build

# Build specific packages
nix build .#dabao-helloworld
nix build .#baosec
nix build .#bootloader
```

Build outputs are placed in a `result` symlink.

## Available Packages

| Command | Alias | Description |
|---------|-------|-------------|
| `nix build .#dabao-helloworld` | `.#dabao` | Dabao hello world app |
| `nix build .#baosec` | — | Baosec application |
| `nix build .#bao1x-baremetal-dabao` | `.#baremetal` | Baremetal dabao |
| `nix build .#bao1x-boot0` | — | Bootloader stage 0 |
| `nix build .#bao1x-boot1` | — | Bootloader stage 1 |
| `nix build .#bao1x-alt-boot1` | — | Alternative boot 1 |
| `nix build .#bootloader` | — | All bootloaders (boot0 + boot1 + alt-boot1) |

## Development Shell

```bash
# Enter dev shell with stable Rust 1.92.0 + xous targets
nix develop

# Use standard cargo commands
cargo xtask dabao helloworld

# For code formatting (nightly required)
nix develop .#nightly
cargo fmt --check
cargo fmt
```

## Verifying Reproducibility

```bash
nix build --rebuild .#dabao-helloworld
```

This builds twice and compares results. If they differ, it reports an error.

## Challenges Solved
**Custom Rust target**: The `riscv32imac-unknown-xous-elf` target is built from source using Nix via [rust-xous-flake](https://github.com/sbellem/rust-xous-flake). _Note: this is not a bootstrapped build—it uses the pre-built Rust 1.92.0 compiler._

**No git in Nix sandbox**: The following files are patched at build time (via `substituteInPlace` in `flake.nix`) to use environment variables instead of git commands:
- `tools/src/sign_image.rs` — uses hardcoded version instead of `SemVer::from_git()`
- `xtask/src/versioning.rs` — reads `XOUS_VERSION` env var instead of `git describe`
- `tools/src/swap_writer.rs` — reads `GIT_REV` env var instead of `git rev-parse`

**Reproducibility**: 
- Set `SOURCE_DATE_EPOCH=1`, `CARGO_INCREMENTAL=0`, and `--remap-path-prefix` for deterministic builds
- Modified `xtask/src/versioning.rs` to use `SOURCE_DATE_EPOCH` for the build timestamp instead of `Local::now()` (commit e30d405)

**Dependency vendoring**: Used Crane to vendor Cargo dependencies. The `locales/` workspace required separate vendoring due to its own `Cargo.lock`.

## Speeding Up Builds with Cachix (Optional)

First builds compile the Rust toolchain and can be slow. [Cachix](https://www.cachix.org/) provides pre-built binaries.

**Using the public cache (read-only, no account needed):**

```bash
# Install cachix
nix profile install nixpkgs#cachix

# Enable the xous-core cache
cachix use xous-core

# Builds now download pre-built artifacts when available
nix build .#dabao-helloworld
```

**To enable CI cache writes (maintainers):**

1. Create account at [cachix.org](https://cachix.org)
2. (Optional) Create a Cachix organization for shared team ownership
3. Create public cache (e.g., `xous-core`)
4. Generate auth token with write access
5. Add secret: `gh secret set CACHIX_AUTH_TOKEN`
6. Uncomment `authToken` and `warmup-cache` sections in `.github/workflows/nix.yml`

A public cache is available at https://app.cachix.org/cache/xous-core (read-only for PRs from forks).

## Tested

- [x] dabao-helloworld on hardware
- [x] boot1 on hardware
- [x] baosec build
- [x] bao1x-baremetal-dabao build
- [x] CI workflow

## Caveats to Consider for Reviewers

- [ ] Custom Rust target is not bootstrapped—uses pre-built Rust ~~1.92.0~~ 1.93.0 compiler
- [ ] Version string (`xousVersion`) requires manual updates to `gitTag` and `gitTagRevCount` in `flake.nix` when tags change
- [ ] `locales/Cargo.lock` must be kept in sync separately from main `Cargo.lock`
- [x] Builds run with `--no-verify` flag (skips signature verification) like ci ([`.github/workflows/build.yml`](https://github.com/betrusted-io/xous-core/blob/146405fb57b2bcd47e65eaa626ba630e1588a967/.github/workflows/build.yml#L41)) does
- [x] Deterministic build check on CI (`nix build --rebuild`) runs but failures are non-blocking (`continue-on-error: true`)
- [ ] Only dabao, alt-boot1, boot1 have been tested on hardware
- [ ] `xtask/src/versioning.rs` modified to support `SOURCE_DATE_EPOCH` for reproducible timestamps
- [ ] Consider setting up Cachix to speed up CI builds
- [x] Commit https://github.com/betrusted-io/xous-core/pull/777/commits/b1b05c1082bbe240fb504940075718f0d8247286 belongs to another PR is there just to help minimize cache usage on Github CI infra 

## Troubleshooting

**"experimental features 'nix-command' and 'flakes' are disabled"**

If you installed Nix without the Determinate Systems installer, add to `~/.config/nix/nix.conf`:

```
experimental-features = nix-command flakes
```

Then restart your shell or run `sudo systemctl restart nix-daemon` (Linux).

---

# Outdated section

> **Note**: This section documents some parts of the development process and is kept for historical reference.

<details><summary>(click to expand)</summary>

Still needs some work, but should work to build dabao helloworld, dabao-console, and boot1.

To use it, run `nix develop` to enter the dev shell, and then `cargo xtask` commands to build uf2 artifacts.

- [x] test helloworld uf2 files on dabao dev board
- [x] test boot1 uf2 files on dabao dev board
- [x] build artifacts with `nix build` (wip at https://github.com/sbellem/xous-core/blob/nix-build/flake.nix)
- [x] build `riscv32imac-unknown-xous-elf` with nix (wip at https://github.com/sbellem/rust-xous-flake/tree/main)
- [x] add ci

## Some challenges
In sandboxed environments for `nix build`, `git` is not available, and therefore image signing via xous-semver fails as it relies on `git describe` to get the version. The current workaround is to patch the code "dynamically" in `flake.nix` to read a hardcoded base version combined with the git revision which `nix` has access to (`self.shortRev`). This still does not exactly match the output of `git describe` and thus needs to be addressed properly.

- [x] Figure out how to get semver without `git describe` for nix build sandboxed environment where `git` is not available.

Current `flake.nix` does not yield reproducible builds. This can be tested with `nix build .#dabao --rebuild` for instance.

- [x] Figure out how to get reproducible builds. **NOTE**: some changes had to be made to xous-core code to replace a timestamp with UNIX epoch time. -- perhaps this could be avoided with an in-place substitution (?).

Also relate to the sandbox environment, which does not have git access, we need to vendor dependencies.

- [x] Vendor dependencies, with crane or some other tools.

**Note that in order to make the above work (build without git access, in offline mode), ~~Cargo lock files had to be updated, and~~ we run the xtask commands with `--offline` and `--no-verify`.**

### CI Cache Over-usage Issue
- [x] Need to figure out how to fine-tune caching so that it does not max out the cache capacity (10 GB). 

In the meantime work is being done on fork at https://github.com/sbellem/xous-core/tree/nix-troubleshoot.

**Answer**: Use cachix

A public cache has been setup at https://app.cachix.org/cache/xous-core. For PRs from forks it can only be used to pull (read-only). To support pushes (writes) betrusted-io would need to add an auth token.
</details>