### PR TITLE
Fix encoding of WS2812C one bit

### DIFF
--- a/libs/bio-lib/src/c/include/ws2812.h
+++ b/libs/bio-lib/src/c/include/ws2812.h
@@ -42,11 +42,8 @@ void ws2812c(uint32_t pin, uint32_t *strip, uint32_t len) {
                 wait_quantum();
                 wait_quantum();
                 wait_quantum();
-                // 5 lo
+                // 2 lo
                 clear_gpio_pins_n(antimask);
-                wait_quantum();
-                wait_quantum();
-                wait_quantum();
                 wait_quantum();
                 wait_quantum();
             }


### PR DESCRIPTION
Shouldn't a one bit be encoded by 5 hi and 2 lo (not 5 hi and 5 lo)?