### PR TITLE
improve display boot stability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "xous 0.9.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
+ "xous-api-susres 0.9.68",
  "xous-api-ticktimer",
  "xous-ipc 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/services/bao-video/Cargo.toml
+++ b/services/bao-video/Cargo.toml
@@ -26,6 +26,7 @@ rkyv = { version = "0.8.8", default-features = false, features = [
     "alloc",
 ] }
 modals = { path = "../modals", optional = true }
+susres = { package = "xous-api-susres", path = "../../api/xous-api-susres" }
 
 # QR decoding
 libm = { version = "0.2.8" }

--- a/services/bao-video/src/main.rs
+++ b/services/bao-video/src/main.rs
@@ -70,6 +70,8 @@ use xous_ipc::Buffer;
 pub const IMAGE_WIDTH: usize = 256;
 pub const IMAGE_HEIGHT: usize = 240;
 
+const MAX_RETRIES: u32 = 5;
+
 #[derive(PartialEq, Eq, Clone, Copy)]
 enum DisplayOrientation {
     Normal,
@@ -224,10 +226,9 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
     let hal = Hal::new();
 
     let mut display = Oled128x128::new(main_thread_token, bao1x_api::PERCLK, &iox, &udma_global);
-    // these unwrap because if we have a time-out at this stage, it's likely a hardware problem
-    display.init().unwrap();
+    retry_display_op(&udma_global, &mut display, |d| d.init()).unwrap();
     display.clear();
-    display.draw().unwrap();
+    retry_display_op(&udma_global, &mut display, |d| d.draw()).unwrap();
 
     // ---- panic handler - set up early so we can see panics quickly
     // install the graphical panic handler. It won't catch really early panics, or panics in this crate,
@@ -968,7 +969,9 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                         }
                     }
                 }
-                GfxOpcode::Quit => break,
+                GfxOpcode::Quit => {
+                    log::info!("refusing to quit, this operation is not supported on this platform!");
+                }
                 _ => {
                     // This is perfectly normal because not all opcodes are handled by all platforms.
                     log::debug!("Invalid or unhandled opcode: {:?}", opcode);
@@ -979,11 +982,6 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
             tt.sleep_ms(10_000).unwrap();
         }
     }
-    log::trace!("main loop exit, destroying servers");
-    xns.unregister_server(sid).unwrap();
-    xous::destroy_server(sid).unwrap();
-    log::trace!("quitting");
-    xous::terminate_process(0)
 }
 
 #[allow(unused_variables)]
@@ -993,5 +991,37 @@ fn display_timeout_handler(udma_global: &UdmaGlobal, display: &mut Oled128x128) 
     {
         udma_global.reset(PeriphId::from(bao1x_hal::board::get_display_pins().0));
         display.reinit_spi();
+    }
+}
+
+/// This is actually "infalliable" in the sense that if we can't initialize the
+/// display, we diverge and reboot.
+fn retry_display_op<F, R, E>(udma: &UdmaGlobal, display: &mut Oled128x128, mut op: F) -> Result<R, E>
+where
+    F: FnMut(&mut Oled128x128) -> Result<R, E>,
+    E: core::fmt::Debug,
+{
+    let mut attempts = 0;
+    loop {
+        match op(display) {
+            Ok(val) => return Ok(val),
+            Err(e) => {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                attempts += 1;
+                if attempts >= MAX_RETRIES {
+                    log::warn!("Display seems stuck, rebooting whole chip.");
+                    let xns = xous_names::XousNames::new().unwrap();
+                    let susres = susres::Susres::new_without_hook(&xns).unwrap();
+                    susres.reboot(true).ok();
+                }
+                log::warn!(
+                    "Display op failed (attempt {}/{}), resetting SPI block... {:?}",
+                    attempts,
+                    MAX_RETRIES,
+                    e
+                );
+                display_timeout_handler(udma, display);
+            }
+        }
     }
 }


### PR DESCRIPTION
an instance of the SPI interface timing out was observed on boot. It's rare, but it happens.

This wraps those early calls with a retry loop and then fail to reboot in case something really goes wrong.

Assisted-by: qwen3.6:27b (local)