### PR TITLE
add support for more keyboard input configs on baosec

### DIFF
--- a/apps-baosec/vault2/src/main.rs
+++ b/apps-baosec/vault2/src/main.rs
@@ -378,7 +378,7 @@ fn main() -> ! {
             }
             Some(VaultOp::KeyPress) => xous::msg_scalar_unpack!(msg, k1, _k2, _k3, _k4, {
                 let k = char::from_u32(k1 as u32).unwrap_or('\u{0000}');
-                log::info!("key {}", k);
+                log::debug!("key {:x}", k1);
                 if menu_active {
                     menu_mgr.key_press(k);
                 } else {
@@ -488,6 +488,9 @@ fn main() -> ! {
                             .ok();
                             vault_ui.refresh_draw_list();
                             vault_ui.redraw();
+                        }
+                        '⏯' => {
+                            log::info!("accel event");
                         }
                         _ => {
                             log::trace!("unhandled key {}", k);

--- a/libs/bao1x-hal/Cargo.toml
+++ b/libs/bao1x-hal/Cargo.toml
@@ -73,6 +73,7 @@ board-baosec = [
     "ux-api/std",
 ] # USB form factor token
 # "lite" variant of baosec. Shares the same basic flags but some things remapped when this is added.
+accel-kbd = []
 oem-baosec-lite = ["sensor-lis2dh12"]
 
 loader-baosec = [

--- a/libs/bao1x-hal/src/board/baosec.rs
+++ b/libs/bao1x-hal/src/board/baosec.rs
@@ -397,6 +397,8 @@ pub enum KeyPress {
     Left,
     Center,
     Right,
+    #[cfg(feature = "accel-kbd")]
+    Accel,
     Invalid,
     None,
 }
@@ -435,12 +437,13 @@ pub fn scan_keyboard<T: IoSetup + IoGpio>(
 
 // key:    sr1 & 0xFF | sr0 & 0xFF
 //  -- must read sr0 to pick up multiple key hit --
-// down:   0x10 | 0xfffe 1111_1110
-// select: 0x11 | 0xfffd 1111_1101 (press in on jog dial)
-// up:     0x12 | 0xfffb 1111_1011
-// right:  0x14 | 0xffef 1110_1111
-// left:   0x15 | 0xffdf 1101_1111
-// center: 0x16 | 0xffbf 1011_1111
+// down:   0x10 | 0xfffe 1111_1111_1110
+// select: 0x11 | 0xfffd 1111_1111_1101 (press in on jog dial)
+// up:     0x12 | 0xfffb 1111_1111_1011
+// right:  0x14 | 0xffef 1111_1110_1111
+// left:   0x15 | 0xffdf 1111_1101_1111
+// center: 0x16 | 0xffbf 1111_1011_1111
+// accel:  0x19 | 0xfdff 1101_1111_1111
 
 /// SR0 will contain the current raw status of all the keys and the interrupt
 /// system will continue to notify us that an event is happening until all keys
@@ -452,7 +455,7 @@ pub fn kpc_sr0_to_key(raw_event: u32) -> [KeyPress; 4] {
     let mut key_presses: [KeyPress; 4] = [KeyPress::None; 4];
     let mut key_press_index = 0;
     let masked = raw_event & 0x7F;
-    for position in 0..7 {
+    for position in 0..12 {
         if (masked & (1 << position)) == 0 {
             let kp_candidate = match position {
                 0 => KeyPress::Down,
@@ -461,6 +464,8 @@ pub fn kpc_sr0_to_key(raw_event: u32) -> [KeyPress; 4] {
                 4 => KeyPress::Right,
                 5 => KeyPress::Left,
                 6 => KeyPress::Center,
+                #[cfg(feature = "accel-kbd")]
+                9 => KeyPress::Accel,
                 _ => KeyPress::Invalid,
             };
             if kp_candidate != KeyPress::Invalid && key_press_index < key_presses.len() {
@@ -487,6 +492,8 @@ pub fn kpc_sr1_to_key(raw_event: u32) -> KeyPress {
         0x14 => KeyPress::Right,
         0x15 => KeyPress::Left,
         0x16 => KeyPress::Center,
+        #[cfg(feature = "accel-kbd")]
+        0x19 => KeyPress::Accel,
         _ => KeyPress::Invalid,
     }
 }

--- a/services/bao1x-hal-service/Cargo.toml
+++ b/services/bao1x-hal-service/Cargo.toml
@@ -48,9 +48,11 @@ swap = []
 mpw = ["bao1x-hal/mpw"]
 bmp180 = ["bao1x-hal/bmp180"]
 board-baosec = ["bao1x-hal/board-baosec"]
-oem-baosec-lite = ["bao1x-hal/oem-baosec-lite"]
 board-baosor = ["bao1x-hal/board-baosor"]
 board-dabao = ["bao1x-hal/board-dabao"]
+
+accel-kbd = []
+oem-baosec-lite = ["bao1x-hal/oem-baosec-lite"]
 
 with-duart = ["bao1x-hal/debug-print-duart"]
 default = ["app-uart", "utralib"]

--- a/services/bao1x-hal-service/src/servers/keyboard.rs
+++ b/services/bao1x-hal-service/src/servers/keyboard.rs
@@ -137,6 +137,8 @@ fn map_keypress(kp: KeyPress) -> char {
         // by mapping "fire" to the center key, we get a UI-specific action key without invoking
         // shell commands in the background unintentionally.
         KeyPress::Center => '🔥',
+        #[cfg(feature = "accel-kbd")]
+        KeyPress::Accel => '⏯',
         _ => '\u{0000}',
     }
 }
@@ -466,6 +468,7 @@ fn keyboard_service() {
                     if kpc_aoint.kpc.r(utra::dkpc::SFR_SR1) != 0 {
                         let sr1 = unsafe { kpc_aoint.kpc.base().add(8).read_volatile() };
                         let key_down = bao1x_hal::board::kpc_sr1_to_key(sr1);
+                        log::info!("{:?}", key_down);
                         key_tracker.register_key_down(key_down, now);
                         if key_down != KeyPress::Invalid {
                             kc.push(map_keypress(key_down))


### PR DESCRIPTION
minor changes and improvements to keyboard handler behavior

probably revealing some need for more abstractions/APIs to deal with more keyboard types and formats, but the problem is only slowly starting to become clear tome.