### PR TITLE
Fix crash from vault itemcache filter oob

### DIFF
--- a/apps-baosec/vault2/src/itemcache.rs
+++ b/apps-baosec/vault2/src/itemcache.rs
@@ -363,3 +363,41 @@ impl ItemLists {
         self.li_mut(list_type).full_list()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk(name: &str, guid: &str) -> ListItem {
+        ListItem::new(name.into(), String::new(), guid.into(), 0, 0)
+    }
+
+    // Regression for the `Err(len)` out-of-bounds: a criteria that sorts past
+    // every entry must not panic. binary_search_by returns Err(insertion_point)
+    // in 0..=len, and `Err(len)` is legitimate when the criteria sorts past
+    // every existing element.
+    #[test]
+    fn filter_criteria_past_end_does_not_panic() {
+        let mut v = FilteredListView::new();
+        for name in ["alpha", "bravo", "charlie"] {
+            v.push(mk(name, name));
+        }
+        v.filter(&"z".to_string());
+        assert_eq!(v.filter_len(), 0);
+    }
+
+    // Regression for the backwards-walk off-by-one (`while index.saturating_sub(1) > 0`,
+    // which is equivalent to `while index > 1` and excludes list[0]).
+    // Three items share a sortable_name; binary_search_by("ab") lands on the
+    // midpoint (Ok(1)) and the backwards walk must reach list[0] for
+    // filter_range to cover all three.
+    #[test]
+    fn filter_walk_back_includes_index_zero() {
+        let mut v = FilteredListView::new();
+        v.push(mk("ab", "g1"));
+        v.push(mk("ab", "g2"));
+        v.push(mk("ab", "g3"));
+        v.filter(&"ab".to_string());
+        assert_eq!(v.filter_len(), 3);
+    }
+}

--- a/apps-baosec/vault2/src/itemcache.rs
+++ b/apps-baosec/vault2/src/itemcache.rs
@@ -236,9 +236,7 @@ impl FilteredListView {
         // step 1. binary search to find if the criteria is even anywhere in the list.
         match self.list.binary_search_by(|probe| probe.sortable_name.partial_cmp(criteria).unwrap()) {
             Ok(mut index) | Err(mut index) => {
-                // `binary_search_by` returns `Err(insertion_point)` in `0..=len`, so
-                // `Err(len)` is legitimate when the criteria sorts past every entry.
-                // Guard the index before dereferencing.
+                // `Err(len)` is a valid insertion point - guard before indexing.
                 if index >= self.list.len()
                     || !self.list[index].name.to_lowercase().starts_with(criteria)
                 {
@@ -372,10 +370,6 @@ mod tests {
         ListItem::new(name.into(), String::new(), guid.into(), 0, 0)
     }
 
-    // Regression for the `Err(len)` out-of-bounds: a criteria that sorts past
-    // every entry must not panic. binary_search_by returns Err(insertion_point)
-    // in 0..=len, and `Err(len)` is legitimate when the criteria sorts past
-    // every existing element.
     #[test]
     fn filter_criteria_past_end_does_not_panic() {
         let mut v = FilteredListView::new();
@@ -386,11 +380,6 @@ mod tests {
         assert_eq!(v.filter_len(), 0);
     }
 
-    // Regression for the backwards-walk off-by-one (`while index.saturating_sub(1) > 0`,
-    // which is equivalent to `while index > 1` and excludes list[0]).
-    // Three items share a sortable_name; binary_search_by("ab") lands on the
-    // midpoint (Ok(1)) and the backwards walk must reach list[0] for
-    // filter_range to cover all three.
     #[test]
     fn filter_walk_back_includes_index_zero() {
         let mut v = FilteredListView::new();

--- a/apps-baosec/vault2/src/itemcache.rs
+++ b/apps-baosec/vault2/src/itemcache.rs
@@ -236,18 +236,21 @@ impl FilteredListView {
         // step 1. binary search to find if the criteria is even anywhere in the list.
         match self.list.binary_search_by(|probe| probe.sortable_name.partial_cmp(criteria).unwrap()) {
             Ok(mut index) | Err(mut index) => {
-                if !self.list[index].name.to_lowercase().starts_with(criteria) {
+                // `binary_search_by` returns `Err(insertion_point)` in `0..=len`, so
+                // `Err(len)` is legitimate when the criteria sorts past every entry.
+                // Guard the index before dereferencing.
+                if index >= self.list.len()
+                    || !self.list[index].name.to_lowercase().starts_with(criteria)
+                {
                     self.filter_range = None
                 } else {
                     // step 2. we have to go backwards in the list because if we have several matches, we are
                     // not guaranteed to be at the first match. Find that first match with a linear search.
                     //ts[2] = tt.elapsed_ms();
-                    while index.saturating_sub(1) > 0 {
-                        if self.list[index - 1].name.to_lowercase().starts_with(criteria) {
-                            index -= 1;
-                        } else {
-                            break;
-                        }
+                    while index > 0
+                        && self.list[index - 1].name.to_lowercase().starts_with(criteria)
+                    {
+                        index -= 1;
                     }
                     // the index now starts at the range of matches. Find the end of matches with another
                     // linear search.

--- a/apps/vault/src/itemcache.rs
+++ b/apps/vault/src/itemcache.rs
@@ -237,9 +237,7 @@ impl FilteredListView {
         // step 1. binary search to find if the criteria is even anywhere in the list.
         match self.list.binary_search_by(|probe| probe.sortable_name.partial_cmp(criteria).unwrap()) {
             Ok(mut index) | Err(mut index) => {
-                // `binary_search_by` returns `Err(insertion_point)` in `0..=len`, so
-                // `Err(len)` is legitimate when the criteria sorts past every entry.
-                // Guard the index before dereferencing.
+                // `Err(len)` is a valid insertion point - guard before indexing.
                 if index >= self.list.len()
                     || !self.list[index].name.to_lowercase().starts_with(criteria)
                 {
@@ -546,10 +544,6 @@ mod tests {
         ListItem::new(name.into(), String::new(), false, guid.into(), 0, 0)
     }
 
-    // Regression for the `Err(len)` out-of-bounds: a criteria that sorts past
-    // every entry must not panic. binary_search_by returns Err(insertion_point)
-    // in 0..=len, and `Err(len)` is legitimate when the criteria sorts past
-    // every existing element.
     #[test]
     fn filter_criteria_past_end_does_not_panic() {
         let mut v = FilteredListView::new();
@@ -560,11 +554,6 @@ mod tests {
         assert_eq!(v.filter_len(), 0);
     }
 
-    // Regression for the backwards-walk off-by-one (`while index.saturating_sub(1) > 0`,
-    // which is equivalent to `while index > 1` and excludes list[0]).
-    // Three items share a sortable_name; binary_search_by("ab") lands on the
-    // midpoint (Ok(1)) and the backwards walk must reach list[0] for
-    // filter_range to cover all three.
     #[test]
     fn filter_walk_back_includes_index_zero() {
         let mut v = FilteredListView::new();

--- a/apps/vault/src/itemcache.rs
+++ b/apps/vault/src/itemcache.rs
@@ -237,18 +237,21 @@ impl FilteredListView {
         // step 1. binary search to find if the criteria is even anywhere in the list.
         match self.list.binary_search_by(|probe| probe.sortable_name.partial_cmp(criteria).unwrap()) {
             Ok(mut index) | Err(mut index) => {
-                if !self.list[index].name.to_lowercase().starts_with(criteria) {
+                // `binary_search_by` returns `Err(insertion_point)` in `0..=len`, so
+                // `Err(len)` is legitimate when the criteria sorts past every entry.
+                // Guard the index before dereferencing.
+                if index >= self.list.len()
+                    || !self.list[index].name.to_lowercase().starts_with(criteria)
+                {
                     self.filter_range = None
                 } else {
                     // step 2. we have to go backwards in the list because if we have several matches, we are
                     // not guaranteed to be at the first match. Find that first match with a linear search.
                     //ts[2] = tt.elapsed_ms();
-                    while index.saturating_sub(1) > 0 {
-                        if self.list[index - 1].name.to_lowercase().starts_with(criteria) {
-                            index -= 1;
-                        } else {
-                            break;
-                        }
+                    while index > 0
+                        && self.list[index - 1].name.to_lowercase().starts_with(criteria)
+                    {
+                        index -= 1;
                     }
                     // the index now starts at the range of matches. Find the end of matches with another
                     // linear search.

--- a/apps/vault/src/itemcache.rs
+++ b/apps/vault/src/itemcache.rs
@@ -537,3 +537,41 @@ impl ItemLists {
         self.li_mut(list_type).selected_page()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk(name: &str, guid: &str) -> ListItem {
+        ListItem::new(name.into(), String::new(), false, guid.into(), 0, 0)
+    }
+
+    // Regression for the `Err(len)` out-of-bounds: a criteria that sorts past
+    // every entry must not panic. binary_search_by returns Err(insertion_point)
+    // in 0..=len, and `Err(len)` is legitimate when the criteria sorts past
+    // every existing element.
+    #[test]
+    fn filter_criteria_past_end_does_not_panic() {
+        let mut v = FilteredListView::new();
+        for name in ["alpha", "bravo", "charlie"] {
+            v.push(mk(name, name));
+        }
+        v.filter(&"z".to_string());
+        assert_eq!(v.filter_len(), 0);
+    }
+
+    // Regression for the backwards-walk off-by-one (`while index.saturating_sub(1) > 0`,
+    // which is equivalent to `while index > 1` and excludes list[0]).
+    // Three items share a sortable_name; binary_search_by("ab") lands on the
+    // midpoint (Ok(1)) and the backwards walk must reach list[0] for
+    // filter_range to cover all three.
+    #[test]
+    fn filter_walk_back_includes_index_zero() {
+        let mut v = FilteredListView::new();
+        v.push(mk("ab", "g1"));
+        v.push(mk("ab", "g2"));
+        v.push(mk("ab", "g3"));
+        v.filter(&"ab".to_string());
+        assert_eq!(v.filter_len(), 3);
+    }
+}


### PR DESCRIPTION
There is an out-of-bounds error in Vault that I keep hitting on my Precursor when plugging in a USB cable to have Vault type my passwords then hit 'Down'.  I find the bug hard to reproduce deterministically, but the crash reveals an OOB bug in Vault.  This is the crash location that is reported when "Guru Meditation" appears.  Specifically, if the index is an insertion point (i.e. len(list)) then indexing there is OOB.  I included some simple tests.

# More info from my agent

`FilteredListView::filter` was panicking with
`index out of bounds: the len is N but the index is N` whenever
the search criteria sorted lexicographically past every existing
entry.

`binary_search_by` returns `Err(insertion_point)` in `0..=len`,
so `Err(len)` is legitimate. The merged `Ok | Err` arm then
indexed `self.list[len]` and panicked. This PR guards the index
before dereferencing and treats the past-the-end case identically
to "criteria isn't a prefix of `list[index]`".

The same fix is applied symmetrically to both copies of the
routine:

- `apps/vault/src/itemcache.rs` (precursor vault)
- `apps-baosec/vault2/src/itemcache.rs` (baosec / daochip vault2)

## Also included

A latent off-by-one in the same arm: the backwards-walk loop's
`while index.saturating_sub(1) > 0` is equivalent to `while index > 1`
and excluded `list[0]` from `filter_range` when the first
prefix-match landed at position 0. Replaced with
`while index > 0 && self.list[index - 1]...starts_with(criteria)`.

Independent bug, low-impact (off-by-one on the front of the
filter window), but folded in because it's in the same hunk and
the review cost is the same.

## Repro / test plan

I observed the panic on
Precursor PVT2 hardware after plugging a USB-C cable into a
foregrounded vault. Post-fix, vault tolerates any criteria
(including ones that sort past every entry) by emptying
`filter_range` rather than panicking.

vault2 is verified to compile against the fix; I do not have
baosec / daochip hardware to runtime-verify on the Bao1x side,
so a maintainer with that path should sanity-check before
merging.
