### PR TITLE
xtask: support and propagate cargo --config arg 

### DIFF
--- a/xtask/src/builder.rs
+++ b/xtask/src/builder.rs
@@ -184,6 +184,7 @@ pub(crate) struct Builder {
     detached_app_features: Vec<String>,
     git_describe: Option<String>,
     git_rev: Option<String>,
+    cargo_configs: Vec<String>,
 }
 
 impl Builder {
@@ -219,7 +220,13 @@ impl Builder {
             detached_app_features: Vec::new(),
             git_describe: None,
             git_rev: None,
+            cargo_configs: Vec::new(),
         }
+    }
+
+    pub fn set_cargo_configs(&mut self, configs: Vec<String>) -> &mut Builder {
+        self.cargo_configs = configs;
+        self
     }
 
     pub fn set_git_describe(&mut self, git_describe: String) -> &mut Builder {
@@ -675,7 +682,7 @@ impl Builder {
             }
             println!();
             // build
-            let status = Command::new(cargo()).current_dir(project_root()).args(&local_args).status()?;
+            let status = cargo(&self.cargo_configs).current_dir(project_root()).args(&local_args).status()?;
             if !status.success() {
                 return Err("Local build failed".into());
             }
@@ -700,7 +707,7 @@ impl Builder {
                 }
                 println!(" {} {}", name, version);
                 // build
-                let status = Command::new(cargo())
+                let status = cargo(&self.cargo_configs)
                     .current_dir(project_root())
                     .args([&remote_args[..], &[name, "--version", version].to_vec()[..]].concat())
                     .status()?;
@@ -906,7 +913,7 @@ impl Builder {
                     print!(" {}", arg);
                 }
                 println!();
-                let status = Command::new(cargo()).current_dir(dir).args(&hosted_args).status()?;
+                let status = cargo(&self.cargo_configs).current_dir(dir).args(&hosted_args).status()?;
                 if !status.success() {
                     return Err("cargo run failed to launch hosted mode".into());
                 }
@@ -985,7 +992,7 @@ impl Builder {
                 presign_file
                     .push(format!("{}-presign.img", self.loader.name().unwrap_or("baremetal".to_string())));
 
-                let status = Command::new(cargo())
+                let status = cargo(&self.cargo_configs)
                     .current_dir(project_root())
                     .args([
                         "run",
@@ -1021,7 +1028,7 @@ impl Builder {
                         Some(gd) => vec!["--git-describe", gd],
                         None => vec![],
                     };
-                    Command::new(cargo())
+                    cargo(&self.cargo_configs)
                         .current_dir(project_root())
                         .args([
                             "run",
@@ -1080,7 +1087,7 @@ impl Builder {
 
             // ------ if targeting renode, regenerate the Platform file -----
             if self.run_svd2repl {
-                Command::new(cargo())
+                cargo(&self.cargo_configs)
                     .current_dir(project_root())
                     .args([
                         "run",
@@ -1116,7 +1123,7 @@ impl Builder {
             loader_bin.push("loader.bin");
             let mut loader_presign = output_bundle.parent().unwrap().to_owned();
             loader_presign.push("loader_presign.bin");
-            let status = Command::new(cargo())
+            let status = cargo(&self.cargo_configs)
                 .current_dir(project_root())
                 .args([
                     "run",
@@ -1139,7 +1146,7 @@ impl Builder {
                 None => vec![],
             };
             let status = if self.utra_target.contains("bao1x") {
-                Command::new(cargo())
+                cargo(&self.cargo_configs)
                     .current_dir(project_root())
                     .args([
                         "run",
@@ -1166,7 +1173,7 @@ impl Builder {
                     .args(&git_describe_args)
                     .status()?
             } else {
-                Command::new(cargo())
+                cargo(&self.cargo_configs)
                     .current_dir(project_root())
                     .args([
                         "run",
@@ -1195,7 +1202,7 @@ impl Builder {
             xous_img_path.push("xous.img");
 
             let status = if self.utra_target.contains("bao1x") {
-                Command::new(cargo())
+                cargo(&self.cargo_configs)
                     .current_dir(project_root())
                     .args([
                         "run",
@@ -1223,7 +1230,7 @@ impl Builder {
                     .args(&git_describe_args)
                     .status()?
             } else {
-                Command::new(cargo())
+                cargo(&self.cargo_configs)
                     .current_dir(project_root())
                     .args([
                         "run",
@@ -1357,7 +1364,7 @@ impl Builder {
             args.push(git_describe);
         }
 
-        let status = Command::new(cargo()).current_dir(project_root()).args(&args).status()?;
+        let status = cargo(&self.cargo_configs).current_dir(project_root()).args(&args).status()?;
 
         if !status.success() {
             return Err("cargo build failed".into());
@@ -1391,7 +1398,7 @@ impl Builder {
         let detached_offset =
             format!("{}", bao1x_api::offsets::dabao::APP_RRAM_START - bao1x_api::offsets::KERNEL_START);
         args.push(&detached_offset);
-        let status = Command::new(cargo()).current_dir(project_root()).args(&args).status()?;
+        let status = cargo(&self.cargo_configs).current_dir(project_root()).args(&args).status()?;
 
         if !status.success() {
             return Err("cargo build failed".into());
@@ -1404,7 +1411,7 @@ impl Builder {
             Some(gd) => vec!["--git-describe", gd],
             None => vec![],
         };
-        Command::new(cargo())
+        cargo(&self.cargo_configs)
             .current_dir(project_root())
             .args([
                 "run",
@@ -1508,7 +1515,13 @@ impl Builder {
     }
 }
 
-pub fn cargo() -> String { env::var("CARGO").unwrap_or_else(|_| "cargo".to_string()) }
+pub fn cargo(configs: &[String]) -> Command {
+    let mut cmd = Command::new(env::var("CARGO").unwrap_or_else(|_| "cargo".to_string()));
+    for path in configs {
+        cmd.args(["--config", path]);
+    }
+    cmd
+}
 
 pub fn project_root() -> PathBuf {
     Path::new(&env!("CARGO_MANIFEST_DIR")).ancestors().nth(1).unwrap().to_path_buf()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -67,6 +67,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(rev) = git_rev_opt {
         builder.set_git_rev(rev);
     }
+    let cargo_configs = get_flag("--config")?;
+    builder.set_cargo_configs(cargo_configs.clone());
     if do_version {
         builder.add_feature("timestamp");
     };
@@ -184,7 +186,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for feature in features {
         builder.add_feature(&feature);
         if feature.starts_with("xous/lang-") {
-            track_language_changes(&feature)?;
+            track_language_changes(&feature, &cargo_configs)?;
             language_set = true;
         }
     }
@@ -203,7 +205,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if !language_set {
         // the default language is english
-        track_language_changes("en")?;
+        track_language_changes("en", &cargo_configs)?;
     }
     let gdb_stub = env::args().filter(|x| x == "--gdb-stub").count() != 0;
     if gdb_stub {
@@ -622,7 +624,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             local_args.push("artybio");
 
             let status =
-                std::process::Command::new(cargo()).current_dir(project_root()).args(&local_args).status()?;
+                cargo(&cargo_configs).current_dir(project_root()).args(&local_args).status()?;
             if !status.success() {
                 return Err("Baremetal build failed".into());
             }
@@ -862,8 +864,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // ---- other single-purpose commands ----
-        Some("generate-locales") => generate_locales()?,
-        Some("wycheproof-import") => wycheproof_import()?,
+        Some("generate-locales") => generate_locales(&cargo_configs)?,
+        Some("wycheproof-import") => wycheproof_import(&cargo_configs)?,
         Some("dummy-template") => generate_app_menus(&Vec::new()),
         task => {
             if let Some(task) = task {

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -371,12 +371,12 @@ pub(crate) fn ensure_compiler(
 }
 
 /// Regenerate the locales files. This is only done when the command is explicitly run.
-pub(crate) fn generate_locales() -> Result<(), std::io::Error> {
+pub(crate) fn generate_locales(cargo_configs: &[String]) -> Result<(), std::io::Error> {
     let ts = filetime::FileTime::from_system_time(std::time::SystemTime::now());
     filetime::set_file_mtime("locales/src/lib.rs", ts)?;
     let mut path = project_root();
     path.push("locales");
-    let status = Command::new(cargo()).current_dir(path).args(["build", "--package", "locales"]).status()?;
+    let status = cargo(cargo_configs).current_dir(path).args(["build", "--package", "locales"]).status()?;
     if !status.success() {
         return Err(std::io::Error::new(std::io::ErrorKind::Other, "Couldn't generate the locales"));
     }
@@ -384,10 +384,10 @@ pub(crate) fn generate_locales() -> Result<(), std::io::Error> {
 }
 
 /// Import the Wycheproof test vectors
-pub(crate) fn wycheproof_import() -> Result<(), crate::DynError> {
+pub(crate) fn wycheproof_import(cargo_configs: &[String]) -> Result<(), crate::DynError> {
     let input_file = "tools/wycheproof-import/x25519_test.json";
     let output_file = "services/shellchat/src/cmds/x25519_test.bin";
-    let status = Command::new(cargo())
+    let status = cargo(cargo_configs)
         .current_dir(project_root())
         .args(["run", "--package", "wycheproof-import", "--", input_file, output_file])
         .status()?;
@@ -401,7 +401,7 @@ pub(crate) fn wycheproof_import() -> Result<(), crate::DynError> {
     Ok(())
 }
 
-pub(crate) fn track_language_changes(last_lang: &str) -> Result<(), crate::DynError> {
+pub(crate) fn track_language_changes(last_lang: &str, cargo_configs: &[String]) -> Result<(), crate::DynError> {
     let last_config = "target/LAST_LANG";
     let mut contents = String::new();
 
@@ -416,7 +416,7 @@ pub(crate) fn track_language_changes(last_lang: &str) -> Result<(), crate::DynEr
         println!("Locale language changed to {}", last_lang);
         let mut file = OpenOptions::new().create(true).write(true).truncate(true).open(last_config).unwrap();
         write!(file, "{}", last_lang).unwrap();
-        generate_locales()?
+        generate_locales(cargo_configs)?
     } else {
         println!("No change to the target locale language of {}", contents);
     }


### PR DESCRIPTION
### Problem

There is no way to pass extra cargo configuration (e.g. vendored source paths) through `cargo xtask` to the underlying cargo invocations. This is needed for offline/sandboxed builds where a custom `.cargo/config.toml` must be merged in.

### Proposed Solution

Accept `--config` flags in `cargo xtask` and thread them through all internal cargo invocations.

The `cargo()` helper is refactored from returning a `String` to returning a `Command` with the config flags already applied, so every call site picks them up automatically.

### Usage

```
cargo xtask dabao --config .cargo/vendor.toml
```

### Files changed

- `xtask/src/main.rs` — parse `--config` flag, pass to builder and utility functions
- `xtask/src/builder.rs` — store configs in `Builder`, refactor `cargo()` to return `Command`
- `xtask/src/utils.rs` — thread `cargo_configs` through `generate_locales()`, `wycheproof_import()`, `track_language_changes()`
