### PR TITLE
Add AI contribution policy.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ will not be tolerated).
 - You **should** disclose the use of AI tools where it might be helpful to the maintainer reviewing your contribution. 
 - Using AI tools to correct grammar and spelling does not require disclosure.
 - Make your disclosure in your commit message as a trailer; e.g. `Assisted-by: ChatGPTv5`
+- Use the tag "AI" on pull requests that were primarily generated or guided by AI tools
 
 ## Contribution Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,23 @@ By participating in this project you agree to abide by the
 (please read the full text so that you can understand what actions will and
 will not be tolerated).
 
+## AI-Assisted Project Contributions
+
+- You may use AI assistance for contributing to this project in accordance with these principles of accountability and transparency.
+
+### Accountability
+
+- When you submit a contribution, you represent that you are the author and that you are fully accountable for the entirety of the contribution.
+- You are responsible for your contribution, including vouching for the quality, license compliance, and utility of your submission.
+- Using AI assistance in your contribution does not relieve you of the responsibility to ensure that your contribution meets project standards; your contributions must be modular, reviewable, and clearly explainable.
+
+### Transparency
+
+- You **must** disclose the use of AI tools when a significant part of the contribution is generated without changes.
+- You **should** disclose the use of AI tools where it might be helpful to the maintainer reviewing your contribution. 
+- Using AI tools to correct grammar and spelling does not require disclosure.
+- Make your disclosure in your commit message as a trailer; e.g. `Assisted-by: ChatGPTv5`
+
 ## Contribution Workflow
 
 This is an overview of the contribution workflow:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,11 @@ will not be tolerated).
 - Make your disclosure in your commit message as a trailer; e.g. `Assisted-by: ChatGPTv5`
 - Use the tag "AI" on pull requests that were primarily generated or guided by AI tools
 
+### Scope and Cadence
+- Prefer one concern per PR. Bug fixes, refactors, and documentation updates belong in separate PRs even when they touch the same file.
+- For mechanical changes that span many files or services (e.g. pattern sweeps), split into per-target PRs and open no more than two per week so review stays tractable.
+- Before a large or cross-cutting change, open an issue or discussion first to align on scope.
+
 ## Contribution Workflow
 
 This is an overview of the contribution workflow:


### PR DESCRIPTION
Addresses https://github.com/betrusted-io/xous-core/discussions/839

This PR adds portions of Fedora's AI-assisted contribution policy to this project's contribution guidelines. I referenced [the final published policy](https://docs.fedoraproject.org/en-US/council/policy/ai-contribution-policy/), rather than the proposed policy wordings linked in the discussion.I also incorporated @bunnie 's concerns about AI-assisted contributions reducing the quality of submissions in the AI policy itself.

I chose not to copy the policy wording verbatim as it is licensed CC BY-SA, which is not compatible with this project's contribution guidelines which are checked in to the repo under the Apache license.

Feedback on this PR is welcome.