### PR TITLE
Write NetError code at byte 1 too, so std-recv decode works

### DIFF
--- a/services/net/src/std_glue.rs
+++ b/services/net/src/std_glue.rs
@@ -54,15 +54,19 @@ pub(crate) fn respond_with_error(mut env: xous::MessageEnvelope, code: NetError)
     body.valid = None;
     let s: &mut [u8] = unsafe { body.buf.as_slice_mut() };
     let mut i = s.iter_mut();
+    let code = code as u8;
 
     // Duplicate error to ensure it's seen as an error regardless of byte order/return type
     // This is necessary because errors are encoded as `u8` slices, but "good"
     // responses may be encoded as `u16` or `u32` slices.
+    //
+    // Mirror code at byte 1 (where the std-side recv path reads) in
+    // addition to byte 4 (where the std-side send path reads).
+    *i.next()? = 1;
+    *i.next()? = code;
     *i.next()? = 1;
     *i.next()? = 1;
-    *i.next()? = 1;
-    *i.next()? = 1;
-    *i.next()? = code as u8;
+    *i.next()? = code;
     *i.next()? = 0;
     *i.next()? = 0;
     *i.next()? = 0;


### PR DESCRIPTION
The kernel's `respond_with_error` in `services/net/src/std_glue.rs`
writes an 8-byte error packet with the `NetError` code at byte 4.
This matches what the std-side TCP **send** path reads
(`library/std/src/sys/net/connection/xous/tcpstream.rs::write`,
which reads `send_request.raw[4]`).

But the std-side **recv** paths read `result[1]`, not `result[4]`.
With the historical `[1, 1, 1, 1, code, 0, 0, 0]` layout, byte 1
is always `1` — so `result[1] == 8` (`TimedOut`) and `result[1] == 9`
(`WouldBlock`) never match. Every recv-path error therefore falls
through to a generic `io::const_error!(io::ErrorKind::Other,
"recv_slice failure")` regardless of what the kernel actually
returned.

This PR mirrors the code at byte 1 (in addition to byte 4), so
both std-side decoders see the right value. Fully backward-
compatible: anything reading byte 4 keeps working unchanged, and
the "buf interpreted as u32-LE != 0" error-marker property still
holds because byte 0 is still 1.

A separate, complementary PR against `rust-lang/rust` should
update the std-side recv paths to read byte 4 (matching the send
path). This kernel-side change is the workaround that ships
immediately and works with any std version.

## Why this matters

The bug makes `std::net::TcpStream::set_read_timeout()` plus
"distinguish TimedOut from other errors" effectively unusable on
Xous: every `TimedOut` from the kernel surfaces as a generic
opaque IO error in user code.

For most Xous applications this is latent — short-lived sockets
that don't poll on a timeout never trigger it. But any
application that uses long-lived TCP/WSS connections with a
short read timeout (the standard pattern for "let me poll for
data without blocking the writer") sees fatal-looking errors on
every poll. We hit this in a Signal client that uses 5-second
read timeouts on its Signal-server WebSocket: every WS died
within 5 seconds of opening, with `recv_slice failure`
propagating up through `tungstenite::Error::Io` into the
application as a generic transport-layer abort.

After this PR, `ErrorKind::TimedOut` and `ErrorKind::WouldBlock`
are reachable from the recv side of `std::net::TcpStream`, the
WS lives indefinitely, and the application can use the standard
timeout-and-poll pattern.

## The change

```diff
--- a/services/net/src/std_glue.rs
+++ b/services/net/src/std_glue.rs
@@ pub(crate) fn respond_with_error(...)
     body.valid = None;
     let s: &mut [u8] = unsafe { body.buf.as_slice_mut() };
     let mut i = s.iter_mut();
+    // NetError is not Copy; bind to u8 once.
+    let code_u8 = code as u8;

     // Duplicate error to ensure it's seen as an error regardless of byte order/return type
     // This is necessary because errors are encoded as `u8` slices, but "good"
     // responses may be encoded as `u16` or `u32` slices.
+    //
+    // The std-side Xous net backend disagrees with itself about which
+    // byte the error code lives in:
+    //   library/std/src/sys/net/connection/xous/tcpstream.rs SEND path
+    //     reads `send_request.raw[4]` for the code.
+    //   library/std/src/sys/net/connection/xous/tcpstream.rs RECV path,
+    //     udp.rs RECV path, and tcplistener.rs ACCEPT path all read
+    //     `result[1]` for the code — but with the historical
+    //     [1,1,1,1, code, 0,0,0] layout, byte 1 was always 1, so
+    //     ErrorKind::TimedOut and ErrorKind::WouldBlock were
+    //     unreachable from the recv side.
+    //
+    // Fix: write the code at byte 1 (where the buggy std-recv looks)
+    // in addition to byte 4 (where std-send looks). Both call sites
+    // now decode correctly. The "buf as u32 LE != 0" marker still
+    // holds because byte 0 is still 1.
-    *i.next()? = 1;
-    *i.next()? = 1;
-    *i.next()? = 1;
-    *i.next()? = 1;
-    *i.next()? = code as u8;
+    *i.next()? = 1;             // byte 0 — error marker
+    *i.next()? = code_u8;       // byte 1 — code (where std-recv reads)
+    *i.next()? = 1;             // byte 2 — marker
+    *i.next()? = 1;             // byte 3 — marker
+    *i.next()? = code_u8;       // byte 4 — code (where std-send reads)
     *i.next()? = 0;
     *i.next()? = 0;
     *i.next()? = 0;
```

## Validation

Reproduced and verified on Precursor PVT2 hardware:

- **Pre-fix UART:** every WS opened by the application's WSS
  pump died within ~5 seconds with `recv_slice failure` from the
  std-side wrapper (sysroot `tcpstream.rs:225`). Cumulative
  effect: a Signal client could not maintain a server connection
  long enough to complete a single send.

- **Post-fix UART:** `respond_with_error(NetError::TimedOut)` now
  surfaces in the std-side caller as
  `Err(io::Error { kind: ErrorKind::TimedOut, ... })`. The
  application's reader loop matches `WouldBlock | TimedOut` and
  treats it as a non-event (sleep + retry), as intended. The
  Signal-server WS lives until the server itself rotates it
  (~30-60 seconds, code 1001 "Connection Idle Timeout"), at
  which point the application reconnects normally.

I also verified that the `send` path still works correctly (it
still reads byte 4, which is unchanged) — outbound TLS/WSS
traffic continued through the test session.

## Caveats / open questions

1. The "right" fix is in the **Rust standard library**, where
   the recv paths should read `result[4]` (matching the send
   path) rather than `result[1]`. I'm sending a separate PR to
   `rust-lang/rust` for that. This kernel-side change is the
   workaround that ships immediately without a Rust toolchain
   release dependency. The two changes are independent and
   composable: they could both be in place permanently with no
   conflict (the kernel writes both bytes; std reads either,
   both have the right value).

2. `NetError::Unaddressable = 1` happens to collide with the
   marker value `1`. After this change, byte 1 still reads as
   `1` for a `respond_with_error(Unaddressable)`, but std doesn't
   special-case `Unaddressable` (it only special-cases byte 1 ==
   8 for TimedOut and 9 for WouldBlock); other variants fall
   through to the generic Other-kind error. So the collision is
   benign in current code, though if the std side ever adds a
   special case for `result[1] == 1` it would conflict — worth a
   note in a code comment.

3. No new tests because there isn't a hosted-mode net test that
   exercises read timeouts end-to-end. The existing `services/net/`
   tests don't cover this path. Worth adding, but I'd suggest as
   a follow-up rather than blocking this PR.

## Reference for reviewers

- The buggy std-side decoder lives at
  `library/std/src/sys/net/connection/xous/tcpstream.rs:215-225`
  (recv path), `udp.rs:147-149`, and
  `tcplistener.rs:131-133`. All read `result[1]` / `raw[1]`.
- The matching working std-side encoder is at
  `tcpstream.rs:266-273` (send path), which reads
  `send_request.raw[4]`.
- Equivalent commit on a public fork:
  https://github.com/tunnell/xous-core/commit/cfcc12eee

## Agent disclosure

An agent was used to deep dive into the networking stack to find this issue, and given the technical nature of the finding was also used to draft this PR.