### PR TITLE
pddb: fix negative seek offsets in seek_from_point

### DIFF
--- a/.github/workflows/pddb-renode-ci.yml
+++ b/.github/workflows/pddb-renode-ci.yml
@@ -12,7 +12,7 @@
 # fail=.. xfail=.. xpass=.. total=..`, `CI done`). Known product bugs are
 # pinned as XFAIL so the suite is green while still detecting regressions AND
 # accidental fixes (XPASS fails the run: update the registry).
-# Expected steady-state totals: pass=98 fail=0 xfail=14 xpass=0 total=112.
+# Expected steady-state totals: pass=101 fail=0 xfail=11 xpass=0 total=112.
 #
 # The robot suite (emulation/tests/pddb-fs.robot) drives the first-boot UX
 # (format prompt, boot PIN x2, unattended 4 MiB smalldb format) through

--- a/services/pddb-fs-tests/src/tests/rw.rs
+++ b/services/pddb-fs-tests/src/tests/rw.rs
@@ -129,9 +129,10 @@ pub fn io_seek_and_write() {
 
 /// Ported from upstream `file_test_io_seek_shakedown`. Exercises negative
 /// `SeekFrom::End`/`SeekFrom::Current` offsets, which is exactly PFC-3
-/// territory: the server casts the offset with `as u64` before
-/// `checked_sub`, so any negative seek errors out (services/pddb/src/
-/// libstd/mod.rs seek_key/seek_from_point). XFAIL PFC-3.
+/// territory: the server used to cast the offset with `as u64` before
+/// `checked_sub`, so any negative seek errored out (services/pddb/src/
+/// libstd/mod.rs seek_key/seek_from_point). Was XFAIL PFC-3; now pins the
+/// fix.
 pub fn io_seek_shakedown() {
     let tmp = TmpDict::new("io_seek_shakedown");
     let path = tmp.path("file");
@@ -184,8 +185,8 @@ pub fn io_eof() {
 }
 
 /// Xous-specific: a matrix of `SeekFrom::Start`-only seeks (0, mid, last
-/// byte, exactly at EOF). Never goes through the `by < 0` branch of
-/// seek_from_point, so this must pass regardless of PFC-3.
+/// byte, exactly at EOF). Never passes a negative offset to seek_from_point,
+/// so this must pass regardless of PFC-3.
 pub fn seek_start_matrix() {
     let tmp = TmpDict::new("seek_start_matrix");
     let path = tmp.path("file");
@@ -211,8 +212,9 @@ pub fn seek_start_matrix() {
 /// Xous-specific: negative `SeekFrom::End`/`SeekFrom::Current` offsets in
 /// isolation (End coverage that smoke::seek_negative_current doesn't
 /// exercise). Correct POSIX behavior: `End(-3)` on a 10-byte file lands at 7;
-/// a subsequent `Current(-5)` from 10 lands at 5. XFAIL PFC-3: the server's
-/// `by as u64` cast before `checked_sub` makes every negative offset error.
+/// a subsequent `Current(-5)` from 10 lands at 5. Was XFAIL PFC-3 (the
+/// server's `by as u64` cast before `checked_sub` made every negative offset
+/// error); now pins the fix.
 pub fn seek_negative_offsets() {
     let tmp = TmpDict::new("seek_negative_offsets");
     let path = tmp.path("file");
@@ -354,8 +356,4 @@ pub const TESTS: &[(&str, fn())] = &[
     ("rw::read_zero_length_buffer_and_empty_file", read_zero_length_buffer_and_empty_file as fn()),
 ];
 
-pub const XFAILS: &[(&str, &str)] = &[
-    ("rw::io_seek_shakedown", "PFC-3"),
-    ("rw::seek_negative_offsets", "PFC-3"),
-    ("rw::seek_end_after_write_staleness", "PFC-5"),
-];
+pub const XFAILS: &[(&str, &str)] = &[("rw::seek_end_after_write_staleness", "PFC-5")];

--- a/services/pddb-fs-tests/src/tests/smoke.rs
+++ b/services/pddb-fs-tests/src/tests/smoke.rs
@@ -87,8 +87,9 @@ fn overwrite_shorter_inner(path: &str, first_len: usize) {
     assert_eq!(readback, second, "truncating overwrite did not read back intact");
 }
 
-/// SeekFrom::Current with a negative offset must rewind. XFAIL PFC-3: the
-/// server casts the offset with `as u64`, so any negative seek errors out.
+/// SeekFrom::Current with a negative offset must rewind. Was XFAIL PFC-3
+/// (the server cast the offset with `as u64`, so any negative seek errored
+/// out); now pins the fix.
 pub fn seek_negative_current() {
     let tmp = TmpDict::new("seek_negative_current");
     let path = tmp.path("seek");
@@ -154,7 +155,6 @@ pub const TESTS: &[(&str, fn())] = &[
 pub const XFAILS: &[(&str, &str)] = &[
     // smoke::overwrite_shorter_large (PFC-1) is not here: it crashes the pddb
     // server outright and is disabled above.
-    ("smoke::seek_negative_current", "PFC-3"),
     ("smoke::two_files_close_one", "PFC-4"),
 ];
 

--- a/services/pddb/src/libstd/mod.rs
+++ b/services/pddb/src/libstd/mod.rs
@@ -581,23 +581,14 @@ pub(crate) fn seek_key(
     let file = get_fd(fds, fd)?;
 
     fn seek_from_point(this: &mut FileHandle, point: u64, by: i64) -> Result<u64, crate::PddbRetcode> {
-        let by64 = by as u64;
         // Note that it's possible to seek past the end of a key, and in this case
         // the `offset` will be greater than the `len`. This is fine, and `len` will
-        // be updated as soon as `write()` is called.
-        if by < 0 {
-            this.offset = point.checked_sub(by64).ok_or_else(|| {
-                // std::io::Error::new(std::io::ErrorKind::InvalidInput, "cannot seek before 0")
-                log::error!("cannot seek before 0");
-                crate::PddbRetcode::UnexpectedEof
-            })?;
-        } else {
-            this.offset = point.checked_add(by64).ok_or_else(|| {
-                // std::io::Error::new(std::io::ErrorKind::InvalidInput, "seek overflowed")
-                log::error!("seek overflowed");
-                crate::PddbRetcode::UnexpectedEof
-            })?;
-        }
+        // be updated as soon as `write()` is called. `None` covers both
+        // seek-before-0 and u64 overflow.
+        this.offset = point.checked_add_signed(by).ok_or_else(|| {
+            log::error!("seek out of range");
+            crate::PddbRetcode::UnexpectedEof
+        })?;
         Ok(this.offset)
     }
 


### PR DESCRIPTION
Negative `SeekFrom::Current`/`SeekFrom::End` offsets never worked: the seek
arm cast the signed offset to u64 and checked-subtracted it, which fails for
every negative value. Replaced with `checked_add_signed`, which keeps the
seek-before-zero and overflow errors. Details in the commit message.

Renode fs suite (#909): the three pinned seek tests flip to pass; the whole
series plus the fixed client runs 113/0, cold and warm boots.

Developed with AI assistance, see commit trailers.