### PR TITLE
emulation: cast frequency to ulong for Renode v1.16+ compatibility

### DIFF
--- a/emulation/peripherals/LiteX_Timer_32.cs
+++ b/emulation/peripherals/LiteX_Timer_32.cs
@@ -20,7 +20,7 @@ namespace Antmicro.Renode.Peripherals.Timers.Betrusted
         public LiteX_Timer_32(Machine machine, long frequency) : base(machine)
         {
             IRQ = new GPIO();
-            innerTimer = new LimitTimer(machine.ClockSource, frequency, this, "LiteXTimer32", eventEnabled: true, autoUpdate: true);
+            innerTimer = new LimitTimer(machine.ClockSource, (ulong)frequency, this, "LiteXTimer32", eventEnabled: true, autoUpdate: true);
             innerTimer.LimitReached += delegate
             {
                 this.Log(LogLevel.Noisy, "Limit reached");


### PR DESCRIPTION
Renode v1.16 changed the `LimitTimer` constructor signature from
`long frequency` to `ulong frequency`. The current
`emulation/peripherals/LiteX_Timer_32.cs` passes `long`, which causes
Renode to fail peripheral compilation on startup against current
Renode versions.

The symptom: `renode emulation/xous-release.resc` exits immediately
with a peripheral build failure rather than booting Xous. The fix is
a one-line `(ulong)` cast at the LimitTimer construction site.

Tested with Renode v1.16.1.4499 (build 9d55b4e6-202604170227) against
the standard `xous-release.resc` startup. With the cast, Xous boots
through to the main loop. Without it, Renode exits before any boot
output appears.

Marked draft because I'd appreciate maintainer input on:

1. Whether you'd prefer a Renode-version pin in the build script
   instead of a source-level cast (e.g., document v1.15.x as the
   tested baseline). The cast is forward-compatible; pinning is
   reproducible. Both are reasonable.
2. Whether other peripherals in `emulation/peripherals/` have the
   same pattern that needs updating. I only verified the
   `LiteX_Timer_32` path while bringing up sigchat in Renode, so
   there may be other affected files I haven't touched.

Happy to extend the PR scope or split as you prefer.

Used Claude Code to write most of this text and also setup the test infrastructure that caught this bug.
