### PR TITLE
OWC api

### DIFF
--- a/libs/bao1x-api/src/offsets/common.rs
+++ b/libs/bao1x-api/src/offsets/common.rs
@@ -20,6 +20,17 @@ pub const RRAM_STORAGE_LEN: usize = 0x3D_A000;
 pub const SWAP_START_UF2: usize = 0x7000_0000;
 pub const SWAP_UF2_LEN: usize = 0x0800_0000; // 128 MiB
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, num_derive::FromPrimitive, num_derive::ToPrimitive)]
+pub enum OneWayErr {
+    OutOfBounds,
+    IncFail,
+    InvalidCoding,
+    // used to report messaging errors in xous environments
+    InternalError,
+    // used to indicate things are OK in xous environments
+    None,
+}
+
 // Define a trait with just the offset
 pub trait OneWayEncoding: TryFrom<u32> {
     const OFFSET: usize;

--- a/libs/bao1x-hal/src/acram.rs
+++ b/libs/bao1x-hal/src/acram.rs
@@ -7,9 +7,9 @@
 //! In the case of baremetal targets of course everything is mapped, so these
 //! restrictions are not a concern.
 
-use bao1x_api::OneWayEncoding;
 use bao1x_api::bollard;
 use bao1x_api::offsets::*;
+use bao1x_api::{OneWayEncoding, OneWayErr};
 #[cfg(feature = "std")]
 use xous::MemoryRange;
 
@@ -29,17 +29,6 @@ pub const ONEWAY_MAX_VALUE: u32 = 10_0000;
 /// Maximum number of times the one way counter can be incremented in
 /// a single boot attempt.
 pub const ONEWAY_MAX_DELTA: u32 = 512;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, num_derive::FromPrimitive, num_derive::ToPrimitive)]
-pub enum OneWayErr {
-    OutOfBounds,
-    IncFail,
-    InvalidCoding,
-    // used to report messaging errors in xous environments
-    InternalError,
-    // used to indicate things are OK in xous environments
-    None,
-}
 
 pub struct OneWayCounter {
     #[cfg(feature = "std")]

--- a/libs/bao1x-hal/src/acram.rs
+++ b/libs/bao1x-hal/src/acram.rs
@@ -30,12 +30,17 @@ pub const ONEWAY_MAX_VALUE: u32 = 10_0000;
 /// a single boot attempt.
 pub const ONEWAY_MAX_DELTA: u32 = 512;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, num_derive::FromPrimitive, num_derive::ToPrimitive)]
 pub enum OneWayErr {
     OutOfBounds,
     IncFail,
     InvalidCoding,
+    // used to report messaging errors in xous environments
+    InternalError,
+    // used to indicate things are OK in xous environments
+    None,
 }
+
 pub struct OneWayCounter {
     #[cfg(feature = "std")]
     mapping: MemoryRange,

--- a/libs/keystore-api/src/gen2_api.rs
+++ b/libs/keystore-api/src/gen2_api.rs
@@ -24,6 +24,9 @@ pub enum Opcode {
     /// Flag operations
     GetFlags = 512,
     SetFlags = 513,
+    /// One way counter operations
+    GetOneWayCounter = 768,
+    IncOneWayCounter = 769,
 
     // ----- below are non-cryptographic opcodes but used to manipulate sensitive state -----
     /// Set bootwait parameters
@@ -41,3 +44,8 @@ pub enum EphemeralOp {
     GetMsb,
     SetMsb,
 }
+
+/// Series of magic numbers not meant for cryptographic authentication,
+/// but for detecting fat-fingered API implementations.
+pub const OWC_MAGIC_GET: [usize; 3] = [0x2b46_2ab3, 0xf7e3_1b59, 0x7bba_d222];
+pub const OWC_MAGIC_INC: [usize; 3] = [0xeb5d_fc81, 0x8b6d_6a90, 0xf720_491a];

--- a/services/keystore/Cargo.toml
+++ b/services/keystore/Cargo.toml
@@ -78,6 +78,10 @@ bao1x = ["utralib/bao1x", "aes/bao1x"]
 
 debug-hal = ["bao1x-hal/debug-print-duart"]
 
+# Enables incrementing one way counters. Off by default because this API can be, at the very least,
+# used to grief the security layer if not worse
+owc-inc = []
+
 board-baosec = [
     "utralib/bao1x",
     "keystore-api/gen2",

--- a/services/keystore/src/lib.rs
+++ b/services/keystore/src/lib.rs
@@ -1,4 +1,4 @@
-use bao1x_api::{BackupFlags, OneWayEncoding};
+use bao1x_api::{BackupFlags, OneWayEncoding, OneWayErr};
 pub use cipher::{
     BlockBackend, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, ParBlocksSizeUser,
     consts::U16, generic_array::GenericArray, inout::InOut,
@@ -9,8 +9,6 @@ use xous::CID;
 use xous_ipc::Buffer;
 pub(crate) type BatchBlocks = GenericArray<Block, U16>;
 use std::convert::TryInto;
-
-use bao1x_hal::acram::*;
 
 #[derive(Debug)] // there is no confidential information in the external structure; it's safe to Debug it
 pub struct Keystore {

--- a/services/keystore/src/lib.rs
+++ b/services/keystore/src/lib.rs
@@ -1,4 +1,4 @@
-use bao1x_api::BackupFlags;
+use bao1x_api::{BackupFlags, OneWayEncoding};
 pub use cipher::{
     BlockBackend, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, ParBlocksSizeUser,
     consts::U16, generic_array::GenericArray, inout::InOut,
@@ -9,6 +9,8 @@ use xous::CID;
 use xous_ipc::Buffer;
 pub(crate) type BatchBlocks = GenericArray<Block, U16>;
 use std::convert::TryInto;
+
+use bao1x_hal::acram::*;
 
 #[derive(Debug)] // there is no confidential information in the external structure; it's safe to Debug it
 pub struct Keystore {
@@ -232,6 +234,83 @@ impl Keystore {
             xous::Result::Scalar5(_, flags, _, _, _) => Ok(BackupFlags::new_with_raw_value(flags as u32)),
             _ => unimplemented!(),
         }
+    }
+
+    /// Marked as `unsafe` because the offset needs to be correct. It's recommended to use
+    /// `inc_owc_coded()` where possible. This function is necessary for the cases that don't
+    /// fit into the `encode_oneway` mechanism, e.g. key revocations, etc.
+    ///
+    /// All you have to do to be safe is no be super-sure you got the offset right.
+    #[cfg(feature = "owc-inc")]
+    pub unsafe fn inc_owc(&self, offset: usize) -> Result<(), OneWayErr> {
+        let result = xous::send_message(
+            self.conn,
+            xous::Message::new_blocking_scalar(
+                Opcode::IncOneWayCounter.to_usize().unwrap(),
+                offset,
+                OWC_MAGIC_INC[0],
+                OWC_MAGIC_INC[1],
+                OWC_MAGIC_INC[2],
+            ),
+        );
+        match result {
+            Ok(xous::Result::Scalar5(_, arg1, _arg2, _arg3, _arg4)) => {
+                match num_traits::FromPrimitive::from_usize(arg1) {
+                    Some(OneWayErr::None) => Ok(()),
+                    Some(e) => Err(e),
+                    _ => Err(OneWayErr::InternalError),
+                }
+            }
+            _ => Err(OneWayErr::InternalError),
+        }
+    }
+
+    /// Automatically increments the correct slot based on the OFFSET encoded in the definition
+    #[cfg(feature = "owc-inc")]
+    pub fn inc_owc_coded<T>(&self) -> Result<(), OneWayErr>
+    where
+        T: OneWayEncoding,
+        T::Error: core::fmt::Debug,
+    {
+        let offset: usize = T::OFFSET;
+        if offset < MAX_ONEWAY_COUNTERS {
+            unsafe { self.inc_owc(offset) }
+        } else {
+            Err(OneWayErr::OutOfBounds)
+        }
+    }
+
+    pub fn get_owc(&self, offset: usize) -> Result<u32, OneWayErr> {
+        let result = xous::send_message(
+            self.conn,
+            xous::Message::new_blocking_scalar(
+                Opcode::GetOneWayCounter.to_usize().unwrap(),
+                offset,
+                OWC_MAGIC_GET[0],
+                OWC_MAGIC_GET[1],
+                OWC_MAGIC_GET[2],
+            ),
+        );
+        match result {
+            Ok(xous::Result::Scalar5(_id, arg1, arg2, _arg3, _arg4)) => {
+                match num_traits::FromPrimitive::from_usize(arg1) {
+                    Some(OneWayErr::None) => Ok(arg2 as u32),
+                    Some(e) => Err(e),
+                    _ => Err(OneWayErr::InternalError),
+                }
+            }
+            _ => Err(OneWayErr::InternalError),
+        }
+    }
+
+    pub fn get_owc_decoded<T>(&self) -> Result<T, OneWayErr>
+    where
+        T: OneWayEncoding,
+        T: TryFrom<u32>,
+        T::Error: core::fmt::Debug,
+    {
+        let raw = self.get_owc(T::OFFSET)?;
+        T::try_from(raw).map_err(|_| OneWayErr::InvalidCoding)
     }
 
     #[cfg(feature = "bao1x")]

--- a/services/keystore/src/platform/baosec/server.rs
+++ b/services/keystore/src/platform/baosec/server.rs
@@ -1,7 +1,9 @@
 use bao1x_api::BackupFlags;
+use bao1x_hal::acram::{MAX_ONEWAY_COUNTERS, OneWayErr};
 use bao1x_hal::board::{BOOKEND_END, BOOKEND_START};
 use bao1x_hal::rram::Reram;
 use keystore_api::*;
+use num_traits::*;
 use xous::SID;
 use xous_ipc::Buffer;
 
@@ -117,6 +119,39 @@ pub fn keystore(sid: SID) -> ! {
             Opcode::IsDeveloper => {
                 if let Some(scalar) = msg.body.scalar_message_mut() {
                     if store.is_developer() { scalar.arg1 = 0 } else { scalar.arg1 = 1 }
+                }
+            }
+            Opcode::IncOneWayCounter => {
+                if let Some(scalar) = msg.body.scalar_message_mut() {
+                    if [scalar.arg2, scalar.arg3, scalar.arg4] == OWC_MAGIC_INC
+                        && scalar.arg1 < MAX_ONEWAY_COUNTERS
+                    {
+                        match unsafe { store.owc.inc(scalar.arg1) } {
+                            Ok(_) => {
+                                scalar.arg1 = OneWayErr::None.to_usize().unwrap();
+                            }
+                            Err(e) => scalar.arg1 = e.to_usize().unwrap(),
+                        }
+                    } else {
+                        scalar.arg1 = OneWayErr::InternalError.to_usize().unwrap();
+                    }
+                }
+            }
+            Opcode::GetOneWayCounter => {
+                if let Some(scalar) = msg.body.scalar_message_mut() {
+                    if [scalar.arg2, scalar.arg3, scalar.arg4] == OWC_MAGIC_GET
+                        && scalar.arg1 < MAX_ONEWAY_COUNTERS
+                    {
+                        match store.owc.get(scalar.arg1) {
+                            Ok(val) => {
+                                scalar.arg1 = OneWayErr::None.to_usize().unwrap();
+                                scalar.arg2 = val as usize;
+                            }
+                            Err(e) => scalar.arg1 = e.to_usize().unwrap(),
+                        }
+                    } else {
+                        scalar.arg1 = OneWayErr::InternalError.to_usize().unwrap();
+                    }
                 }
             }
             Opcode::InvalidCall => {

--- a/services/keystore/src/platform/baosec/server.rs
+++ b/services/keystore/src/platform/baosec/server.rs
@@ -1,5 +1,5 @@
-use bao1x_api::BackupFlags;
-use bao1x_hal::acram::{MAX_ONEWAY_COUNTERS, OneWayErr};
+use bao1x_api::{BackupFlags, OneWayErr};
+use bao1x_hal::acram::MAX_ONEWAY_COUNTERS;
 use bao1x_hal::board::{BOOKEND_END, BOOKEND_START};
 use bao1x_hal::rram::Reram;
 use keystore_api::*;

--- a/services/keystore/src/platform/baosec/store.rs
+++ b/services/keystore/src/platform/baosec/store.rs
@@ -21,7 +21,7 @@ const KEY_LEN: usize = bao1x_api::SLOT_ELEMENT_LEN_BYTES;
 
 pub struct KeyStore {
     slot_mgr: SlotManager,
-    owc: OneWayCounter,
+    pub owc: OneWayCounter,
     master_key: Option<[u8; KEY_LEN]>,
 }
 


### PR DESCRIPTION
APIs for inspecting and incrementing one-way counters in Xous

Off by default unless the "owc-inc" flag is active on the keystore since randomly being able to increment counters can lead to the chip being bricked.