### PR TITLE
Backup register features & SPIM timeout fixes

### DIFF
--- a/bao1x-boot/boot1/src/main.rs
+++ b/bao1x-boot/boot1/src/main.rs
@@ -219,10 +219,10 @@ pub unsafe extern "C" fn rust_entry() -> ! {
     // needed after reset for the display to initialize
     if let Some(ref mut sh1107) = oled {
         // show the boot logo
-        sh1107.init();
+        sh1107.init().ok();
         delay(100);
         sh1107.blit_screen(&ux_api::bitmaps::baochip128x128::BITMAP);
-        sh1107.draw();
+        sh1107.draw().ok();
         delay(150);
     } else {
         delay(250);
@@ -450,5 +450,5 @@ pub fn marquee(sh1107: &mut Oled128x128, msg: &str) {
         bao1x_hal::sh1107::Mono::White.into(),
         bao1x_hal::sh1107::Mono::Black.into(),
     );
-    sh1107.draw();
+    sh1107.draw().ok();
 }

--- a/bao1x-boot/boot1/src/platform/bao1x/usb/handlers.rs
+++ b/bao1x-boot/boot1/src/platform/bao1x/usb/handlers.rs
@@ -364,6 +364,7 @@ pub fn usb_ep1_bulk_out_complete(
                                             None,
                                         ),
                                         false,
+                                        ((100_000_000 / 2) / 2_000_000) as u8,
                                     ),
                                     &iox,
                                 )

--- a/libs/bao1x-api/src/lib.rs
+++ b/libs/bao1x-api/src/lib.rs
@@ -18,7 +18,7 @@ pub mod signatures;
 pub use offsets::*;
 pub mod clocks;
 pub mod pubkeys;
-use arbitrary_int::u31;
+use arbitrary_int::u30;
 use bitbybit::bitfield;
 pub use clocks::*;
 pub mod bio;
@@ -65,8 +65,13 @@ pub const AUTO_AUDIT_LIMIT: u32 = 3;
 #[bitfield(u32)]
 #[derive(PartialEq, Eq, Debug)]
 pub struct BackupFlags {
-    #[bits(1..=31, rw)]
-    reserved: u31,
+    #[bits(2..=31, rw)]
+    reserved: u30,
+    /// When true, the system has previously booted. This is reserved for OS-level management. It is
+    /// not automatically managed by the bootloader. However, after an AORST_N, the flag should be `false`
+    /// by hardware design.
+    #[bit(1, rw)]
+    warm_boot: bool,
     /// When `false`, indicates that the time in the RTC register is not synchronized to the offset
     /// that is read from disk. Upon first encounter with an external time source, the offset should
     /// be captured and recorded to disk.

--- a/libs/bao1x-hal/src/buram.rs
+++ b/libs/bao1x-hal/src/buram.rs
@@ -1,7 +1,7 @@
 use core::ops::Range;
 
 const KEY_RANGE: Range<usize> = 2..8;
-const KEY_LEN: usize = range_len(KEY_RANGE) * size_of::<u32>();
+pub const KEY_LEN: usize = range_len(KEY_RANGE) * size_of::<u32>();
 const HASH_LOC: usize = 0;
 const FLAGS_LOC: usize = 1;
 

--- a/libs/bao1x-hal/src/sh1107.rs
+++ b/libs/bao1x-hal/src/sh1107.rs
@@ -466,7 +466,13 @@ impl<'a> Oled128x128<'a> {
                 .txrx_data_async_from_parts::<u8>(total_buf_len, len, true, false)
                 .expect("Couldn't initiate oled command");
         }
-        self.spim.txrx_await(false).map(|_| ())
+        self.spim
+            .txrx_await(false)
+            .inspect_err(|_| {
+                #[cfg(feature = "std")]
+                log::error!("timeout in send_command");
+            })
+            .map(|_| ())
     }
 
     pub fn init(&mut self) -> Result<(), xous::Error> {
@@ -612,7 +618,10 @@ impl<'a> FrameBuffer for Oled128x128<'a> {
                     .txrx_data_async_from_parts::<u8>(page * chunk_size, chunk_size, true, false)
                     .expect("Couldn't initiate oled data transfer");
             }
-            self.spim.txrx_await(false)?;
+            self.spim.txrx_await(false).inspect_err(|_| {
+                #[cfg(feature = "std")]
+                log::error!("timeout in draw");
+            })?;
         }
         Ok(())
     }

--- a/libs/bao1x-hal/src/sh1107.rs
+++ b/libs/bao1x-hal/src/sh1107.rs
@@ -183,6 +183,7 @@ pub struct Oled128x128<'a> {
     powerdown: bool,
     power_port: IoxPort,
     power_pin: u8,
+    clk_div: u8,
 }
 
 impl<'a> Oled128x128<'a> {
@@ -267,7 +268,17 @@ impl<'a> Oled128x128<'a> {
             power_port,
             power_pin,
             powerdown: false,
+            clk_div: ((perclk_freq / 2) / 2_000_000) as u8,
         }
+    }
+
+    // used to recover a wedged SPI interface
+    pub fn reinit_spi(&mut self) {
+        self.spim.send_cmd_list(&[crate::udma::SpimCmd::Config(
+            SpimClkPol::LeadingEdgeRise,
+            SpimClkPha::CaptureOnLeading,
+            self.clk_div,
+        )]);
     }
 
     /// This should only be called to initialize the panic handler with its own
@@ -300,8 +311,9 @@ impl<'a> Oled128x128<'a> {
             Option<CommandSet>,
         ),
         bool,
+        u8,
     ) {
-        (self.spim.into_raw_parts(), self.powerdown)
+        (self.spim.into_raw_parts(), self.powerdown, self.clk_div)
     }
 
     /// Creates a clone of the display handle. This is only safe if the handles are used in a
@@ -331,6 +343,7 @@ impl<'a> Oled128x128<'a> {
                 Option<CommandSet>,
             ),
             bool,
+            u8,
         ),
         iox: &'a T,
     ) -> Self
@@ -354,6 +367,7 @@ impl<'a> Oled128x128<'a> {
                 command_set,
             ),
             powerdown,
+            clk_div,
         ) = display_parts;
         // compile them into a new object
         let mut spim = unsafe {
@@ -398,6 +412,7 @@ impl<'a> Oled128x128<'a> {
             powerdown,
             power_pin,
             power_port,
+            clk_div,
         }
     }
 
@@ -407,7 +422,7 @@ impl<'a> Oled128x128<'a> {
 
     pub fn screen_size(&self) -> Point { Point::new(WIDTH, LINES) }
 
-    pub fn redraw(&mut self) { self.draw(); }
+    pub fn redraw(&mut self) -> Result<(), xous::Error> { self.draw() }
 
     pub fn blit_screen(&mut self, bmp: &[u32]) { self.buffer.copy_from_slice(bmp); }
 
@@ -417,21 +432,21 @@ impl<'a> Oled128x128<'a> {
 
     pub fn stash(&mut self) { self.stash.copy_from_slice(&self.buffer); }
 
-    pub fn pop(&mut self) {
+    pub fn pop(&mut self) -> Result<(), xous::Error> {
         self.buffer.copy_from_slice(&self.stash);
-        self.redraw();
+        self.redraw()
     }
 
     fn set_data(&self) { self.iox.set_gpio_pin_value(self.cd_port, self.cd_pin, IoxValue::High); }
 
     fn set_command(&self) { self.iox.set_gpio_pin_value(self.cd_port, self.cd_pin, IoxValue::Low); }
 
-    pub fn send_command<'b, U>(&'b mut self, cmd: U)
+    pub fn send_command<'b, U>(&'b mut self, cmd: U) -> Result<(), xous::Error>
     where
         U: IntoIterator<Item = u8> + 'b,
     {
         if self.powerdown {
-            return;
+            return Ok(());
         }
         self.set_command();
         let total_buf_len = self.buffer.len() * size_of::<u32>();
@@ -451,16 +466,12 @@ impl<'a> Oled128x128<'a> {
                 .txrx_data_async_from_parts::<u8>(total_buf_len, len, true, false)
                 .expect("Couldn't initiate oled command");
         }
-        self.spim.txrx_await(false).unwrap_or_else(|_e| {
-            #[cfg(feature = "std")]
-            log::error!("txrx err {:?}", _e);
-            &[]
-        });
+        self.spim.txrx_await(false).map(|_| ())
     }
 
-    pub fn init(&mut self) {
+    pub fn init(&mut self) -> Result<(), xous::Error> {
         if self.powerdown {
-            return;
+            return Ok(());
         }
         use Command::*;
         let init_sequence = [
@@ -483,17 +494,18 @@ impl<'a> Oled128x128<'a> {
 
         for command in init_sequence {
             let bytes = command.encode();
-            self.send_command(bytes);
+            self.send_command(bytes)?;
         }
         // clear the frame buffer
         self.buffer_mut().fill(0xFFFF_FFFF);
-        self.draw();
+        self.draw()?;
 
         let display_on = [DisplayOnOff(DisplayState::On)];
         for command in display_on {
             let bytes = command.encode();
-            self.send_command(bytes);
+            self.send_command(bytes)?;
         }
+        Ok(())
     }
 
     pub fn powerdown(&mut self) {
@@ -516,9 +528,9 @@ impl<'a> Oled128x128<'a> {
         self.powerdown = false;
     }
 
-    pub fn brightness(&mut self, level: u8) {
+    pub fn brightness(&mut self, level: u8) -> Result<(), xous::Error> {
         let bytes = Command::SetContrastControl(level).encode();
-        self.send_command(bytes);
+        self.send_command(bytes)
     }
 
     #[cfg(feature = "std")]
@@ -574,10 +586,10 @@ impl<'a> Oled128x128<'a> {
 
 impl<'a> FrameBuffer for Oled128x128<'a> {
     /// Copies the SRAM buffer to IFRAM and then transfers that over SPI
-    fn draw(&mut self) {
+    fn draw(&mut self) -> Result<(), xous::Error> {
         self.hw_buf.copy_from_slice(&self.buffer);
         if self.powerdown {
-            return;
+            return Ok(());
         }
         let chunk_size = 16;
         let chunks = self.buffer().len() * size_of::<u32>() / chunk_size;
@@ -588,8 +600,8 @@ impl<'a> FrameBuffer for Oled128x128<'a> {
             // the transaction is done before the data is done transmitting, and we have to
             // toggle set_data() only after the physical transaction is done, not after the
             // the last UDMA action has been queued.
-            self.send_command(Command::SetPageAddress(0).encode());
-            self.send_command(Command::SetColumnAddress(page as u8).encode());
+            self.send_command(Command::SetPageAddress(0).encode())?;
+            self.send_command(Command::SetColumnAddress(page as u8).encode())?;
             // wait for commands to finish before toggling set_data
             // self.spim.tx_data_await(false);
             // crate::println!("Send page {}, offset {:x}", page, page * chunk_size);
@@ -600,12 +612,9 @@ impl<'a> FrameBuffer for Oled128x128<'a> {
                     .txrx_data_async_from_parts::<u8>(page * chunk_size, chunk_size, true, false)
                     .expect("Couldn't initiate oled data transfer");
             }
-            self.spim.txrx_await(false).unwrap_or_else(|_e| {
-                #[cfg(feature = "std")]
-                log::error!("txrx err {:?}", _e);
-                &[]
-            });
+            self.spim.txrx_await(false)?;
         }
+        Ok(())
     }
 
     fn clear(&mut self) { self.buffer_mut().fill(0xFFFF_FFFF); }

--- a/libs/bao1x-hal/src/udma/spim.rs
+++ b/libs/bao1x-hal/src/udma/spim.rs
@@ -476,7 +476,7 @@ impl Spim {
         &self.ifram.as_phys_slice()[..self.tx_buf_len_bytes / size_of::<T>()]
     }
 
-    fn send_cmd_list(&mut self, cmds: &[SpimCmd]) {
+    pub fn send_cmd_list(&mut self, cmds: &[SpimCmd]) {
         for cmd_chunk in cmds.chunks(SPIM_CMD_BUF_LEN_BYTES / size_of::<u32>()) {
             for (src, dst) in cmd_chunk.iter().zip(self.cmd_buf_mut().iter_mut()) {
                 *dst = (*src).into();

--- a/libs/keystore-api/src/gen2_api.rs
+++ b/libs/keystore-api/src/gen2_api.rs
@@ -15,8 +15,15 @@ pub enum Opcode {
     AesOracle = 4,
     /// initiate key wrapper operation
     AesKwp = 5,
-    /// Ephemeral secret operations
-    EphemeralOp = 256,
+    /// Ephemeral secret operations. Split into MSB/LSB pairs, because we want to strictly use
+    /// scalar messages only for this. This helps to ensure to leakage of secrets to memory pages
+    /// (there is some risk of stack spillage, but this at least reduces the attack surface).
+    /// The ephemeral secret is 192 bits long - so the `Scalar` operation is split into 1x control
+    /// word, and 3x 32 bit words that transmit the secret.
+    Ephemeral = 256,
+    /// Flag operations
+    GetFlags = 512,
+    SetFlags = 513,
 
     // ----- below are non-cryptographic opcodes but used to manipulate sensitive state -----
     /// Set bootwait parameters
@@ -25,4 +32,12 @@ pub enum Opcode {
 
     /// Used to map unknown opcodes
     InvalidCall = 65535,
+}
+
+#[derive(num_derive::FromPrimitive, num_derive::ToPrimitive, Debug)]
+pub enum EphemeralOp {
+    GetLsb,
+    SetLsb,
+    GetMsb,
+    SetMsb,
 }

--- a/libs/ux-api/src/minigfx/mod.rs
+++ b/libs/ux-api/src/minigfx/mod.rs
@@ -47,7 +47,7 @@ pub trait FrameBuffer {
     /// and background colors for a color theme.
     fn xor_pixel(&mut self, p: Point);
     /// Swaps the drawable buffer to the screen and sends it to the hardware
-    fn draw(&mut self);
+    fn draw(&mut self) -> Result<(), xous::Error>;
     /// Clears the drawable buffer
     fn clear(&mut self);
     /// Returns the size of the frame buffer as a Point
@@ -68,7 +68,7 @@ impl FrameBuffer for DynFb<'_> {
 
     fn get_pixel(&self, p: Point) -> Option<ColorNative> { self.0.get_pixel(p) }
 
-    fn draw(&mut self) { self.0.draw(); }
+    fn draw(&mut self) -> Result<(), xous::Error> { self.0.draw() }
 
     fn clear(&mut self) { self.0.clear(); }
 

--- a/loader/src/platform/bao1x/bao1x.rs
+++ b/loader/src/platform/bao1x/bao1x.rs
@@ -168,10 +168,10 @@ pub fn early_init_hw() -> u32 {
             &mut iox,
             &mut udma_global,
         );
-        sh1107.init();
+        sh1107.init().ok();
         sh1107.buffer_mut().fill(0xFFFF_FFFF);
         sh1107.blit_screen(&ux_api::bitmaps::baochip128x128::BITMAP);
-        sh1107.draw();
+        sh1107.draw().ok();
     }
 
     #[cfg(feature = "board-dabao")]
@@ -228,10 +228,10 @@ pub fn oled_init<'a>(
         iox,
         udma_global,
     );
-    sh1107.init();
+    sh1107.init().ok();
     sh1107.buffer_mut().fill(0xFFFF_FFFF);
     sh1107.blit_screen(&ux_api::bitmaps::baochip128x128::BITMAP);
-    sh1107.draw();
+    sh1107.draw().ok();
     sh1107
 }
 
@@ -415,5 +415,5 @@ pub fn progress_bar(fb: &mut dyn FrameBuffer, progress: usize) {
             false,
         );
     }
-    fb.0.draw();
+    fb.0.draw().ok();
 }

--- a/services/bao-video/src/main.rs
+++ b/services/bao-video/src/main.rs
@@ -227,9 +227,10 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
     let hal = Hal::new();
 
     let mut display = Oled128x128::new(main_thread_token, bao1x_api::PERCLK, &iox, &udma_global);
-    display.init();
+    // these unwrap because if we have a time-out at this stage, it's likely a hardware problem
+    display.init().unwrap();
     display.clear();
-    display.draw();
+    display.draw().unwrap();
 
     // ---- panic handler - set up early so we can see panics quickly
     // install the graphical panic handler. It won't catch really early panics, or panics in this crate,
@@ -522,7 +523,9 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                                 )
                             };
                             response.replace(acquisition).unwrap();
-                            display.pop();
+                            display
+                                .pop()
+                                .unwrap_or_else(|_| display_timeout_handler(&udma_global, &mut display));
                             hal.set_preemption(true);
                         }
                         // forward messages on to listeners iff we don't have an active modal
@@ -603,7 +606,9 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                             Mono::White.into(),
                             Mono::Black.into(),
                         );
-                        display.draw();
+                        display
+                            .draw()
+                            .unwrap_or_else(|_| display_timeout_handler(&udma_global, &mut display));
                         let mut img =
                             rqrr::PreparedImage::prepare_from_greyscale(IMAGE_WIDTH, IMAGE_HEIGHT, |x, y| {
                                 frame[y * IMAGE_WIDTH + x]
@@ -641,7 +646,9 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                                             )
                                         };
                                         response.replace(acquisition).unwrap();
-                                        display.pop();
+                                        display.pop().unwrap_or_else(|_| {
+                                            display_timeout_handler(&udma_global, &mut display)
+                                        });
                                         #[cfg(not(feature = "hosted-baosec"))]
                                         hal.set_preemption(true);
                                     } else {
@@ -685,7 +692,7 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                         );
                     }
 
-                    display.draw();
+                    display.draw().unwrap_or_else(|_| display_timeout_handler(&udma_global, &mut display));
 
                     // clear the front buffer
                     display.clear();
@@ -762,7 +769,9 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                 GfxOpcode::Flush => {
                     if qr_request.is_none() {
                         log::trace!("***gfx flush*** redraw##");
-                        display.redraw();
+                        display
+                            .redraw()
+                            .unwrap_or_else(|_| display_timeout_handler(&udma_global, &mut display));
                     }
                 }
                 GfxOpcode::Clear => {
@@ -797,7 +806,9 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                 GfxOpcode::DrawSleepScreen => {
                     if let Some(_scalar) = msg.body.scalar_message() {
                         display.blit_screen(&ux_api::bitmaps::baochip128x128::BITMAP);
-                        display.redraw();
+                        display
+                            .redraw()
+                            .unwrap_or_else(|_| display_timeout_handler(&udma_global, &mut display));
                     } else {
                         panic!("Incorrect message type");
                     }
@@ -805,7 +816,9 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                 GfxOpcode::DrawBootLogo => {
                     if let Some(_scalar) = msg.body.scalar_message() {
                         display.blit_screen(&ux_api::bitmaps::baochip128x128::BITMAP);
-                        display.redraw();
+                        display
+                            .redraw()
+                            .unwrap_or_else(|_| display_timeout_handler(&udma_global, &mut display));
                     } else {
                         panic!("Incorrect message type");
                     }
@@ -833,7 +846,7 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                     // no failure if it's not
                 }
                 GfxOpcode::Pop => {
-                    display.pop();
+                    display.pop().unwrap_or_else(|_| display_timeout_handler(&udma_global, &mut display));
                     if let Some(scalar) = msg.body.scalar_message_mut() {
                         // ack the message if it's a blocking scalar
                         scalar.arg1 = 1;
@@ -857,8 +870,8 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                     // safety: this is safe because we call init() a prescribed delay after power-up
                     unsafe { display.powerup() };
                     tt.sleep_ms(5).ok();
-                    display.init();
-                    display.pop();
+                    display.init().unwrap_or_else(|_| display_timeout_handler(&udma_global, &mut display));
+                    display.pop().unwrap_or_else(|_| display_timeout_handler(&udma_global, &mut display));
                     if let Some(scalar) = msg.body.scalar_message_mut() {
                         // ack the message if it's a blocking scalar
                         scalar.arg1 = 1;
@@ -874,7 +887,9 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                 GfxOpcode::Brightness => {
                     if let Some(scalar) = msg.body.scalar_message_mut() {
                         let brightness = scalar.arg1.min(255) as u8;
-                        display.brightness(brightness);
+                        display
+                            .brightness(brightness)
+                            .unwrap_or_else(|_| display_timeout_handler(&udma_global, &mut display));
                     }
                 }
                 GfxOpcode::Quit => break,
@@ -893,4 +908,10 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
     xous::destroy_server(sid).unwrap();
     log::trace!("quitting");
     xous::terminate_process(0)
+}
+
+fn display_timeout_handler(udma_global: &UdmaGlobal, display: &mut Oled128x128) {
+    log::info!("resetting display spim block");
+    udma_global.reset(PeriphId::from(bao1x_hal::board::get_display_pins().0));
+    display.reinit_spi();
 }

--- a/services/bao-video/src/main.rs
+++ b/services/bao-video/src/main.rs
@@ -912,6 +912,9 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
 
 fn display_timeout_handler(udma_global: &UdmaGlobal, display: &mut Oled128x128) {
     log::info!("resetting display spim block");
-    udma_global.reset(PeriphId::from(bao1x_hal::board::get_display_pins().0));
-    display.reinit_spi();
+    #[cfg(feature = "board-baosec")]
+    {
+        udma_global.reset(PeriphId::from(bao1x_hal::board::get_display_pins().0));
+        display.reinit_spi();
+    }
 }

--- a/services/bao-video/src/panic.rs
+++ b/services/bao-video/src/panic.rs
@@ -57,6 +57,7 @@ pub(crate) fn panic_handler_thread(
             Option<CommandSet>,
         ),
         bool,
+        u8,
     ),
 ) {
     thread::spawn({
@@ -111,7 +112,7 @@ pub(crate) fn panic_handler_thread(
                         }
                     }
 
-                    display.draw();
+                    display.draw().ok();
                     append_string("~Guru Meditation~", &mut display);
                 }
                 let body = match msg.body.memory_message() {
@@ -138,7 +139,7 @@ pub(crate) fn panic_handler_thread(
                         &mut display,
                     );
                 }
-                display.draw();
+                display.draw().ok();
             }
         }
     });

--- a/services/bao1x-emu/src/display.rs
+++ b/services/bao1x-emu/src/display.rs
@@ -126,7 +126,7 @@ impl<'a> Oled128x128 {
 
     pub fn screen_size(&self) -> Point { Point::new(WIDTH, LINES) }
 
-    pub fn redraw(&mut self) { self.draw(); }
+    pub fn redraw(&mut self) -> Result<(), xous::Error> { self.draw() }
 
     pub fn blit_screen(&mut self, bmp: &[u32]) { self.buffer.copy_from_slice(bmp); }
 
@@ -136,18 +136,19 @@ impl<'a> Oled128x128 {
 
     pub fn stash(&mut self) { self.stash.copy_from_slice(&self.buffer); }
 
-    pub fn pop(&mut self) {
+    pub fn pop(&mut self) -> Result<(), xous::Error> {
         self.buffer.copy_from_slice(&self.stash);
-        self.redraw();
+        self.redraw()
     }
 
-    pub fn send_command<'b, U>(&'b mut self, _cmd: U)
+    pub fn send_command<'b, U>(&'b mut self, _cmd: U) -> Result<(), xous::Error>
     where
         U: IntoIterator<Item = u8> + 'b,
     {
+        Ok(())
     }
 
-    pub fn init(&mut self) {}
+    pub fn init(&mut self) -> Result<(), xous::Error> { Ok(()) }
 }
 
 impl FrameBuffer for Oled128x128 {

--- a/services/bao1x-emu/src/display.rs
+++ b/services/bao1x-emu/src/display.rs
@@ -151,11 +151,12 @@ impl<'a> Oled128x128 {
 }
 
 impl FrameBuffer for Oled128x128 {
-    fn draw(&mut self) {
+    fn draw(&mut self) -> Result<(), xous::Error> {
         for (index, pixel) in self.native_buffer.lock().unwrap().iter_mut().enumerate() {
             *pixel =
                 if (self.buffer[index / 32] & (1 << (index % 32))) != 0 { DARK_COLOUR } else { LIGHT_COLOUR }
         }
+        Ok(())
     }
 
     fn clear(&mut self) { self.buffer_mut().fill(0xFFFF_FFFF); }

--- a/services/graphics-server/src/backend/betrusted.rs
+++ b/services/graphics-server/src/backend/betrusted.rs
@@ -373,7 +373,10 @@ impl FrameBuffer for XousDisplay {
     }
 
     /// Swaps the drawable buffer to the screen and sends it to the hardware
-    fn draw(&mut self) { self.redraw(); }
+    fn draw(&mut self) -> Result<(), xous::Error> {
+        self.redraw();
+        Ok(())
+    }
 
     /// Clears the drawable buffer
     fn clear(&mut self) {

--- a/services/graphics-server/src/backend/minifb.rs
+++ b/services/graphics-server/src/backend/minifb.rs
@@ -237,7 +237,10 @@ impl FrameBuffer for XousDisplay {
     }
 
     /// Swaps the drawable buffer to the screen and sends it to the hardware
-    fn draw(&mut self) { self.redraw(); }
+    fn draw(&mut self) -> Result<(), xous::Error> {
+        self.redraw();
+        Ok(())
+    }
 
     /// Clears the drawable buffer
     fn clear(&mut self) {

--- a/services/keystore/src/lib.rs
+++ b/services/keystore/src/lib.rs
@@ -1,3 +1,4 @@
+use bao1x_api::BackupFlags;
 pub use cipher::{
     BlockBackend, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, ParBlocksSizeUser,
     consts::U16, generic_array::GenericArray, inout::InOut,
@@ -207,6 +208,99 @@ impl Keystore {
             }
             _ => unimplemented!(),
         }
+    }
+
+    pub fn set_flags(&self, flags: BackupFlags) -> Result<(), xous::Error> {
+        xous::send_message(
+            self.conn,
+            xous::Message::new_blocking_scalar(
+                Opcode::SetFlags.to_usize().unwrap(),
+                flags.raw_value() as usize,
+                0,
+                0,
+                0,
+            ),
+        )
+        .map(|_| ())
+    }
+
+    pub fn get_flags(&self) -> Result<BackupFlags, xous::Error> {
+        match xous::send_message(
+            self.conn,
+            xous::Message::new_blocking_scalar(Opcode::GetFlags.to_usize().unwrap(), 0, 0, 0, 0),
+        )? {
+            xous::Result::Scalar5(_, flags, _, _, _) => Ok(BackupFlags::new_with_raw_value(flags as u32)),
+            _ => unimplemented!(),
+        }
+    }
+
+    pub fn set_ephemeral_key(&self, key: &[u8; bao1x_hal::buram::KEY_LEN]) -> Result<(), xous::Error> {
+        let offset = 0;
+        xous::send_message(
+            self.conn,
+            xous::Message::new_blocking_scalar(
+                Opcode::Ephemeral.to_usize().unwrap(),
+                EphemeralOp::SetLsb.to_usize().unwrap(),
+                u32::from_le_bytes(key[offset..offset + 4].try_into().unwrap()) as usize,
+                u32::from_le_bytes(key[offset + 4..offset + 8].try_into().unwrap()) as usize,
+                u32::from_le_bytes(key[offset + 8..offset + 12].try_into().unwrap()) as usize,
+            ),
+        )
+        .map(|_| ())?;
+
+        let offset = bao1x_hal::buram::KEY_LEN / 2;
+        xous::send_message(
+            self.conn,
+            xous::Message::new_blocking_scalar(
+                Opcode::Ephemeral.to_usize().unwrap(),
+                EphemeralOp::SetMsb.to_usize().unwrap(),
+                u32::from_le_bytes(key[offset..offset + 4].try_into().unwrap()) as usize,
+                u32::from_le_bytes(key[offset + 4..offset + 8].try_into().unwrap()) as usize,
+                u32::from_le_bytes(key[offset + 8..offset + 12].try_into().unwrap()) as usize,
+            ),
+        )
+        .map(|_| ())
+    }
+
+    pub fn get_ephemeral_key(&self) -> Result<[u8; bao1x_hal::buram::KEY_LEN], xous::Error> {
+        let mut key = [0u8; bao1x_hal::buram::KEY_LEN];
+        let offset = 0;
+        match xous::send_message(
+            self.conn,
+            xous::Message::new_blocking_scalar(
+                Opcode::Ephemeral.to_usize().unwrap(),
+                EphemeralOp::GetLsb.to_usize().unwrap(),
+                0,
+                0,
+                0,
+            ),
+        )? {
+            xous::Result::Scalar5(_, _, arg2, arg3, arg4) => {
+                key[offset..offset + 4].copy_from_slice(&arg2.to_le_bytes());
+                key[offset + 4..offset + 8].copy_from_slice(&arg3.to_le_bytes());
+                key[offset + 8..offset + 12].copy_from_slice(&arg4.to_le_bytes());
+            }
+            _ => unimplemented!(),
+        }
+        let offset = bao1x_hal::buram::KEY_LEN / 2;
+        match xous::send_message(
+            self.conn,
+            xous::Message::new_blocking_scalar(
+                Opcode::Ephemeral.to_usize().unwrap(),
+                EphemeralOp::GetMsb.to_usize().unwrap(),
+                0,
+                0,
+                0,
+            ),
+        )? {
+            xous::Result::Scalar5(_, _, arg2, arg3, arg4) => {
+                key[offset..offset + 4].copy_from_slice(&arg2.to_le_bytes());
+                key[offset + 4..offset + 8].copy_from_slice(&arg3.to_le_bytes());
+                key[offset + 8..offset + 12].copy_from_slice(&arg4.to_le_bytes());
+            }
+            _ => unimplemented!(),
+        }
+        Ok(key)
     }
 }
 

--- a/services/keystore/src/lib.rs
+++ b/services/keystore/src/lib.rs
@@ -234,6 +234,7 @@ impl Keystore {
         }
     }
 
+    #[cfg(feature = "bao1x")]
     pub fn set_ephemeral_key(&self, key: &[u8; bao1x_hal::buram::KEY_LEN]) -> Result<(), xous::Error> {
         let offset = 0;
         xous::send_message(
@@ -262,6 +263,7 @@ impl Keystore {
         .map(|_| ())
     }
 
+    #[cfg(feature = "bao1x")]
     pub fn get_ephemeral_key(&self) -> Result<[u8; bao1x_hal::buram::KEY_LEN], xous::Error> {
         let mut key = [0u8; bao1x_hal::buram::KEY_LEN];
         let offset = 0;

--- a/services/keystore/src/platform/baosec/server.rs
+++ b/services/keystore/src/platform/baosec/server.rs
@@ -1,3 +1,4 @@
+use bao1x_api::BackupFlags;
 use bao1x_hal::board::{BOOKEND_END, BOOKEND_START};
 use bao1x_hal::rram::Reram;
 use keystore_api::*;
@@ -52,9 +53,50 @@ pub fn keystore(sid: SID) -> ! {
                 store.aes_kwp(&mut kwp).expect("couldn't wrap key");
                 buffer.replace(kwp).unwrap();
             }
-            Opcode::EphemeralOp => {
-                // this will use the backup_mgr to store ephemeral secrets
-                todo!()
+            Opcode::Ephemeral => {
+                if let Some(scalar) = msg.body.scalar_message_mut() {
+                    let ephemeral_op: EphemeralOp =
+                        num_traits::FromPrimitive::from_usize(scalar.arg1).expect("invalid ephemeral op");
+                    let offset = match ephemeral_op {
+                        EphemeralOp::GetLsb | EphemeralOp::SetLsb => 0,
+                        EphemeralOp::GetMsb | EphemeralOp::SetMsb => bao1x_hal::buram::KEY_LEN / 2,
+                    };
+                    match ephemeral_op {
+                        EphemeralOp::SetLsb | EphemeralOp::SetMsb => {
+                            let mut key = backup_mgr.get_backup_key();
+                            key[offset..offset + 4].copy_from_slice(&scalar.arg2.to_le_bytes());
+                            key[offset + 4..offset + 8].copy_from_slice(&scalar.arg3.to_le_bytes());
+                            key[offset + 8..offset + 12].copy_from_slice(&scalar.arg4.to_le_bytes());
+                            // zeroize
+                            scalar.arg1 = 0;
+                            scalar.arg2 = 0;
+                            scalar.arg3 = 0;
+                            scalar.arg4 = 0;
+                            backup_mgr.set_backup_key(key);
+                        }
+                        EphemeralOp::GetLsb | EphemeralOp::GetMsb => {
+                            let key = backup_mgr.get_backup_key();
+                            scalar.arg2 =
+                                u32::from_le_bytes(key[offset..offset + 4].try_into().unwrap()) as usize;
+                            scalar.arg3 =
+                                u32::from_le_bytes(key[offset + 4..offset + 8].try_into().unwrap()) as usize;
+                            scalar.arg4 =
+                                u32::from_le_bytes(key[offset + 8..offset + 12].try_into().unwrap()) as usize;
+                        }
+                    }
+                }
+            }
+            Opcode::GetFlags => {
+                if let Some(scalar) = msg.body.scalar_message_mut() {
+                    let flags = backup_mgr.get_flags();
+                    scalar.arg1 = flags.raw_value() as usize;
+                }
+            }
+            Opcode::SetFlags => {
+                if let Some(scalar) = msg.body.scalar_message_mut() {
+                    let flag = BackupFlags::new_with_raw_value(scalar.arg1 as u32);
+                    backup_mgr.set_flags(flag);
+                }
             }
             Opcode::Bootwait => {
                 if let Some(scalar) = msg.body.scalar_message_mut() {

--- a/services/keystore/src/platform/hosted.rs
+++ b/services/keystore/src/platform/hosted.rs
@@ -133,7 +133,7 @@ pub fn keystore(sid: SID) -> ! {
                 }
                 buffer.replace(kwp).unwrap();
             }
-            Opcode::EphemeralOp => {
+            Opcode::Ephemeral => {
                 todo!()
             }
             _ => {


### PR DESCRIPTION
Add:
- ephemeral key interface to keystore
- warm boot flag to keystore

Fix:
- SPIM timeout issue on displays
- Fix by propagating timeout up the stack & adding OS-level handler
- in case of timeout, reset the block and re-initialize

Suspected root cause is a similar issue to the `backpressure` bug that affects the SPIM block when talking to SPI flash, but manifesting in a different form. I checked and this is using the backpressure flag, but backpressure only affects the Rx path. I seem to remember that only affected the Rx-side, but...clearly there is something else going on.