### PR TITLE
remove potential race condition in sending U2F packets over USB

### DIFF
--- a/services/bao-video/src/main.rs
+++ b/services/bao-video/src/main.rs
@@ -432,6 +432,7 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
     let mut bw_thresh: u8 = 128;
     let mut qr_request: Option<xous::MessageEnvelope> = None;
     let mut kbd_listeners: Vec<(CID, usize)> = Vec::new();
+    let cam_started = Arc::new(AtomicBool::new(false));
     #[allow(unused_mut)]
     let mut orientation = DisplayOrientation::Normal;
     loop {
@@ -445,41 +446,6 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                 #[cfg(not(feature = "hosted-baosec"))]
                 GfxOpcode::AcquireQr => {
                     if qr_request.is_none() {
-                        // reset camera UDMA block
-                        udma_global.reset(PeriphId::Cam);
-
-                        // display.stash(); // save a copy of the UI
-                        // this will defer response until later
-                        qr_request = msg_opt.take();
-
-                        // power up the camera
-                        // starts MCLK
-                        iox.setup_pin(
-                            cam_clk.0,
-                            cam_clk.1,
-                            Some(IoxDir::Output),
-                            Some(IoxFunction::AF3),
-                            None,
-                            None,
-                            Some(IoxEnable::Disable),
-                            Some(IoxDriveStrength::Drive8mA),
-                        );
-                        timer.wo(utra::pwm::REG_CH_EN, 1);
-                        timer.rmwf(utra::pwm::REG_TIM0_CMD_R_TIMER0_START, 1);
-                        tt.sleep_ms(2).ok(); // wait for camera to clock-up
-                        // bring camera out of powerdown
-                        iox.set_gpio_pin_value(cam_pdwn.0, cam_pdwn.1, IoxValue::Low);
-                        tt.sleep_ms(3).ok(); // wait for camera to power-up
-                        let (pid, mid) = cam.read_id(&mut i2c);
-                        log::info!("Camera pid {:x}, mid {:x}", pid, mid);
-                        cam.init(&mut i2c, bao1x_api::camera::Resolution::Res320x240);
-                        tt.sleep_ms(1).ok();
-
-                        let (cols, _rows) = cam.resolution();
-                        let border = (cols - IMAGE_WIDTH) / 2;
-                        cam.set_slicing((border, 0), (cols - border, IMAGE_HEIGHT));
-                        log::info!("320x240 resolution setup with 256x240 slicing");
-
                         // decode dummy data - what this does is load the swapped out QR decoding logic, thus
                         // improving the latency of the decoder on the "first hit". The sole purpose of this
                         // is to improve the user experience during scanning.
@@ -505,18 +471,84 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                         } else {
                             log::error!("test image failed to decode, this shouldn't happen!");
                         }
-
-                        // turning off preemption makes camera acquisition smoother; the OS will naturally try
-                        // to schedule other tasks between camera frames after each
-                        // CamIrq interrupt
-                        hal.set_preemption(false);
                         // fix orientation if it's upside down
                         if orientation == DisplayOrientation::UpsideDown {
                             display
                                 .flip_vertical(false)
                                 .unwrap_or_else(|_| display_timeout_handler(&udma_global, &mut display))
                         }
-                        // now start acquisition
+
+                        // reset camera UDMA block
+                        udma_global.reset(PeriphId::Cam);
+
+                        // display.stash(); // save a copy of the UI
+                        // this will defer response until later
+                        qr_request = msg_opt.take();
+
+                        // power up the camera
+                        // starts MCLK
+                        iox.setup_pin(
+                            cam_clk.0,
+                            cam_clk.1,
+                            Some(IoxDir::Output),
+                            Some(IoxFunction::AF3),
+                            None,
+                            None,
+                            Some(IoxEnable::Disable),
+                            Some(IoxDriveStrength::Drive8mA),
+                        );
+                        timer.wo(utra::pwm::REG_CH_EN, 1);
+                        timer.rmwf(utra::pwm::REG_TIM0_CMD_R_TIMER0_START, 1);
+                        tt.sleep_ms(5).ok(); // wait for camera to clock-up
+                        // bring camera out of powerdown
+                        iox.set_gpio_pin_value(cam_pdwn.0, cam_pdwn.1, IoxValue::Low);
+                        tt.sleep_ms(10).ok(); // wait for camera to power-up
+                        let (pid, mid) = cam.read_id(&mut i2c);
+                        log::info!("Camera pid {:x}, mid {:x}", pid, mid);
+                        cam.init(&mut i2c, bao1x_api::camera::Resolution::Res320x240);
+                        tt.sleep_ms(5).ok();
+
+                        let (cols, _rows) = cam.resolution();
+                        let border = (cols - IMAGE_WIDTH) / 2;
+                        cam.set_slicing((border, 0), (cols - border, IMAGE_HEIGHT));
+                        log::info!("320x240 resolution setup with 256x240 slicing");
+
+                        cam_started.store(false, Ordering::SeqCst);
+
+                        // start watchdog to make sure camera is running
+                        let _ = std::thread::spawn({
+                            let cid = cid.clone();
+                            let cam_started = cam_started.clone();
+                            move || {
+                                let hal = Hal::new();
+                                let start = std::time::Instant::now();
+                                while !cam_started.load(Ordering::SeqCst)
+                                    && std::time::Instant::now().duration_since(start).as_millis() < 600
+                                {
+                                    std::thread::sleep(std::time::Duration::from_millis(30));
+                                }
+                                if !cam_started.load(Ordering::SeqCst) {
+                                    // force an IRQ into the pipe to start the camera
+                                    xous::try_send_message(
+                                        cid,
+                                        xous::Message::new_scalar(
+                                            GfxOpcode::CamIrq.to_usize().unwrap(),
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                        ),
+                                    )
+                                    .ok();
+                                }
+                                // turning off preemption makes camera acquisition smoother; the OS will
+                                // naturally try to schedule other tasks
+                                // between camera frames after each CamIrq interrupt
+                                hal.set_preemption(false);
+                            }
+                        });
+
+                        // now start an acquisition
                         cam.capture_async();
                     }
                     // if qr_request is already pending, ignore any new acquisition requests
@@ -567,6 +599,7 @@ pub fn wrapped_main(main_thread_token: MainThreadToken) -> ! {
                     }
                 }
                 GfxOpcode::CamIrq => {
+                    cam_started.store(true, Ordering::SeqCst);
                     // copy the camera data to our FB
                     let fb: &[u32] = cam.rx_buf();
                     // fb is an array of IMAGE_WIDTH x IMAGE_HEIGHT x u16

--- a/services/usb-bao1x/src/hw.rs
+++ b/services/usb-bao1x/src/hw.rs
@@ -57,6 +57,7 @@ pub struct Bao1xUsb<'a> {
     // from the interrupt handler.
     pub double_lock: AtomicBool,
     pub led_state: KeyboardLedsReport,
+    pub irq_serviced: AtomicBool,
 }
 
 impl<'a> Bao1xUsb<'a> {
@@ -122,6 +123,7 @@ impl<'a> Bao1xUsb<'a> {
             serial_rx: [0u8; SERIAL_MAX_PACKET_SIZE],
             double_lock: AtomicBool::new(false),
             led_state: KeyboardLedsReport::default(),
+            irq_serviced: AtomicBool::new(false),
         }
     }
 
@@ -355,6 +357,7 @@ pub(crate) fn composite_handler(_irq_no: usize, arg: *mut usize) {
                 while let Some(u2f_msg) = usb.fido_tx_queue.borrow_mut().pop_front() {
                     u2f.write_report(&u2f_msg).ok();
                 }
+                usb.irq_serviced.store(true, Ordering::SeqCst);
             }
             Some(UsbIrqReq::KbdTx) => {
                 let keyboard = composite.device::<NKROBootKeyboard<'_, _>, _>();

--- a/services/usb-bao1x/src/main.rs
+++ b/services/usb-bao1x/src/main.rs
@@ -441,6 +441,7 @@ pub(crate) fn main_hw() -> ! {
                     unsafe { Buffer::from_memory_message_mut(msg.body.memory_message_mut().unwrap()) };
                 let mut u2f_ipc = buffer.to_original::<U2fMsgIpc, _>().unwrap();
                 if cu.device.state() != usb_device::device::UsbDeviceState::Configured {
+                    log::warn!("U2fTx: HANGUP");
                     u2f_ipc.code = U2fCode::Hangup;
                     buffer.replace(u2f_ipc).unwrap();
                     continue;
@@ -454,6 +455,15 @@ pub(crate) fn main_hw() -> ! {
                         cu.fido_tx_queue.borrow_mut().push_back(u2f_msg);
                     }
                     cu.sw_irq(UsbIrqReq::FidoTx);
+                    // ensure that the interrupt has happened, because the interrupt can create
+                    // concurrency issues on the fido_tx_queue if we've re-entered this function
+                    // before the interrupt has processed
+                    while !cu.irq_serviced.load(Ordering::SeqCst) {
+                        xous::yield_slice();
+                    }
+                    // clear the serviced flag here - this is OK because this is the only other thread
+                    // that can access the variable.
+                    cu.irq_serviced.store(false, Ordering::SeqCst);
                     log::debug!("enqueued U2F packet {:x?}", u2f_ipc.data);
                     u2f_ipc.code = U2fCode::TxAck;
                 } else {


### PR DESCRIPTION
The hardware handler structure passes through an interrupt request boundary that breaks assumptions around the borrow handler due to the unsafe transmutation of the record pointer at the interrupt handler entry. This means that records shared between the userspace and machine handler space are not part of the borrow-checker's review.

This patch adds an AtomicBool flag that indicates if the ISR has completed running, and forces the userspace to wait until the ISR has completed before returning. This does potentially slow down the rate of packet transmission but it ensures that the `fido_tx_queue` structure does not have concurrency issues in the case where the following happens:

1. U2fTx opcode encountered
2. fido_tx_queue has a u2f_msg put on it
3. ISR triggered
4. in the process of handling the ISR, a page fault is hit, so the ISR doesn't start for some time.
5. Before the ISR returns, another U2FTx opcode is encountered
6. fido_tx_queue is being modified by userspace
7. The ISR is able to resume
8. You have a simultaneous modification to the fido_tx_queue which is UB.

I think it's maybe possible that this scenario above can't structurally happen due to an ISR page fault not allowing the system to resume through to "normal" code running (iirc the swapper will handle a page fault in ISR and resume directly into the ISR routine) but this patch guards against incorrectness in that implementation.

for what it's worth, later tests show that this bug was not actually at the root cause of the behavior I was chasing down, so in fact this was not happening. However I think it's still a good idea to fix this potential problem.