### PR TITLE
fix: use runtime CARGO_MANIFEST_DIR

### DIFF
--- a/locales/build.rs
+++ b/locales/build.rs
@@ -144,5 +144,5 @@ fn main() {
 }
 
 fn project_root() -> PathBuf {
-    Path::new(&env!("CARGO_MANIFEST_DIR")).ancestors().nth(1).unwrap().to_path_buf()
+    Path::new(&std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set — this binary must be run via cargo")).ancestors().nth(1).unwrap().to_path_buf()
 }

--- a/xtask/src/builder.rs
+++ b/xtask/src/builder.rs
@@ -1511,7 +1511,7 @@ impl Builder {
 pub fn cargo() -> String { env::var("CARGO").unwrap_or_else(|_| "cargo".to_string()) }
 
 pub fn project_root() -> PathBuf {
-    Path::new(&env!("CARGO_MANIFEST_DIR")).ancestors().nth(1).unwrap().to_path_buf()
+    Path::new(&std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set — this binary must be run via cargo")).ancestors().nth(1).unwrap().to_path_buf()
 }
 
 use std::fs::File;


### PR DESCRIPTION
### Problem
`project_root()` in `locales/build.rs` and `xtask/src/builder.rs` uses the `env!("CARGO_MANIFEST_DIR")` macro, which captures the path at compile time. When the compiled binary runs in a different location than where it was originally built --- such as inside a Guix/Nix build sandbox or container -- the baked-in path is stale and points to the wrong directory.

### Proposed Solution
Replace `env!("CARGO_MANIFEST_DIR")` with `std::env::var("CARGO_MANIFEST_DIR")`. This reads the variable at runtime, so it always reflects the actual workspace location.

Files changed:
* `locales/build.rs`
* `xtask/src/builder.rs`