### PR TITLE
update the descriptive name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,8 +726,12 @@ dependencies = [
  "bao1x-hal",
  "bitbybit",
  "log",
+ "num-derive 0.4.2",
+ "num-traits",
  "utralib 0.1.27",
  "xous 0.9.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-api-names",
+ "xous-api-susres 0.9.68",
  "xous-api-ticktimer",
 ]
 

--- a/bao1x-boot/boot1/src/main.rs
+++ b/bao1x-boot/boot1/src/main.rs
@@ -35,7 +35,7 @@ use crate::secboot::try_boot;
 // - "Towards" - not a release yet, but working towards the stated milestone
 // - Eliminating "Towards" is done at the tag-out point.
 // - The "base" name is the name of the signing key used in the release.
-const RELEASE_DESCRIPTION: &'static str = "bao2-0";
+const RELEASE_DESCRIPTION: &'static str = "Towards 0.10.1 beta-1";
 
 static UART_RX: Mutex<RefCell<VecDeque<u8>>> = Mutex::new(RefCell::new(VecDeque::new()));
 #[allow(dead_code)]

--- a/services/bao-console/src/cmds/test.rs
+++ b/services/bao-console/src/cmds/test.rs
@@ -135,7 +135,7 @@ impl<'a> ShellCmdApi<'a> for Test {
                     conn,
                     xous::Message::new_blocking_scalar(
                         susres::api::Opcode::PlatformSpecific.to_usize().unwrap(),
-                        bao1x_hal_service::api::ClockOp::DeepSleep.to_usize().unwrap(),
+                        bao1x_hal::clocks::ClockOp::DeepSleep.to_usize().unwrap(),
                         0,
                         0,
                         0,


### PR DESCRIPTION
moving towards a 0.10.1 release, instead of the original release name