### PR TITLE
fix cfg gating for gdb-stub in xous-log

### DIFF
--- a/services/xous-log/src/platform/bao1x/implementation.rs
+++ b/services/xous-log/src/platform/bao1x/implementation.rs
@@ -13,6 +13,7 @@ use utralib::generated::*;
 
 pub struct Output {
     // This element is not used, but rather it prevents the interrupt handler from going out of scope.
+    #[cfg(all(feature = "bao1x", not(feature = "hwsim"), not(feature = "gdb-stub")))]
     _uart_irq: Pin<Box<bao1x_hal::udma::UartIrq>>,
 }
 
@@ -88,7 +89,10 @@ pub fn init() -> Output {
     println!("Mapped UART @ {:08x}", uart.as_ptr() as usize);
     println!("Process: map success!");
 
-    Output { _uart_irq: uart_irq }
+    Output {
+        #[cfg(all(feature = "bao1x", not(feature = "hwsim"), not(feature = "gdb-stub")))]
+        _uart_irq: uart_irq,
+    }
 }
 
 #[cfg(all(feature = "bao1x", not(feature = "hwsim"), not(feature = "gdb-stub")))]


### PR DESCRIPTION
how to repro:  `cargo xtask dabao --feature gdb-stub`
The build will fail.  add this fix and it passes 🎉 

This fix (or some fix, feel free to fix this another way if another way is better) seems necessary for anyone who wants to use the UART2 pins on the dabao board (need to add the feature gdb-stub to free up UART2 which is otherwise mapped by xous-log)