### PR TITLE
Baobit audit

### DIFF
--- a/libs/bao1x-api/src/signatures.rs
+++ b/libs/bao1x-api/src/signatures.rs
@@ -162,6 +162,16 @@ pub struct SealedFields {
     ///
     /// If no valid keys are found, the device is effectively bricked and goes into a "die" state.
     pub pubkeys: [Pubkey; 4],
+    /// Placeholder for baobit commit: this is the hash of the toolchain used to generate the image.
+    /// In many images, this is just 0's; but for signed release images, this is injected into the file
+    /// prior to applying the final signature. This injection has to happen after everything is done
+    /// because the rules of the reproducible build system disallow it from knowing its final commit
+    /// state: you have to commit its final state, which changes its reported commit state, and so
+    /// forth, so at build time you can't know what toolchain was used to build you - only after
+    /// the build is complete is the information revealed to the user.
+    ///
+    /// This field is long enough to hold a SHA-1 git hash.
+    pub toolchain: [u8; 20],
 }
 
 impl AsRef<[u8]> for SealedFields {
@@ -178,6 +188,7 @@ impl Default for SealedFields {
             min_semver: [0u8; 16],
             semver: [0u8; 16],
             pubkeys: [Pubkey::default(); 4],
+            toolchain: [0u8; 20],
         }
     }
 }

--- a/tools/restore.py
+++ b/tools/restore.py
@@ -657,6 +657,7 @@ def main():
             # now try to download all the artifacts and check their versions
             # this list should visit kernels in order from newest to oldest.
             URL_LIST = [
+                'https://ci.betrusted.io/releases/v0.10.0/',
                 'https://ci.betrusted.io/releases/v0.9.16/',
                 'https://ci.betrusted.io/releases/v0.9.15/',
                 'https://ci.betrusted.io/releases/v0.9.14/',

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -60,8 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let do_version = env::args().filter(|x| x == "--no-timestamp").count() == 0;
     let git_describe_opt = get_flag("--git-describe")?.first().cloned();
     let git_rev_opt = get_flag("--git-rev")?.first().cloned();
-    let baobit_commit_opt = get_flag("--baobit-commit")?.first().cloned();
-    generate_version(do_version, git_describe_opt.clone(), baobit_commit_opt.clone());
+    generate_version(do_version, git_describe_opt.clone());
     if let Some(desc) = git_describe_opt {
         builder.set_git_describe(desc);
     }

--- a/xtask/src/versioning.rs
+++ b/xtask/src/versioning.rs
@@ -27,11 +27,7 @@ fn write_if_changed(path: &str, new_data: &[u8]) {
     vfile.write_all(new_data).expect(&format!("couldn't write to {}", path));
 }
 
-pub(crate) fn generate_version(
-    add_timestamp: bool,
-    forced_version: Option<String>,
-    baobit_commit: Option<String>,
-) {
+pub(crate) fn generate_version(add_timestamp: bool, forced_version: Option<String>) {
     let gitver = {
         if let Some(ver) = forced_version {
             ver.as_bytes().to_vec()
@@ -77,17 +73,7 @@ pub(crate) fn generate_version(
     .expect("couldn't add our semver");
     new_data.extend_from_slice(&semver_code);
 
-    // Baochip versioning is just SEMVER + BAOBIT_COMMIT. Now that
-    // the semver_code has been added to new_data, we can extend it with the Baobit commit.
-    if let Some(ref commit) = baobit_commit {
-        writeln!(semver_code, "pub const BAOBIT_COMMIT: &'static str = \"{}\";", commit)
-            .expect("couldn't add baobit commit");
-    } else {
-        // For builds that aren't built in the reproducible environment, the baobit commit is unspecified
-        writeln!(semver_code, "pub const BAOBIT_COMMIT: &'static str = \"unspecified\";")
-            .expect("couldn't add baobit commit placeholder");
-    }
-
+    // Baochip versioning is just SEMVER
     write_if_changed(version_file, &new_data);
     write_if_changed(boot0_version_file, &semver_code);
     write_if_changed(boot1_version_file, &semver_code);


### PR DESCRIPTION
Contains the code needed to shuffle the baobit toolchain injection until the final signing operation.
