### PR TITLE
BIO loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,9 +1366,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1725,8 +1725,11 @@ dependencies = [
  "bao1x-emu",
  "bao1x-hal",
  "bao1x-hal-service",
+ "base64 0.22.1",
  "bio-lib",
  "bytemuck",
+ "crc32fast",
+ "keystore",
  "log",
  "num-derive 0.4.2",
  "num-traits",

--- a/apps-dabao/dabao-console/Cargo.toml
+++ b/apps-dabao/dabao-console/Cargo.toml
@@ -29,7 +29,11 @@ xous-usb-hid = { git = "https://github.com/betrusted-io/xous-usb-hid.git", branc
 bio-lib = { path = "../../libs/bio-lib" }
 arbitrary-int = "1.2"
 
-# aes testing
+# loadable BIO
+keystore = { path = "../../services/keystore", features = ["board-dabao"] }
+base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
+crc32fast = "1.5.0"
+
 [features]
 bao1x = ["utralib/bao1x", "usb-bao1x/bao1x", "aes/bao1x"]
 board-dabao = [

--- a/apps-dabao/dabao-console/src/cmds.rs
+++ b/apps-dabao/dabao-console/src/cmds.rs
@@ -94,6 +94,8 @@ mod ws2812;
 use ws2812::*;
 mod touch;
 use touch::*;
+mod bio;
+use bio::*;
 
 pub struct CmdEnv {
     common_env: CommonEnv,
@@ -106,6 +108,7 @@ pub struct CmdEnv {
     aes_cmd: Aes,
     ws2812_cmd: Ws2812,
     touch_cmd: Touch,
+    bio: BioLoader,
 }
 impl CmdEnv {
     pub fn new(xns: &xous_names::XousNames) -> CmdEnv {
@@ -134,6 +137,7 @@ impl CmdEnv {
             aes_cmd,
             ws2812_cmd: Ws2812::new(),
             touch_cmd: Touch::new(),
+            bio: BioLoader::new(),
         }
     }
 
@@ -162,6 +166,7 @@ impl CmdEnv {
             &mut self.aes_cmd,
             &mut self.ws2812_cmd,
             &mut self.touch_cmd,
+            &mut self.bio,
         ];
 
         if let Some(cmdline) = maybe_cmdline {

--- a/apps-dabao/dabao-console/src/cmds/bio.rs
+++ b/apps-dabao/dabao-console/src/cmds/bio.rs
@@ -1,0 +1,556 @@
+// bio.rs - REPL command that receives a BIO program over serial and runs it.
+//
+// The BIO program is stored in the "data slot" array in the keystore. This is
+// a stand-in solution because the Dabao does not have a permanent storage partition
+// by default, but the data array is big enough to hold BIO programs with room to spare.
+// By putting the programs there, we keep a fairly open slate for future options
+// for data storage using e.g. a dedicated chunk of RRAM while also improving utilization
+// of an otherwise under-utilized resource on the chip.
+
+use core::fmt::Write;
+use std::time::Duration;
+
+use bao1x_api::bio::*;
+use bao1x_api::bio_resources::*;
+use bao1x_api::dabao::{APP_BIO_CLK_INDEX, APP_BIO_CODE_INDICES, APP_BIO_CODE_VALID, APP_BIO_PINS_INDEX};
+use bao1x_hal::bio::{Bio, CoreCsr};
+use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
+use keystore::Keystore;
+
+use crate::{CommonEnv, ShellCmdApi};
+
+// -- Constants ----------------------------------------------------------------
+
+const CHUNK_DATA_SIZE: usize = 64;
+const CHUNK_INDEX_BYTES: usize = 2;
+const CHUNK_CRC_BYTES: usize = 4;
+/// Total decoded wire size per chunk.
+const CHUNK_WIRE_SIZE: usize = CHUNK_INDEX_BYTES + CHUNK_DATA_SIZE + CHUNK_CRC_BYTES; // 70
+/// Size of BIO memory in 32-bit words
+const BIO_MEM_BYTES: usize = 0xf00;
+const NUM_CHUNKS: usize = BIO_MEM_BYTES / CHUNK_DATA_SIZE;
+/// These pins avoid unconnected I/O, I/Os tied to other functions, and the console UART.
+const ALLOWED_PINS: [u8; 17] = [1, 2, 3, 4, 5, 11, 12, 16, 17, 18, 19, 23, 24, 26, 27, 28, 29];
+const VALID_CODE: [u8; 32] = {
+    let mut b = [0u8; 32];
+    b[0] = 1;
+    b
+};
+
+// -- Command state -------------------------------------------------------------
+fn check_pins(pins: &mut Vec<u8>) {
+    pins.retain(|p| ALLOWED_PINS.contains(p));
+    pins.sort();
+    pins.dedup();
+}
+
+pub struct BioLoader {
+    /// Raw 64-byte payloads indexed by chunk number.
+    /// `None` means that chunk has not yet been received.
+    chunks: Vec<Option<[u8; CHUNK_DATA_SIZE]>>,
+
+    /// How many distinct chunk slots are currently filled.
+    received_count: usize,
+
+    /// BIO clock config
+    target_freq: u32,
+
+    /// Pins used by this BIO
+    pin_spec: Vec<u8>,
+
+    /// Actual code
+    code: Option<[u8; BIO_MEM_BYTES]>,
+
+    store: Keystore,
+
+    bio_ss: Bio,
+    _fifo_handle: CoreHandle,
+    fifo: CoreCsr,
+    resource_grant: ResourceGrant,
+
+    core_init: bool,
+}
+
+impl BioLoader {
+    pub fn new() -> Self {
+        let xns = xous_names::XousNames::new().unwrap();
+        let keystore = Keystore::new(&xns);
+
+        // check if the CODE_VALID key has a valid number; if not, this is a factory new
+        // part and the parameters need initialization
+        let erase_check = keystore.read_app_key(APP_BIO_CODE_VALID).unwrap();
+        if !(erase_check == [0u8; 32] || erase_check == VALID_CODE) {
+            log::info!("Initializing BIO keys to valid initial state");
+            // the key array is uninit, initialize it
+            keystore.write_app_key(APP_BIO_PINS_INDEX, &[0u8; 32]).ok();
+            keystore.write_app_key(APP_BIO_CLK_INDEX, &[0u8; 32]).ok();
+            // instead of writing all 0's to the code space
+            keystore.write_app_key(APP_BIO_CODE_VALID, &[0u8; 32]).ok();
+        }
+
+        // this now happens fairly late in the init due to the gate above
+        let mut bio_ss = Bio::new();
+        // claim core resource and initialize it
+        let resource_grant =
+            bio_ss.claim_resources(&Self::resource_spec()).expect("Couldn't claim BIO resources");
+
+        log::info!("BIO loader reserving core: {:?}", resource_grant.cores[0]);
+
+        // safety: fifo is stored in this object so they aren't Drop'd before the object is
+        // destroyed
+        let fifo_handle = unsafe { bio_ss.get_core_handle(Fifo::Fifo0) }
+            .expect("Didn't get FIFO0 handle")
+            .expect("Didn't get FIFO0 handle");
+        let fifo = CoreCsr::from_handle(&fifo_handle);
+
+        bio_ss
+            .setup_fifo_event_triggers(FifoEventConfig {
+                which: Fifo::Fifo0,
+                trigger_slot: TriggerSlot::new_with_raw_value(1),
+                level: FifoLevel::new_with_raw_value(1),
+                trigger_less_than: false,
+                trigger_greater_than: true,
+                trigger_equal_to: true,
+            })
+            .expect("couldn't set FIFO trigger configuration");
+        bio_ss
+            .setup_fifo_event_triggers(FifoEventConfig {
+                which: Fifo::Fifo0,
+                trigger_slot: TriggerSlot::new_with_raw_value(0),
+                level: FifoLevel::new_with_raw_value(0),
+                trigger_less_than: false,
+                trigger_greater_than: false,
+                trigger_equal_to: true,
+            })
+            .expect("couldn't set FIFO trigger configuration");
+
+        let mut loader = BioLoader {
+            chunks: vec![None; NUM_CHUNKS],
+            received_count: 0,
+            target_freq: 700_000_000,
+            pin_spec: vec![],
+            code: None,
+            store: keystore,
+            bio_ss,
+            _fifo_handle: fifo_handle,
+            fifo,
+            resource_grant,
+            core_init: false,
+        };
+        match loader.reload() {
+            Err(s) => {
+                log::error!("Couldn't setup BIO: {:?}", s)
+            }
+            _ => (),
+        }
+
+        loader
+    }
+
+    pub fn reload(&mut self) -> Result<(), String> {
+        let config = {
+            let mut clk_buf = [0u8; 4];
+            let clk_slice = self
+                .store
+                .read_app_key(APP_BIO_CLK_INDEX)
+                .map_err(|_| "Couldn't read keystore".to_string())?;
+            clk_buf.copy_from_slice(&clk_slice[..4]);
+            self.target_freq = 350_000_000;
+            if clk_buf != [0u8; 4] {
+                let target_freq = u32::from_le_bytes(clk_buf);
+                if target_freq > 0 && target_freq <= 350_000_000 {
+                    log::info!("target_freq {}", target_freq);
+                    self.target_freq = target_freq;
+                    CoreConfig { clock_mode: bao1x_api::bio::ClockMode::TargetFreqInt(target_freq) }
+                } else {
+                    CoreConfig { clock_mode: bao1x_api::bio::ClockMode::TargetFreqInt(350_000_000) }
+                }
+            } else {
+                CoreConfig { clock_mode: bao1x_api::bio::ClockMode::TargetFreqInt(350_000_000) }
+            }
+        };
+        // release any claimed pins
+        let mut io_config = IoConfig::default();
+        for pin in &self.pin_spec {
+            self.bio_ss.release_dynamic_pin(*pin, &BioLoader::resource_spec().claimer).ok();
+            io_config.mapped |= 1 << (*pin as u32);
+        }
+        if io_config.mapped != 0 {
+            io_config.mode = IoConfigMode::ClearOnly;
+            io_config.mapped = !io_config.mapped;
+            self.bio_ss.setup_io_config(io_config).ok();
+        }
+        // now init a new set of pins
+        let mut pin_spec = self
+            .store
+            .read_app_key(APP_BIO_PINS_INDEX)
+            .map_err(|_| "Couldn't read keystore".to_string())?
+            .to_vec();
+
+        let mut code_buf = [0u8; 0xf00];
+        let code_found =
+            self.store.read_app_key(APP_BIO_CODE_VALID).map_err(|_| "Couldn't read keystore".to_string())?[0]
+                != 0;
+        for (fetch_index, chunk) in APP_BIO_CODE_INDICES.zip(code_buf.chunks_mut(32)) {
+            chunk.copy_from_slice(
+                &self
+                    .store
+                    .read_app_key(fetch_index as usize)
+                    .map_err(|_| "Couldn't read keystore".to_string())?,
+            );
+        }
+
+        if code_found && code_buf.iter().any(|&b| b != 0) {
+            log::info!("code: {:x?}", &code_buf[..16]);
+            if self.core_init {
+                self.bio_ss.de_init_core(self.resource_grant.cores[0]).ok();
+                self.core_init = false;
+            }
+            let actual_freq = self
+                .bio_ss
+                .init_core(self.resource_grant.cores[0], (&code_buf, None), config)
+                .map_err(|e| format!("Couldn't init core: {:?}", e))?;
+            if let Some(actual) = actual_freq {
+                log::info!("Actual quantum frequency: {}Hz", actual);
+            }
+            self.core_init = true;
+        } else {
+            log::info!("No code to load");
+        }
+        self.code = Some(code_buf);
+
+        check_pins(&mut pin_spec);
+        log::info!("Finalized pin spec {:?}", pin_spec);
+        let mut io_config = IoConfig::default();
+        for pin in &pin_spec {
+            log::info!("Claiming pin {}", *pin);
+            // claim pin resource - this only claims the resource, it does not configure it
+            self.bio_ss
+                .claim_dynamic_pin(*pin, &BioLoader::resource_spec().claimer)
+                .map_err(|_| "can't claim pin".to_string())?;
+            // now configure the claimed resource
+            io_config.mapped |= 1 << (*pin as u32);
+        }
+        if io_config.mapped != 0 {
+            io_config.mode = IoConfigMode::SetOnly;
+            log::info!("Map pin mask {:x}", io_config.mapped);
+            self.bio_ss.setup_io_config(io_config).ok();
+        }
+        self.pin_spec = pin_spec;
+
+        if code_found {
+            log::info!("Set core to run {:?}", self.resource_grant);
+            self.bio_ss.set_core_run_state(&self.resource_grant, true);
+        } else {
+            log::info!("Set core to halt {:?}", self.resource_grant);
+            self.bio_ss.set_core_run_state(&self.resource_grant, false);
+        }
+        Ok(())
+    }
+
+    /// Return true when every chunk slot is filled.
+    pub fn is_complete(&self) -> bool { self.received_count == NUM_CHUNKS }
+
+    /// Assemble all received chunks into a `[u8; 0xf00]` code chunk.
+    /// Panics if `is_complete()` is false - caller should check first.
+    pub fn to_code(&self) -> [u8; BIO_MEM_BYTES] {
+        assert!(self.is_complete(), "code not yet complete");
+        let mut code = [0u8; BIO_MEM_BYTES];
+        for (chunk_idx, slot) in self.chunks.iter().enumerate() {
+            let data = slot.as_ref().unwrap();
+            let word_base = chunk_idx * CHUNK_DATA_SIZE;
+            code[word_base..word_base + CHUNK_DATA_SIZE].copy_from_slice(data);
+        }
+        code
+    }
+
+    /// Reset all state in the holding buffer (not to be confused with clearing the PDDB stored data)
+    pub fn clear(&mut self) {
+        for slot in self.chunks.iter_mut() {
+            *slot = None;
+        }
+        self.received_count = 0;
+    }
+
+    /// Persist the assembled code to PDDB, clear in-memory state, and signal
+    /// a reload. Called both from the normal last-chunk path and from `pad`.
+    fn commit(&mut self) -> &'static str {
+        let code = self.to_code();
+        for (i, chunk) in APP_BIO_CODE_INDICES.zip(code.chunks(32)) {
+            self.store.write_app_key(i, chunk.try_into().unwrap()).unwrap();
+        }
+        self.store.write_app_key(APP_BIO_CODE_VALID, &VALID_CODE);
+        self.clear(); // clears the holding buffer for incoming code
+        "SUCCESS"
+    }
+}
+
+impl Resources for BioLoader {
+    fn resource_spec() -> ResourceSpec {
+        ResourceSpec {
+            claimer: "BIO loader".to_string(),
+            cores: vec![CoreRequirement::Any],
+            fifos: vec![Fifo::Fifo0],
+            static_pins: vec![],
+            dynamic_pin_count: 17,
+        }
+    }
+}
+
+impl Drop for BioLoader {
+    fn drop(&mut self) {
+        for &core in self.resource_grant.cores.iter() {
+            self.bio_ss.de_init_core(core).unwrap();
+        }
+        self.core_init = false;
+        let mut io_config = IoConfig::default();
+        for pin in &self.pin_spec {
+            self.bio_ss.release_dynamic_pin(*pin, &BioLoader::resource_spec().claimer).ok();
+            io_config.mapped |= 1 << (*pin as u32);
+        }
+        if io_config.mapped != 0 {
+            io_config.mode = IoConfigMode::ClearOnly;
+            io_config.mapped = !io_config.mapped;
+            self.bio_ss.setup_io_config(io_config).unwrap();
+        }
+        self.bio_ss.release_resources(self.resource_grant.grant_id).unwrap();
+    }
+}
+
+// -- ShellCmdApi implementation ------------------------------------------------
+
+impl<'a> ShellCmdApi<'a> for BioLoader {
+    cmd_api!(bio);
+
+    fn process(&mut self, args: String, _env: &mut CommonEnv) -> Result<Option<String>, xous::Error> {
+        let mut ret = String::new();
+
+        if args == "ready" {
+            write!(ret, "OK").unwrap();
+            return Ok(Some(ret));
+        }
+
+        if args == "clear" {
+            self.clear();
+            self.store.write_app_key(APP_BIO_PINS_INDEX, &[0u8; 32]).ok();
+            self.store.write_app_key(APP_BIO_CLK_INDEX, &[0u8; 32]).ok();
+            // instead of writing all 0's to the code space
+            self.store.write_app_key(APP_BIO_CODE_VALID, &[0u8; 32]).ok();
+
+            for &core in self.resource_grant.cores.iter() {
+                self.bio_ss.de_init_core(core).unwrap();
+            }
+            self.core_init = false;
+            let mut io_config = IoConfig::default();
+            for pin in &self.pin_spec {
+                self.bio_ss.release_dynamic_pin(*pin, &BioLoader::resource_spec().claimer).ok();
+                io_config.mapped |= 1 << (*pin as u32);
+            }
+            if io_config.mapped != 0 {
+                io_config.mode = IoConfigMode::ClearOnly;
+                io_config.mapped = !io_config.mapped;
+                self.bio_ss.setup_io_config(io_config).unwrap();
+            }
+            self.pin_spec = vec![];
+            // don't release this - we still "own" it just in case we get new code uploaded
+            // self.bio_ss.release_resources(self.resource_grant.grant_id).unwrap();
+
+            write!(ret, "CLEAR").unwrap();
+            return Ok(Some(ret));
+        }
+
+        if args.starts_with("pin") {
+            let arg_list: Vec<&str> = args.split_whitespace().collect();
+            let mut pins = Vec::<u8>::new();
+            if arg_list.len() >= 2 {
+                for pin_str in &arg_list[1..] {
+                    if let Ok(pin) = u8::from_str_radix(pin_str, 10) {
+                        pins.push(pin);
+                    }
+                }
+                check_pins(&mut pins);
+                let mut pin_list = [0u8; 32];
+                for (i, p) in pins.iter().enumerate() {
+                    pin_list[i] = *p;
+                }
+                if let Err(e) = self.store.write_app_key(APP_BIO_PINS_INDEX, &pin_list) {
+                    write!(ret, "Write failure: {:?}", e).ok();
+                    return Ok(Some(ret));
+                }
+                log::info!("Set pin spec of {:x?}", pin_list);
+            }
+            write!(ret, "OK").unwrap();
+            return Ok(Some(ret));
+        }
+
+        if args.starts_with("clk") {
+            let arg_list: Vec<&str> = args.split_whitespace().collect();
+            if arg_list.len() >= 2 {
+                if let Ok(clk) = u32::from_str_radix(arg_list[1], 10) {
+                    let mut clk_bytes = [0u8; 32];
+                    clk_bytes[..4].copy_from_slice(&clk.to_le_bytes());
+                    if let Err(e) = self.store.write_app_key(APP_BIO_CLK_INDEX, &clk_bytes) {
+                        write!(ret, "Write failure: {:?}", e).ok();
+                        return Ok(Some(ret));
+                    }
+                }
+            }
+            write!(ret, "OK").unwrap();
+            return Ok(Some(ret));
+        }
+
+        if args.starts_with("reload") {
+            match self.reload() {
+                Ok(_) => {
+                    write!(ret, "BIO load successful").unwrap();
+                    return Ok(Some(ret));
+                }
+                Err(e) => {
+                    write!(ret, "ERR {:?}", e).unwrap();
+                    return Ok(Some(ret));
+                }
+            }
+        }
+
+        if args.starts_with("rx") {
+            self.bio_ss.debug(self.resource_grant.cores[0]);
+            let arg_list: Vec<&str> = args.split_whitespace().collect();
+            let iters =
+                if arg_list.len() >= 2 { usize::from_str_radix(arg_list[1], 10).unwrap_or(1) } else { 1 };
+            let timeout = if arg_list.len() >= 3 {
+                Duration::from_secs(u64::from_str_radix(arg_list[2], 10).unwrap_or(1))
+            } else {
+                Duration::from_secs(1)
+            };
+            for _ in 0..iters {
+                let start = std::time::Instant::now();
+                while self.fifo.csr.rf(utralib::utra::bio_bdma::SFR_FLEVEL_PCLK_REGFIFO_LEVEL0) == 0 {
+                    // wait for entry
+                    if std::time::Instant::now().duration_since(start) > timeout {
+                        log::info!("timeout");
+                        break;
+                    }
+                }
+                let dat = self.fifo.csr.r(utralib::utra::bio_bdma::SFR_RXF0);
+                log::info!("{:x?}", dat);
+            }
+            write!(ret, "OK").unwrap();
+            return Ok(Some(ret));
+        }
+
+        if args.starts_with("tx") {
+            let arg_list: Vec<&str> = args.split_whitespace().collect();
+            if arg_list.len() >= 2 {
+                let s = arg_list[1].trim();
+                let val = if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+                    u32::from_str_radix(hex, 16).map_err(|e| e.to_string())
+                } else {
+                    s.parse::<u32>().map_err(|e| e.to_string())
+                };
+                let iters =
+                    if arg_list.len() == 3 { usize::from_str_radix(arg_list[2], 10).unwrap_or(1) } else { 1 };
+                let mut timeout = false;
+                if let Ok(val) = val {
+                    for _ in 0..iters {
+                        let start = std::time::Instant::now();
+                        while self.fifo.csr.rf(utralib::utra::bio_bdma::SFR_FLEVEL_PCLK_REGFIFO_LEVEL0) > 7 {
+                            // don't overflow the fifo
+                            // wait for entry
+                            if std::time::Instant::now().duration_since(start) > Duration::from_secs(5) {
+                                log::info!("timeout");
+                                timeout = true;
+                                break;
+                            }
+                        }
+                        if timeout {
+                            break;
+                        }
+                        self.fifo.csr.wo(utralib::utra::bio_bdma::SFR_TXF0, val);
+                        log::info!("{:x?}", val);
+                    }
+                    write!(ret, "OK").unwrap();
+                } else {
+                    write!(ret, "ERR bad argument").unwrap();
+                }
+            } else {
+                write!(ret, "ERR tx <val> [repeat]").unwrap();
+            }
+            return Ok(Some(ret));
+        }
+
+        if args == "pad" {
+            // Zero-fill every slot not yet received, then commit.
+            // This allows the host to send only the chunks that carry real data
+            // and let the device pad the remainder of the 0xf00-byte buffer.
+
+            for slot in self.chunks.iter_mut() {
+                if slot.is_none() {
+                    *slot = Some([0u8; CHUNK_DATA_SIZE]);
+
+                    self.received_count += 1;
+                }
+            }
+
+            write!(ret, "{}", self.commit()).unwrap();
+
+            return Ok(Some(ret));
+        }
+
+        // -- Decode base64 argument --------------------------------------------
+        let b64 = args.trim();
+        if b64.is_empty() {
+            write!(ret, "ERR").unwrap();
+            return Ok(Some(ret));
+        }
+
+        let decoded = match B64.decode(b64) {
+            Ok(d) => d,
+            Err(_) => {
+                write!(ret, "ERR").unwrap();
+                return Ok(Some(ret));
+            }
+        };
+
+        if decoded.len() != CHUNK_WIRE_SIZE {
+            write!(ret, "ERR").unwrap();
+            return Ok(Some(ret));
+        }
+
+        // -- Parse fields ------------------------------------------------------
+        let index = u16::from_be_bytes([decoded[0], decoded[1]]) as usize;
+        // data lives at decoded[2..66]
+        let received_crc = u32::from_be_bytes([decoded[66], decoded[67], decoded[68], decoded[69]]);
+
+        // -- Verify CRC over (index bytes || data) -----------------------------
+        let computed_crc = crc32fast::hash(&decoded[..CHUNK_INDEX_BYTES + CHUNK_DATA_SIZE]);
+        if computed_crc != received_crc {
+            write!(ret, "ERR").unwrap();
+            return Ok(Some(ret));
+        }
+
+        // -- Bounds-check index ------------------------------------------------
+        if index >= NUM_CHUNKS {
+            write!(ret, "ERR").unwrap();
+            return Ok(Some(ret));
+        }
+
+        // -- Store chunk (silent overwrite on duplicate) -----------------------
+        let mut data_arr = [0u8; CHUNK_DATA_SIZE];
+        data_arr.copy_from_slice(&decoded[CHUNK_INDEX_BYTES..CHUNK_INDEX_BYTES + CHUNK_DATA_SIZE]);
+
+        let was_empty = self.chunks[index].is_none();
+        self.chunks[index] = Some(data_arr);
+        if was_empty {
+            self.received_count += 1;
+        }
+
+        // -- Reply -------------------------------------------------------------
+        if self.is_complete() {
+            write!(ret, "{}", self.commit()).unwrap();
+        } else {
+            write!(ret, "OK").unwrap();
+        }
+
+        Ok(Some(ret))
+    }
+}

--- a/libs/bao1x-api/src/offsets/baosec.rs
+++ b/libs/bao1x-api/src/offsets/baosec.rs
@@ -134,6 +134,7 @@ pub const THE_FLAG_1: SlotIndex = SlotIndex::Data(260, PartitionAccess::Fw0, RwP
 // NOTE: COLLATERAL is from 261..265, but it is in the "common" page
 
 // [384..=1919] are unused and available for third party use
+pub const APPLICATION: SlotIndex = crate::offsets::APPLICATION;
 
 pub const NUISANCE_KEYS_1: SlotIndex =
     SlotIndex::DataRange(1920..2048, PartitionAccess::Fw0, RwPerms::ReadWrite);

--- a/libs/bao1x-api/src/offsets/common.rs
+++ b/libs/bao1x-api/src/offsets/common.rs
@@ -300,3 +300,6 @@ pub const CLOCK_SCRAMBLE_PARAMS: SlotIndex = SlotIndex::Data(272, PartitionAcces
 //    - "end" bits [47:40] == 0x08
 //
 // Furthermore, IFR slot 0x14, bits [127:120] should have 0x3a in it to enforce write disable on boot0
+
+/// Application slots are available to end users for use, and not reserved for OS or security
+pub const APPLICATION: SlotIndex = SlotIndex::DataRange(384..1920, PartitionAccess::Open, RwPerms::ReadWrite);

--- a/libs/bao1x-api/src/offsets/dabao.rs
+++ b/libs/bao1x-api/src/offsets/dabao.rs
@@ -54,3 +54,13 @@ pub use crate::baosec::{
 
 pub const KEY_SLOTS: [SlotIndex; 6] =
     [THE_FLAG_1, ROOT_SEED, RMA_KEY, NUISANCE_KEYS_0, NUISANCE_KEYS_1, CHAFF_KEYS];
+
+// [384..=1919] are unused and available for third party use
+pub const APPLICATION: SlotIndex = crate::offsets::APPLICATION;
+
+// offsets into the application slot range for storing BIO config
+pub const APP_BIO_CLK_INDEX: usize = 0;
+pub const APP_BIO_PINS_INDEX: usize = 1;
+pub const APP_BIO_CODE_VALID: usize = 2;
+// total length is 0xf00 = 120 slots
+pub const APP_BIO_CODE_INDICES: core::ops::Range<usize> = 3..123;

--- a/libs/bao1x-hal/src/acram.rs
+++ b/libs/bao1x-hal/src/acram.rs
@@ -408,6 +408,13 @@ impl SlotManager {
                 .map_err(|_| AccessError::WriteError)?;
             crate::cache_flush();
         }
+        // Note: we don't report an explicit AccessDenied if the slot has the wrong permissions.
+        // If changing this for production, a full regression test *must* be done on the bootloader
+        // starting with chips that are in the factory-new state. The factory-new initialization
+        // cannot fail for any reason, and this error was made silent as an explicit decision to
+        // avoid having chips bricked due to a fat-fingering of ACLs during setup. The alternative
+        // is that chips which have an ACL issue would effectively be bricked and because of a hang on
+        // the error code returned during initialization of important resources.
 
         if self.user_id.is_accessible(&acl, &AccessType::Read) {
             // read-verify only if we have read access
@@ -415,6 +422,7 @@ impl SlotManager {
             crate::println!("rbk: {:x?}", &readback[..8]);
             if readback != value { Err(AccessError::WriteError) } else { Ok(()) }
         } else {
+            // It's valid to have a write-only slot, in which case, we can't readback verify it.
             Ok(())
         }
     }

--- a/libs/keystore-api/Cargo.toml
+++ b/libs/keystore-api/Cargo.toml
@@ -29,6 +29,8 @@ efuse = []
 policy-menu = []
 
 gen2 = []
+owc-inc = []
+app-keys = []
 
 std = ["derive-rkyv", "xous-names", "xous-ipc", "locales"]
 derive-rkyv = ["rkyv"]

--- a/libs/keystore-api/src/gen2_api.rs
+++ b/libs/keystore-api/src/gen2_api.rs
@@ -26,7 +26,12 @@ pub enum Opcode {
     SetFlags = 513,
     /// One way counter operations
     GetOneWayCounter = 768,
+    #[cfg(feature = "owc-inc")]
     IncOneWayCounter = 769,
+
+    /// Application key operations
+    #[cfg(feature = "app-keys")]
+    AppKeyOp = 1024,
 
     // ----- below are non-cryptographic opcodes but used to manipulate sensitive state -----
     /// Set bootwait parameters
@@ -49,3 +54,4 @@ pub enum EphemeralOp {
 /// but for detecting fat-fingered API implementations.
 pub const OWC_MAGIC_GET: [usize; 3] = [0x2b46_2ab3, 0xf7e3_1b59, 0x7bba_d222];
 pub const OWC_MAGIC_INC: [usize; 3] = [0xeb5d_fc81, 0x8b6d_6a90, 0xf720_491a];
+pub const APPKEY_GUARD: [u32; 4] = [0x3936_e7a6, 0xfc53_a1f7, 0xf2eb_16f3, 0xd2cc_22d9];

--- a/libs/keystore-api/src/rkyv_enum.rs
+++ b/libs/keystore-api/src/rkyv_enum.rs
@@ -35,3 +35,21 @@ pub enum KeywrapError {
     /// The return tuple is: (unwrapped key, correctly wrapped key)
     UpgradeToNew(([u8; 32], [u8; 40])),
 }
+
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Eq, PartialEq, Copy, Clone)]
+pub enum AppKey {
+    // guard is a sequence of magic numbers that prevent fat-fingering this API
+    // it does not prevent malicious, directed attacks, but rather prevents accidents
+    Write { guard: [u32; 4], index: usize, data: [u8; 32] },
+    ReadRequest { guard: [u32; 4], index: usize },
+    ReadResponse { data: [u8; 32] },
+    Uninit,
+    AccessDenied,
+    WriteError,
+    Success,
+    InternalError,
+}
+
+impl Default for AppKey {
+    fn default() -> Self { Self::Uninit }
+}

--- a/services/bao1x-hal-service/src/servers/keyboard.rs
+++ b/services/bao1x-hal-service/src/servers/keyboard.rs
@@ -7,6 +7,7 @@ use bao1x_api::keyboard::*;
 use bao1x_hal::board::KeyPress;
 #[cfg(feature = "board-baosec")]
 use bao1x_hal::kpc_aoint::{AoIntStatus, KpcAoInt};
+#[cfg(feature = "board-baosec")]
 use bao1x_hal_service::Rtc;
 use num_traits::*;
 #[cfg(feature = "board-baosec")]
@@ -357,6 +358,7 @@ fn keyboard_service() {
         }
     });
 
+    #[cfg(feature = "board-baosec")]
     let rtc = Rtc::new();
     #[cfg(feature = "board-baosec")]
     let mut key_tracker = KeyTracker::new();

--- a/services/keystore/Cargo.toml
+++ b/services/keystore/Cargo.toml
@@ -80,7 +80,10 @@ debug-hal = ["bao1x-hal/debug-print-duart"]
 
 # Enables incrementing one way counters. Off by default because this API can be, at the very least,
 # used to grief the security layer if not worse
-owc-inc = []
+owc-inc = ["keystore-api/owc-inc"]
+
+# Enable to allow users to access the application keystore slots
+app-keys = ["keystore-api/app-keys"]
 
 board-baosec = [
     "utralib/bao1x",
@@ -109,6 +112,7 @@ board-dabao = [
     "bao1x-hal",
     "bao1x-hal-service/board-dabao",
     "bao1x-hal/security",
+    "app-keys",
 ] # Dev board form factor
 loader-dabao = []
 

--- a/services/keystore/Cargo.toml
+++ b/services/keystore/Cargo.toml
@@ -83,6 +83,9 @@ debug-hal = ["bao1x-hal/debug-print-duart"]
 owc-inc = ["keystore-api/owc-inc"]
 
 # Enable to allow users to access the application keystore slots
+# Because application keys are stored adjacent to secret keys, it's recommended to leave this
+# feature off if it's not actively being used by the target application, as it reduces the
+# potential attack surface exposed by the keystore server.
 app-keys = ["keystore-api/app-keys"]
 
 board-baosec = [

--- a/services/keystore/src/lib.rs
+++ b/services/keystore/src/lib.rs
@@ -381,6 +381,32 @@ impl Keystore {
         }
         Ok(key)
     }
+
+    #[cfg(feature = "app-keys")]
+    pub fn read_app_key(&self, index: usize) -> Result<[u8; 32], xous::Error> {
+        let app_key = AppKey::ReadRequest { guard: APPKEY_GUARD, index };
+        let mut buf = Buffer::into_buf(app_key).or(Err(xous::Error::InternalError))?;
+        buf.lend_mut(self.conn, Opcode::AppKeyOp.to_u32().unwrap()).or(Err(xous::Error::InternalError))?;
+        match buf.to_original::<AppKey, _>().unwrap() {
+            AppKey::ReadResponse { data } => Ok(data),
+            AppKey::AccessDenied => Err(xous::Error::AccessDenied),
+            _ => Err(xous::Error::InternalError),
+        }
+    }
+
+    #[cfg(feature = "app-keys")]
+    pub fn write_app_key(&self, index: usize, data: &[u8; 32]) -> Result<(), xous::Error> {
+        let mut storage = [0u8; 32];
+        storage.copy_from_slice(data);
+        let app_key = AppKey::Write { guard: APPKEY_GUARD, index, data: storage };
+        let mut buf = Buffer::into_buf(app_key).or(Err(xous::Error::InternalError))?;
+        buf.lend_mut(self.conn, Opcode::AppKeyOp.to_u32().unwrap()).or(Err(xous::Error::InternalError))?;
+        match buf.to_original::<AppKey, _>().unwrap() {
+            AppKey::Success => Ok(()),
+            AppKey::AccessDenied => Err(xous::Error::AccessDenied),
+            _ => Err(xous::Error::InternalError),
+        }
+    }
 }
 
 use core::sync::atomic::{AtomicU32, Ordering};

--- a/services/keystore/src/platform/baosec/server.rs
+++ b/services/keystore/src/platform/baosec/server.rs
@@ -37,23 +37,25 @@ pub fn keystore(sid: SID) -> ! {
         log::debug!("{:?}", opcode);
         match opcode {
             Opcode::AesOracle => {
-                let mut buffer =
-                    unsafe { Buffer::from_memory_message_mut(msg.body.memory_message_mut().unwrap()) };
-                // as_flat saves a copy step, but we have to deserialize some enums manually
-                let mut aes_op = buffer.to_original::<AesOp, _>().unwrap();
-                // TODO: add hardening checks to the deserialization of AesOp. Can't assume the
-                // values are correct coming into this server.
-                store.aes_op(&mut aes_op).expect("couldn't perform AES op");
-                buffer.replace(aes_op).unwrap();
+                if let Some(mem) = msg.body.memory_message_mut() {
+                    let mut buffer = unsafe { Buffer::from_memory_message_mut(mem) };
+                    // as_flat saves a copy step, but we have to deserialize some enums manually
+                    let mut aes_op = buffer.to_original::<AesOp, _>().unwrap();
+                    // TODO: add hardening checks to the deserialization of AesOp. Can't assume the
+                    // values are correct coming into this server.
+                    store.aes_op(&mut aes_op).expect("couldn't perform AES op");
+                    buffer.replace(aes_op).unwrap();
+                }
             }
             Opcode::AesKwp => {
-                let mut buffer =
-                    unsafe { Buffer::from_memory_message_mut(msg.body.memory_message_mut().unwrap()) };
-                let mut kwp = buffer.to_original::<KeyWrapper, _>().unwrap();
-                // TODO: add hardening checks to the deserialization of AesOp. Can't assume the
-                // values are correct coming into this server.
-                store.aes_kwp(&mut kwp).expect("couldn't wrap key");
-                buffer.replace(kwp).unwrap();
+                if let Some(mem) = msg.body.memory_message_mut() {
+                    let mut buffer = unsafe { Buffer::from_memory_message_mut(mem) };
+                    let mut kwp = buffer.to_original::<KeyWrapper, _>().unwrap();
+                    // TODO: add hardening checks to the deserialization of AesOp. Can't assume the
+                    // values are correct coming into this server.
+                    store.aes_kwp(&mut kwp).expect("couldn't wrap key");
+                    buffer.replace(kwp).unwrap();
+                }
             }
             Opcode::Ephemeral => {
                 if let Some(scalar) = msg.body.scalar_message_mut() {
@@ -121,6 +123,7 @@ pub fn keystore(sid: SID) -> ! {
                     if store.is_developer() { scalar.arg1 = 0 } else { scalar.arg1 = 1 }
                 }
             }
+            #[cfg(feature = "owc-inc")]
             Opcode::IncOneWayCounter => {
                 if let Some(scalar) = msg.body.scalar_message_mut() {
                     if [scalar.arg2, scalar.arg3, scalar.arg4] == OWC_MAGIC_INC
@@ -152,6 +155,41 @@ pub fn keystore(sid: SID) -> ! {
                     } else {
                         scalar.arg1 = OneWayErr::InternalError.to_usize().unwrap();
                     }
+                }
+            }
+            #[cfg(feature = "app-keys")]
+            Opcode::AppKeyOp => {
+                if let Some(mem) = msg.body.memory_message_mut() {
+                    let mut buffer = unsafe { Buffer::from_memory_message_mut(mem) };
+                    // as_flat saves a copy step, but we have to deserialize some enums manually
+                    let mut app_key = buffer.to_original::<AppKey, _>().unwrap();
+                    match app_key {
+                        AppKey::ReadRequest { guard, index } => {
+                            if guard != APPKEY_GUARD {
+                                app_key = AppKey::InternalError;
+                            } else {
+                                match store.read_app_key(index) {
+                                    Ok(d) => app_key = AppKey::ReadResponse { data: d },
+                                    Err(xous::Error::AccessDenied) => app_key = AppKey::AccessDenied,
+                                    _ => app_key = AppKey::InternalError,
+                                }
+                            }
+                        }
+                        AppKey::Write { guard, index, data } => {
+                            if guard != APPKEY_GUARD {
+                                app_key = AppKey::InternalError
+                            } else {
+                                match store.write_app_key(&mut rram, index, data) {
+                                    Ok(_) => app_key = AppKey::Success,
+                                    Err(xous::Error::AccessDenied) => app_key = AppKey::AccessDenied,
+                                    Err(xous::Error::HardwareError) => app_key = AppKey::WriteError,
+                                    _ => app_key = AppKey::InternalError,
+                                }
+                            }
+                        }
+                        _ => app_key = AppKey::InternalError,
+                    }
+                    buffer.replace(app_key).unwrap();
                 }
             }
             Opcode::InvalidCall => {

--- a/services/keystore/src/platform/baosec/store.rs
+++ b/services/keystore/src/platform/baosec/store.rs
@@ -386,4 +386,53 @@ impl KeyStore {
     }
 
     pub fn is_developer(&self) -> bool { self.owc.get(bao1x_api::DEVELOPER_MODE).unwrap() != 0 }
+
+    #[cfg(feature = "app-keys")]
+    pub fn read_app_key(&self, index: usize) -> Result<[u8; 32], xous::Error> {
+        use bao1x_api::common::APPLICATION;
+        let real_index = index + bao1x_api::common::APPLICATION.get_base();
+        if real_index < APPLICATION.get_base() || real_index >= APPLICATION.get_base() + APPLICATION.len() {
+            return Err(xous::Error::AccessDenied);
+        } else {
+            use bao1x_api::SlotIndex;
+
+            let slot =
+                SlotIndex::Data(real_index, bao1x_api::PartitionAccess::Open, bao1x_api::RwPerms::ReadWrite);
+            if let Ok(result) = self.slot_mgr.read(&slot) {
+                let mut storage = [0u8; 32];
+                storage.copy_from_slice(result);
+                Ok(storage)
+            } else {
+                Err(xous::Error::AccessDenied)
+            }
+        }
+    }
+
+    #[cfg(feature = "app-keys")]
+    // indices are absolute offsets
+    pub fn write_app_key(&self, rram: &mut Reram, index: usize, data: [u8; 32]) -> Result<(), xous::Error> {
+        use bao1x_api::common::APPLICATION;
+        let real_index = index + bao1x_api::common::APPLICATION.get_base();
+        if real_index < APPLICATION.get_base() || real_index >= APPLICATION.get_base() + APPLICATION.len() {
+            return Err(xous::Error::AccessDenied);
+        } else {
+            use bao1x_api::SlotIndex;
+
+            let slot =
+                SlotIndex::Data(real_index, bao1x_api::PartitionAccess::Open, bao1x_api::RwPerms::ReadWrite);
+            match self.slot_mgr.write(rram, &slot, &data) {
+                Ok(_) => {
+                    // log::info!("write success: {:?} {:x?}", slot, data);
+                    Ok(())
+                }
+                Err(e) => {
+                    log::warn!("Write app key error: {:?}", e);
+                    match e {
+                        bao1x_api::AccessError::WriteError => Err(xous::Error::HardwareError),
+                        _ => Err(xous::Error::AccessDenied),
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR adds to the dabao-console a command that facilitates dynamic loading of BIO programs.

This is particularly useful during BIO program development because one can hot-load and reconfigure BIO programs without having to rebuild the OS & reboot the system to capture the new program.

Requires the use of a helper script, `bio-loader`, which can be found in the eponymous repo in the baochip repository:

https://github.com/baochip/bio-loader