### PR TITLE
use constant-time password verification

### DIFF
--- a/services/root-keys/src/implementation.rs
+++ b/services/root-keys/src/implementation.rs
@@ -882,28 +882,12 @@ impl<'a> RootKeys {
             unsafe {
                 match pw_type {
                     PasswordType::Boot => {
-                        if (*pcache_ptr).hashed_boot_pw_valid == 1 {
-                            for (&src, &dst) in digest.iter().zip((*pcache_ptr).hashed_boot_pw.iter()) {
-                                if dst != src {
-                                    return false;
-                                }
-                            }
-                            true
-                        } else {
-                            false
-                        }
+                        (*pcache_ptr).hashed_boot_pw_valid == 1
+                            && bool::from(digest.ct_eq(&(*pcache_ptr).hashed_boot_pw))
                     }
                     PasswordType::Update => {
-                        if (*pcache_ptr).hashed_update_pw_valid == 1 {
-                            for (&src, &dst) in digest.iter().zip((*pcache_ptr).hashed_update_pw.iter()) {
-                                if dst != src {
-                                    return false;
-                                }
-                            }
-                            true
-                        } else {
-                            false
-                        }
+                        (*pcache_ptr).hashed_update_pw_valid == 1
+                            && bool::from(digest.ct_eq(&(*pcache_ptr).hashed_update_pw))
                     }
                 }
             }


### PR DESCRIPTION
Password verification in root-keys compared hashed passwords byte-by-byte with early return on mismatch, leaking prefix length through timing.

Replace with `subtle::ConstantTimeEq::ct_eq`, matching the pattern from #863 and #864.

Assisted-by: Claude Code (Opus 4.7)