### PR TITLE
ci: fork-friendly GitHub Actions workflow fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,12 @@ jobs:
   build:
     name: Setup Rust
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     strategy:
+      fail-fast: false
       matrix:
         task: ["bao1x-boot0", "bao1x-boot1", "bao1x-alt-boot1", "bao1x-baremetal-dabao", "dabao", "baosec", "hosted-bao1x-ci", "hosted-ci", "renode-image"]
     steps:
@@ -31,7 +36,13 @@ jobs:
       - name: Fetch tags
         run: git fetch --prune --unshallow --tags
 
-      - uses: Swatinem/rust-cache@v1
+      - name: Fetch upstream release tags (forks may lack annotated tags for signing)
+        continue-on-error: true
+        run: |
+          git remote add upstream https://github.com/betrusted-io/xous-core.git 2>/dev/null || true
+          git fetch upstream --tags --prune --no-recurse-submodules
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install RISC-V toolkit
         run: cargo xtask install-toolkit --force --no-verify

--- a/.github/workflows/rustfmt_check.yml
+++ b/.github/workflows/rustfmt_check.yml
@@ -13,10 +13,13 @@ jobs:
           rustup toolchain install nightly
           rustup component add rustfmt --toolchain nightly
 
-      - name: Ensure the `main` branch rustfmt is applied for the run
+      # Use the repo default branch (e.g. main upstream, dev on some forks) so `git fetch`
+      # does not fail with exit 128 when `main` is absent.
+      - name: Ensure default-branch rustfmt.toml is applied for the run
         run: |
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin main
-          git checkout origin/main rustfmt.toml
+          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$DEFAULT_BRANCH"
+          git checkout "origin/$DEFAULT_BRANCH" rustfmt.toml
 
       - name: Generate dummy templates so formating checks don't choke on missing xtask-generated files
         run: cargo xtask dummy-template


### PR DESCRIPTION
## Summary

Split from #876 (per review feedback): CI workflow changes only.

- `rustfmt_check`: use repository default branch instead of hard-coded `main`
- `build`: `rust-cache@v2`, `fail-fast: false`, upstream tag fetch, `GITHUB_TOKEN` for API auth

## Test plan

- [ ] Push to fork and confirm `rustfmt_check` and `build` workflows run

Related: pairs with xtask/install-toolkit-github-auth for install-toolkit 403 fix.

Made with [Cursor](https://cursor.com)