### PR TITLE
Renode CI (std::net, loopback + cross-host suites)

### DIFF
--- a/.github/workflows/pddb-renode-ci.yml
+++ b/.github/workflows/pddb-renode-ci.yml
@@ -1,4 +1,6 @@
-# PDDB std::fs regression suite under Renode emulation.
+# PDDB std::fs and std::net regression suites under Renode emulation.
+#
+# std::fs (build + renode-test jobs below):
 #
 # What this exercises: the REAL xous std::fs path (riscv32 xous std -> senres
 # IPC -> services/pddb/src/libstd/ -> PDDB engine -> emulated SPI NOR) on a
@@ -23,6 +25,31 @@
 #
 # Local fast loop (same image, same choreography, plus a warm-boot leg and an
 # offline flash audit): tools/pddb-fs-ci.py.
+#
+# std::net (build-net + renode-test-net jobs below):
+#
+# Sibling suite exercising the REAL xous std::net path (riscv32 xous std ->
+# net service -> smoltcp -> emulated WF200 wifi + COM link to the
+# betrusted-ec), for the same reason hosted-mode CI can't cover it. The image
+# has no PDDB and no first-boot UX -- boot is fully unattended. The on-target
+# runner `services/net-tests` waits for the net service to report an
+# interface address (`_|TT|_NET.OK,<ip>,_|TE|_`) and emits the same sentinel
+# shape as fs with its own totals line (`NET-TESTS DONE: pass=.. fail=..
+# xfail=.. xpass=.. total=..`, then `CI done`). The suite is 99 tests (smoke
+# 12, tcp 25, udp 14, errors 9, sockopts 8, dns 10, concur 10, timeouts 11).
+# Expected steady-state totals: pass=71 fail=0 xfail=28 xpass=0 total=99.
+# See emulation/tests/net-ci.resc, emulation/tests/std-net.robot, and
+# tools/std-net-ci.py.
+#
+# std::net Cross-host / cross-host (build-net-cross-host + run-net-cross-host jobs below):
+#
+# The same std::net path, but against a REAL Linux peer
+# (emulation/linux-server.resc) on the switch instead of loopback: real DHCP,
+# cross-host TCP/UDP, a real connect-refused RST, and DNS resolved by the
+# peer's dnsd (7 tests). Its driver (tools/std-net-cross-host-ci.py) drives the
+# peer's serial console over a pty to provision services, which renode-test's
+# linear robot form cannot express -- so this suite runs the Python driver
+# directly rather than via a .robot file. Expected: pass=7 fail=0 total=7.
 
 name: PDDB Renode CI
 
@@ -226,3 +253,197 @@ jobs:
             renode-results/logs/
             target/pddb-fs-ci/console-robot.log
             target/pddb-fs-ci/kernel-robot.log
+
+  build-net:
+    name: Build std-net-ci image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Install Ubuntu dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libxkbcommon-dev
+
+      # TOOLCHAIN LOCKSTEP (do NOT replace with `rustup update`): `cargo xtask
+      # install-toolkit` requires the host rustc version to exactly match a
+      # betrusted-io/rust release tag (xtask/src/utils.rs). The renode image
+      # links the xous libstd from that toolkit, and any XFAIL the net-tests
+      # registry grows for CLIENT-side std::net bugs is pinned at this exact
+      # toolkit version. Bump this pin together with a toolkit release, then
+      # re-run the suite: client-side fixes will surface as XPASS and the
+      # registry must be updated in the same PR.
+      - name: Pin Rust toolchain
+        run: |
+          rustup toolchain install 1.96.1 --profile minimal
+          rustup default 1.96.1
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Fetch tags
+        run: git fetch --prune --unshallow --tags
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install RISC-V toolkit
+        run: cargo xtask install-toolkit --force --no-verify
+
+      - name: Clean out old target directory (in case of libstd change)
+        run: rm -rf target/*
+
+      - name: Build the std-net-ci renode image
+        run: cargo xtask std-net-ci --no-verify
+
+      - name: Upload image artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: std-net-ci-image
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            target/riscv32imac-unknown-xous-elf/release/loader.bin
+            target/riscv32imac-unknown-xous-elf/release/xous.img
+
+  renode-test-net:
+    name: Run std-net.robot under renode-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    needs: build-net
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      # Both files land exactly where emulation/tests/std-net.robot expects
+      # them (${IMAGE_DIR} = target/riscv32imac-unknown-xous-elf/release).
+      - name: Download image artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: std-net-ci-image
+          path: target/riscv32imac-unknown-xous-elf/release
+
+      # Same pinned dated Renode portable build as the fs job above -- keep
+      # both in lockstep; see that job's comment for the pin rationale.
+      - name: Download and extract Renode portable
+        run: |
+          RENODE_TARBALL="renode-1.16.1+20260417git9d55b4e69.linux-portable-dotnet.tar.gz"
+          curl --fail --location --retry 5 -o /tmp/renode.tar.gz \
+            "https://dl.antmicro.com/projects/renode/builds/${RENODE_TARBALL}"
+          mkdir -p "$HOME/renode_portable"
+          tar -xzf /tmp/renode.tar.gz --strip-components=1 -C "$HOME/renode_portable"
+          echo "$HOME/renode_portable" >> "$GITHUB_PATH"
+          "$HOME/renode_portable/renode" --version
+
+      - name: Install renode-test python requirements
+        run: python3 -m pip install -r "$HOME/renode_portable/tests/requirements.txt"
+
+      # Per-run blank NOR: the flash model writes THROUGH into its backing
+      # file, so it must be a fresh scratch file, 0xFF-filled like blank NOR
+      # (128 MiB MX66UM1G45G), even though the net image never persists
+      # state. The robot suite's `Prepare Fresh Flash` also re-provisions
+      # this itself; this step just guarantees the directory exists and
+      # documents the contract.
+      - name: Provision fresh 0xFF flash backing file
+        run: |
+          mkdir -p target/std-net-ci
+          python3 -c "open('target/std-net-ci/flash-robot.bin','wb').write(b'\xff'*134217728)"
+
+      - name: Run the std::net robot suite
+        timeout-minutes: 75
+        env:
+          # Quoted: bare YES is YAML-1.1 boolean true, which would export
+          # "true" instead of the literal string Renode's scripts look for.
+          RENODE_CI_MODE: "YES"
+        run: |
+          renode-test -r "$GITHUB_WORKSPACE/renode-results" \
+            emulation/tests/std-net.robot
+
+      - name: Upload robot results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: std-net-renode-ci-results
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            renode-results/robot_output.xml
+            renode-results/log.html
+            renode-results/report.html
+            renode-results/logs/
+            target/std-net-ci/console-robot.log
+            target/std-net-ci/kernel-robot.log
+
+  build-net-cross-host:
+    name: Build std-net-cross-host-ci image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Install Ubuntu dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libxkbcommon-dev
+      # Same toolchain-lockstep pin as build-net; see that job's comment.
+      - name: Pin Rust toolchain
+        run: |
+          rustup toolchain install 1.96.1 --profile minimal
+          rustup default 1.96.1
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Fetch tags
+        run: git fetch --prune --unshallow --tags
+      - uses: Swatinem/rust-cache@v2
+      - name: Install RISC-V toolkit
+        run: cargo xtask install-toolkit --force --no-verify
+      - name: Clean out old target directory (in case of libstd change)
+        run: rm -rf target/*
+      - name: Build the std-net-cross-host-ci renode image
+        run: cargo xtask std-net-cross-host-ci --no-verify
+      - name: Upload image artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: std-net-cross-host-ci-image
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            target/riscv32imac-unknown-xous-elf/release/loader.bin
+            target/riscv32imac-unknown-xous-elf/release/xous.img
+
+  run-net-cross-host:
+    name: Run the cross-host suite (std-net-cross-host-ci.py)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: build-net-cross-host
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Download image artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: std-net-cross-host-ci-image
+          path: target/riscv32imac-unknown-xous-elf/release
+      # Same pinned dated Renode portable build as the fs/net jobs above.
+      - name: Download and extract Renode portable
+        run: |
+          RENODE_TARBALL="renode-1.16.1+20260417git9d55b4e69.linux-portable-dotnet.tar.gz"
+          curl --fail --location --retry 5 -o /tmp/renode.tar.gz \
+            "https://dl.antmicro.com/projects/renode/builds/${RENODE_TARBALL}"
+          mkdir -p "$HOME/renode_portable"
+          tar -xzf /tmp/renode.tar.gz --strip-components=1 -C "$HOME/renode_portable"
+          "$HOME/renode_portable/renode" --version
+      # The cross-host driver boots a Linux peer alongside the DUT and drives the
+      # peer's serial console over a pty, which renode-test's linear robot form
+      # cannot express -- so this suite runs the Python driver directly.
+      - name: Run the cross-host suite
+        timeout-minutes: 45
+        run: |
+          python3 tools/std-net-cross-host-ci.py --renode "$HOME/renode_portable/renode"
+      - name: Upload cross-host logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: std-net-cross-host-ci-results
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            target/std-net-cross-host-ci/console.log
+            target/std-net-cross-host-ci/kernel.log
+            target/std-net-cross-host-ci/run.log
+            target/std-net-cross-host-ci/peer-console.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3966,6 +3966,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "net-tests"
+version = "0.1.0"
+dependencies = [
+ "com",
+ "dns",
+ "gam",
+ "log",
+ "modals",
+ "net",
+ "pddb",
+ "xous 0.9.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-api-log",
+ "xous-api-names",
+ "xous-api-susres 0.9.68",
+ "xous-api-ticktimer",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ members = [
   "apps/hidv2",
   "services/libstd-test",
   "services/pddb-fs-tests",
+  "services/net-tests",
   "services/ffi-test",
   "services/tts",
   "services/cram-console",

--- a/emulation/tests/net-ci.resc
+++ b/emulation/tests/net-ci.resc
@@ -1,0 +1,154 @@
+# std::net CI machine definition (headless SoC + EC pair + wifi switch).
+#
+# Derived from emulation/tests/pddb-ci.resc (see its header for the rationale
+# behind the headless choices); differences for the net suite:
+# - an Ethernet `Switch` is created and the EC's WF200 wifi model attaches to
+#   it (the same wiring as emulation/xous-release-tap.resc, minus the host TAP:
+#   CI must never touch host networking). Additional in-emulation peers (e.g.
+#   emulation/linux-server.resc) can attach to the same switch.
+# - the flash backing file is still per-run scratch, but the net image carries
+#   no PDDB, so nothing in it persists run state; a blank file is fine.
+#
+# The EC machine is MANDATORY here twice over: the SoC's first COM transaction
+# null-derefs in ComConnector without a peer, and the whole point of the net
+# suite is the COM -> EC -> WF200 path.
+#
+# Driven by tools/std-net-ci.py (local loop) or emulation/tests/std-net.robot
+# (renode-test).
+
+# Overridable parameters; defaults resolve relative to this script. Callers
+# (driver/robot) set these before including this file.
+$image_dir?=$ORIGIN/../../target/riscv32imac-unknown-xous-elf/release
+$flash_file?=$ORIGIN/../../target/std-net-ci/flash.bin
+$console_log?=$ORIGIN/../../target/std-net-ci/console.log
+$kernel_log?=$ORIGIN/../../target/std-net-ci/kernel.log
+
+# Add emulation/ to the global path, so @peripherals/..., @soc/... and
+# @ec/... resolve exactly as they do for emulation/betrusted.resc.
+path add $ORIGIN/..
+
+using sysbus
+
+# Deterministic runs: fixed emulation seed (feeds the TRNG models).
+emulation SetSeed 0x0
+
+# Add peripherals that are defined in C#.  You must restart Renode
+# if you modify these files.
+i @peripherals/ABRTCMC.cs
+i @peripherals/BetrustedEcI2C.cs
+i @peripherals/BetrustedSocI2C.cs
+i @peripherals/BetrustedSpinor.cs
+i @peripherals/BetrustedWatchdog.cs
+i @peripherals/BQ24157.cs
+i @peripherals/BQ27421.cs
+i @peripherals/BtEvents.cs
+i @peripherals/ComConnector.cs
+EnsureTypeIsLoaded "Antmicro.Renode.Peripherals.SPI.Betrusted.IComPeripheral"
+EnsureTypeIsLoaded "Antmicro.Renode.Peripherals.SPI.Betrusted.IComController"
+i @peripherals/ComEc.cs
+i @peripherals/ComSoC.cs
+i @peripherals/EcPower.cs
+i @peripherals/EcWifi.cs
+i @peripherals/engine.cs
+i @peripherals/Jtag.cs
+i @peripherals/keyboard.cs
+i @peripherals/keyrom.cs
+i @peripherals/LiteX_Timer_32.cs
+i @peripherals/LM3509.cs
+i @peripherals/LSM6DS3.cs
+i @peripherals/memlcd.cs
+i @peripherals/MXIC_MX66UM1G45G.cs
+i @peripherals/sha512.cs
+i @peripherals/spinor_soft_int.cs
+i @peripherals/ticktimer.cs
+i @peripherals/trng_kernel.cs
+i @peripherals/trng_server.cs
+i @peripherals/TLV320AIC3100.cs
+i @peripherals/TUSB320LAI.cs
+i @peripherals/WF200.cs
+i @peripherals/wfi.cs
+
+EnsureTypeIsLoaded "Antmicro.Renode.Peripherals.CPU.VexRiscv"
+i @peripherals/vexriscv-aes.cs
+
+EnsureTypeIsLoaded "Antmicro.Renode.Peripherals.Timers.Betrusted.TickTimer"
+i @peripherals/susres.cs
+
+# Create the COM SPI bus and the wifi switch
+emulation CreateComConnector "com"
+emulation CreateSwitch "switch"
+
+############### Define the Betrusted SoC ###############
+mach create "SoC"
+machine LoadPlatformDescription @soc/betrusted-soc.repl
+
+sysbus Tag <0xB0000000, 0xB0006000> "Framebuffer"
+
+# Silence GPIO
+sysbus SilenceRange <0xf0003000, 0xF0003FFF>
+# Silence POWER
+sysbus SilenceRange <0xF0014000 100>
+
+# Attach the flash backing to the per-run scratch file (writes persist!)
+sysbus.spinor.flash BackingFile $flash_file
+
+# Load the SPI flash into RAM
+sysbus LoadBinary $ORIGIN/../../utralib/renode/soc_csr.bin 0x20000000
+
+# Connect the SoC to the SPI bus
+connector Connect sysbus.com com
+
+# The macro `reset` gets called implicitly when running `machine Reset`
+macro reset
+"""
+    sysbus LoadBinary $image_dir/loader.bin 0x20500000
+    sysbus LoadBinary $image_dir/xous.img 0x20980000
+    # Set $a0 to point at the args binary
+    cpu SetRegisterUnsafe 10 0x20980000
+    cpu PC 0x20501000
+"""
+
+# File-backed UART capture with immediate flush (xous-swap.resc idiom).
+# All CI markers/sentinels appear on `console` (the log-server UART);
+# `uart` carries kernel debug only.
+uart CreateFileBackend $kernel_log true
+console CreateFileBackend $console_log true
+
+runMacro $reset
+
+mach clear
+
+############### Define the Betrusted EC ###############
+mach create "EC"
+machine LoadPlatformDescription @ec/betrusted-ec.repl
+
+# Connect the EC to the SPI bus
+connector Connect sysbus.com com
+
+# Connect the WF200 to the wifi switch (cf. emulation/xous-release-tap.resc,
+# minus the TAP: no host networking in CI)
+connector Connect sysbus.wifi.wf200 switch
+
+macro reset
+"""
+    sysbus LoadBinary @ec/bt-ec.bin 0x20000000
+    sysbus LoadBinary @ec/wf200_fw.bin 0x2009C000
+    sysbus LoadBinary @ec/loader.bin 0x00000000
+    cpu PC 0
+    cpu SP 0x1001FFFC
+"""
+runMacro $reset
+
+mach clear
+
+# Renode 1.16.1 logs a per-access "Using `GetRegisterUnsafe` API is obsolete"
+# WARNING from each cpu (the wfi/idle path hits it continuously), which can
+# balloon the run log to tens of GB. Suppress cpu messages below Error on both
+# machines; everything else keeps its level.
+mach set "SoC"
+logLevel 3 sysbus.cpu
+mach set "EC"
+logLevel 3 sysbus.cpu
+mach clear
+
+start

--- a/emulation/tests/net-cross-host-ci.resc
+++ b/emulation/tests/net-cross-host-ci.resc
@@ -1,0 +1,164 @@
+# std::net Cross-host CI machine definition: the headless SoC + EC pair plus a real
+# Linux peer (emulation/linux-server.resc) on one Ethernet switch, so the DUT
+# exchanges genuine packets with an independent stack instead of looping back
+# inside itself.
+#
+# Derived from emulation/tests/net-ci.resc (SoC + EC + WF200) with the peer
+# added. Key differences from loopback:
+# - the peer's smc91x NIC and the EC's WF200 attach to the same Renode switch;
+#   the peer's rcS brings up eth0 (192.168.0.1) and starts udhcpd, so the DUT
+#   gets a REAL DHCP lease (the image is built with net/renode-peer, no static
+#   seed). No host TAP -- still no host networking.
+# - the peer's serial console is exposed on a pty so the driver
+#   (tools/std-net-cross-host-ci.py) can bring up its test services (nc echo, dnsd);
+#   the SoC console/kernel UARTs stay file-backed for sentinel parsing.
+# - the peer's rootfs must be a per-run scratch copy: its CFI flash writes back
+#   into the backing file, so $peer_rootfs points at a throwaway.
+#
+# All three machines start together; the driver (tools/std-net-cross-host-ci.py)
+# drives the peer console to provision its services (nc echo, dnsd) and rewrite
+# its udhcpd DNS option before the DUT boots far enough to take a lease.
+
+# Overridable parameters; the driver sets these before including this file.
+$image_dir?=$ORIGIN/../../target/riscv32imac-unknown-xous-elf/release
+$flash_file?=$ORIGIN/../../target/std-net-cross-host-ci/flash.bin
+$console_log?=$ORIGIN/../../target/std-net-cross-host-ci/console.log
+$kernel_log?=$ORIGIN/../../target/std-net-cross-host-ci/kernel.log
+$peer_bin?=$ORIGIN/../versatile-vmlinux
+$peer_rootfs?=$ORIGIN/../../target/std-net-cross-host-ci/peer-rootfs.jffs2
+$peer_pty?=$ORIGIN/../../target/std-net-cross-host-ci/peer.pty
+
+path add $ORIGIN/..
+
+using sysbus
+
+# Deterministic runs: fixed emulation seed (feeds the TRNG models).
+emulation SetSeed 0x0
+
+# Betrusted peripherals defined in C# (identical set to net-ci.resc).
+i @peripherals/ABRTCMC.cs
+i @peripherals/BetrustedEcI2C.cs
+i @peripherals/BetrustedSocI2C.cs
+i @peripherals/BetrustedSpinor.cs
+i @peripherals/BetrustedWatchdog.cs
+i @peripherals/BQ24157.cs
+i @peripherals/BQ27421.cs
+i @peripherals/BtEvents.cs
+i @peripherals/ComConnector.cs
+EnsureTypeIsLoaded "Antmicro.Renode.Peripherals.SPI.Betrusted.IComPeripheral"
+EnsureTypeIsLoaded "Antmicro.Renode.Peripherals.SPI.Betrusted.IComController"
+i @peripherals/ComEc.cs
+i @peripherals/ComSoC.cs
+i @peripherals/EcPower.cs
+i @peripherals/EcWifi.cs
+i @peripherals/engine.cs
+i @peripherals/Jtag.cs
+i @peripherals/keyboard.cs
+i @peripherals/keyrom.cs
+i @peripherals/LiteX_Timer_32.cs
+i @peripherals/LM3509.cs
+i @peripherals/LSM6DS3.cs
+i @peripherals/memlcd.cs
+i @peripherals/MXIC_MX66UM1G45G.cs
+i @peripherals/sha512.cs
+i @peripherals/spinor_soft_int.cs
+i @peripherals/ticktimer.cs
+i @peripherals/trng_kernel.cs
+i @peripherals/trng_server.cs
+i @peripherals/TLV320AIC3100.cs
+i @peripherals/TUSB320LAI.cs
+i @peripherals/WF200.cs
+i @peripherals/wfi.cs
+
+EnsureTypeIsLoaded "Antmicro.Renode.Peripherals.CPU.VexRiscv"
+i @peripherals/vexriscv-aes.cs
+
+EnsureTypeIsLoaded "Antmicro.Renode.Peripherals.Timers.Betrusted.TickTimer"
+i @peripherals/susres.cs
+
+# Shared COM SPI bus and the Ethernet switch that carries the wifi <-> peer link
+emulation CreateComConnector "com"
+emulation CreateSwitch "switch"
+
+############### The Linux peer (ARM Versatile) ###############
+mach create "peer"
+machine LoadPlatformDescription @platforms/boards/versatile.repl
+sysbus Redirect 0xC0000000 0x0 0x10000000
+machine CFIFlashFromFile $peer_rootfs 0x34000000 "flash"
+# Silence the PS2 mouse
+logLevel 3 kmi1.mouse
+# The peer NIC joins the switch
+connector Connect smc91x switch
+# Expose the peer's serial console on a pty for the driver (the trailing `true`
+# creates the pty symlink at $peer_pty).
+emulation CreateUartPtyTerminal "peerterm" $peer_pty true
+connector Connect sysbus.uart0 peerterm
+
+macro reset
+"""
+    sysbus.cpu SetRegisterUnsafe 0 0x0
+    sysbus.cpu SetRegisterUnsafe 1 0x183     # board id
+    sysbus.cpu SetRegisterUnsafe 2 0x100     # atags
+    sysbus LoadELF $peer_bin false
+    sysbus LoadAtags "console=ttyAMA0,115200 root=/dev/mtdblock0 ro rootfstype=jffs2 mtdparts=armflash.0:64m@0x0 earlyprintk mem=256M" 0x10000000 0x100
+    cpu PC 0x8000
+"""
+logLevel 3
+runMacro $reset
+mach clear
+
+############### The Betrusted SoC ###############
+mach create "SoC"
+machine LoadPlatformDescription @soc/betrusted-soc.repl
+
+sysbus Tag <0xB0000000, 0xB0006000> "Framebuffer"
+sysbus SilenceRange <0xf0003000, 0xF0003FFF>
+sysbus SilenceRange <0xF0014000 100>
+sysbus.spinor.flash BackingFile $flash_file
+sysbus LoadBinary $ORIGIN/../../utralib/renode/soc_csr.bin 0x20000000
+connector Connect sysbus.com com
+
+macro reset
+"""
+    sysbus LoadBinary $image_dir/loader.bin 0x20500000
+    sysbus LoadBinary $image_dir/xous.img 0x20980000
+    cpu SetRegisterUnsafe 10 0x20980000
+    cpu PC 0x20501000
+"""
+
+uart CreateFileBackend $kernel_log true
+console CreateFileBackend $console_log true
+
+runMacro $reset
+mach clear
+
+############### The Betrusted EC ###############
+mach create "EC"
+machine LoadPlatformDescription @ec/betrusted-ec.repl
+connector Connect sysbus.com com
+connector Connect sysbus.wifi.wf200 switch
+
+macro reset
+"""
+    sysbus LoadBinary @ec/bt-ec.bin 0x20000000
+    sysbus LoadBinary @ec/wf200_fw.bin 0x2009C000
+    sysbus LoadBinary @ec/loader.bin 0x00000000
+    cpu PC 0
+    cpu SP 0x1001FFFC
+"""
+runMacro $reset
+mach clear
+
+# Suppress the per-access GetRegisterUnsafe obsolete-API warning on both xous
+# CPUs (net-ci.resc rationale: it grows the run log to tens of GB).
+mach set "SoC"
+logLevel 3 sysbus.cpu
+mach set "EC"
+logLevel 3 sysbus.cpu
+mach clear
+
+# Start all machines. The peer boots and is provisioned by the driver before
+# the DUT's slower boot reaches wlan join + DHCP, so the DUT's lease sees the
+# finished peer config; the driver provisions the udhcpd/DNS options first to
+# widen that margin.
+start

--- a/emulation/tests/std-net.robot
+++ b/emulation/tests/std-net.robot
@@ -1,0 +1,94 @@
+*** Comments ***
+std::net suite for `renode-test` (the CI path).
+
+STATUS: adapted from emulation/tests/pddb-fs.robot alongside the fs suite's
+harness; not yet exercised end to end under renode-test. Timeouts below are
+PRE-CALIBRATION PLACEHOLDERS (see *** Variables ***) -- tighten once green-run
+timings exist. tools/std-net-ci.py is the reference driver; this suite mirrors
+its milestone sequence and the two must be kept in lockstep.
+
+Unlike the fs suite there is no first-boot UX to drive: the net image has no
+PDDB, no keyboard, no graphics service, so boot is fully unattended from the
+loader through 'CI done'. Nothing here corresponds to the fs suite's
+REQFMT/PIN/EC-abort choreography or its Inject Keys keywords.
+
+Known delta vs. the python driver (accepted for the linear robot form):
+- the python driver's 180 s host INACTIVITY reaper cannot be expressed in
+  robot's linear form; instead 'PANIC in PID' is a registered failing UART
+  string (fails the pending wait immediately -- a dead net service prints
+  exactly that banner before going silent), and the overall wait is
+  virtual-time bounded.
+- robot timeouts are VIRTUAL-time seconds (decoupled from host speed).
+
+
+*** Settings ***
+Documentation                 Boot betrusted-soc+ec under Renode, wait for the
+...                           net service to report an interface address,
+...                           then assert on the net-tests sentinel stream.
+Suite Setup                   Setup
+Suite Teardown                Teardown
+Test Teardown                 Test Teardown
+Resource                      ${RENODEKEYWORDS}
+Library                       OperatingSystem
+
+*** Variables ***
+${IMAGE_DIR}                  ${CURDIR}/../../target/riscv32imac-unknown-xous-elf/release
+${WORKDIR}                    ${CURDIR}/../../target/std-net-ci
+${FLASH_FILE}                 ${WORKDIR}/flash-robot.bin
+${CONSOLE_LOG}                ${WORKDIR}/console-robot.log
+${KERNEL_LOG}                 ${WORKDIR}/kernel-robot.log
+# Virtual-time seconds (host-speed independent). PRE-CALIBRATION PLACEHOLDERS:
+# no green run has produced real timings yet (see *** Comments ***).
+${BOOT_TIMEOUT}               120
+${NET_READY_TIMEOUT}          300
+${TESTS_TIMEOUT}              1800
+# A failed run's emulation snapshot (2 machines + 128 MiB file-backed flash)
+# is huge and useless for triage; the console/kernel/renode logs suffice.
+# Overrides the renode-keywords.robot default (suite variables win).
+${CREATE_SNAPSHOT_ON_FAIL}    False
+
+*** Keywords ***
+Prepare Fresh Flash
+    [Documentation]           Blank 0xFF NOR image; the flash model writes
+    ...                       through into this file, so it is per-run. The
+    ...                       net image has no persistent state, but the
+    ...                       flash model still requires a backing file.
+    Create Directory          ${WORKDIR}
+    Remove File               ${FLASH_FILE}
+    Remove File               ${CONSOLE_LOG}
+    Remove File               ${KERNEL_LOG}
+    Evaluate                  open(r'${FLASH_FILE}', 'wb').write(b'\\xff' * 134217728)
+
+*** Test Cases ***
+Boot And Run Net Tests
+    Prepare Fresh Flash
+    Execute Command           $image_dir=@${IMAGE_DIR}
+    Execute Command           $flash_file=@${FLASH_FILE}
+    Execute Command           $console_log=@${CONSOLE_LOG}
+    Execute Command           $kernel_log=@${KERNEL_LOG}
+    Execute Command           include @${CURDIR}/net-ci.resc
+    # net-ci.resc ends with 'start'; the first marker is well after reset, so
+    # creating the tester right after the include is safe.
+    Create Terminal Tester    sysbus.console    machine=SoC    timeout=${BOOT_TIMEOUT}
+    # Fail-fast on any panic banner: the net-tests runner installs a panic
+    # hook so CAUGHT test panics never print this -- any occurrence is a real
+    # service death, after which the console goes silent and every later
+    # wait would time out.
+    Register Failing Uart String    PANIC in PID
+
+    Wait For Line On Uart     Welcome to Xous    timeout=${BOOT_TIMEOUT}
+    Wait For Line On Uart     _|TT|_NET.OK,    timeout=${NET_READY_TIMEOUT}
+
+    # Sentinel stream (grammar: services/net-tests/src/main.rs). Pass
+    # criteria: DONE present with fail=0 and xpass=0, final 'CI done', and no
+    # stray FAIL/panic lines in the console log. The DONE counters are
+    # asserted from the console log file rather than the tester result
+    # object (portable across robotframework/remote-protocol versions).
+    Wait For Line On Uart     NET-TESTS DONE:    timeout=${TESTS_TIMEOUT}
+    Wait For Line On Uart     CI done    timeout=60
+
+    # The console file backend flushes every write, so the log is current.
+    ${log}=                   Get File    ${CONSOLE_LOG}    encoding_errors=replace
+    Should Match Regexp       ${log}    NET-TESTS DONE: pass=\\d+ fail=0 xfail=\\d+ xpass=0 total=\\d+
+    Should Not Match Regexp   ${log}    TEST \\S+ FAIL
+    Should Not Contain        ${log}    PANIC in PID

--- a/services/dns/src/time.rs
+++ b/services/dns/src/time.rs
@@ -400,6 +400,7 @@ pub fn start_time_server() {
                             log::warn!(
                                 "Time was negative, recovering from time setting error by clearing utc offset to 0"
                             );
+                            #[cfg(not(feature = "minimal-testing"))]
                             prefs.set_utc_offset(0).ok();
                             utc_offset_ms = 0;
                         }
@@ -425,7 +426,9 @@ pub fn start_time_server() {
                             log::warn!(
                                 "Time was negative, recovering from time setting error by clearing utc and timezone offsets to 0."
                             );
+                            #[cfg(not(feature = "minimal-testing"))]
                             prefs.set_utc_offset(0).ok();
+                            #[cfg(not(feature = "minimal-testing"))]
                             prefs.set_timezone_offset(0).ok();
                             utc_offset_ms = 0;
                             tz_offset_ms = 0;

--- a/services/net-tests/Cargo.toml
+++ b/services/net-tests/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "net-tests"
+version = "0.1.0"
+authors = ["Xous contributors"]
+edition = "2018"
+description = "std::net test runner for Renode CI"
+
+# Dependency versions enforced by Cargo.lock.
+[dependencies]
+xous = "0.9.70"
+log-server = { package = "xous-api-log", version = "0.1.69" }
+ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.70" }
+xous-names = { package = "xous-api-names", version = "0.9.71" }
+log = "0.4.14"
+com = { path = "../com" }
+net = { path = "../net" }
+
+# Feature plumbing only (these already ride in net's and dns's dependency
+# trees): a standalone `cargo check -p net-tests` must enable the target
+# features that whole-image feature unification provides in `xtask` builds.
+dns = { path = "../dns" }
+pddb = { path = "../pddb" }
+gam = { path = "../gam" }
+modals = { path = "../modals" }
+susres = { path = "../../api/xous-api-susres", package = "xous-api-susres" }
+
+[features]
+renode = [
+    "net/renode",
+    "net/renode-minimal",
+    "com/renode",
+    "dns/renode",
+    "dns/minimal-testing",
+    "pddb/renode",
+    "gam/renode",
+    "modals/renode",
+    "susres/renode",
+]
+# Compile in the cross-host themes (peer at PEER_IP on the switch). The
+# cross-host image (xtask std-net-cross-host-ci) sets this; the the loopback suite image
+# does not, so loopback and cross-host share one crate but different registered sets.
+cross-host = []
+default = []

--- a/services/net-tests/README.md
+++ b/services/net-tests/README.md
@@ -1,0 +1,97 @@
+# net-tests
+
+An on-target test suite for the `std::net` implementation backed by the xous
+`net` service.
+
+Hosted-mode CI links the *host's* std, so it never touches our networking code.
+This service is baked into a Renode image and runs on the real riscv32 xous
+libstd, exercising the whole chain: the `std::net` client shim → the `net`
+server (`services/net/`) → smoltcp → the emulated WF200 / COM link. Everything
+runs against the device's own address and 127.0.0.1 (loopback through the real
+stack), so no external network is involved.
+
+`main()` joins the (emulated) wlan and waits for the `net` service to report an
+IPv4 config, then runs every registered test under `catch_unwind` and prints one
+machine-parsable line per test on the log console
+(`TEST <name> PASS|FAIL|XFAIL|XPASS`), ending with a `NET-TESTS DONE: ...`
+summary and `CI done`. A Renode-side driver watches those lines. The suite is 99
+tests across eight themes (`smoke` 12, `tcp` 25, `udp` 14, `errors` 9,
+`sockopts` 8, `dns` 10, `concur` 10, `timeouts` 11); many are ported/adapted
+from rust's own `library/std/src/net/{tcp,udp}/tests.rs`, the rest cover
+xous-specific ground: the small socket buffers and the 1530-byte MTU boundary,
+the loopback path, error-kind decoding, DNS response parsing (against an
+in-image fake resolver), timeout behavior under the emulator's virtual clock,
+and multi-socket concurrency.
+
+Because the image has no DHCP peer on the emulated switch, the `net` service —
+only under its `renode-minimal` feature — seeds a static IPv4 config through the
+same handler a real DHCP bind would use. That is the sole product-code change
+this suite requires, and it is confined to that feature gate.
+
+## Running
+
+```
+cargo xtask std-net-ci --no-verify     # build the Renode image
+python3 tools/std-net-ci.py            # boot, wait for net-up, run (see tools/README.md)
+```
+
+`tools/std-net-ci.py` drives the emulator end to end; `emulation/tests/std-net.robot`
+is the equivalent `renode-test` suite used by `.github/workflows/pddb-renode-ci.yml`.
+
+## Cross-host (cross-host)
+
+The suite above is hermetic: it loops back inside the DUT. A second suite,
+built with the `cross-host` feature, exercises what loopback cannot — the DUT
+exchanging real packets with a second Renode machine
+(`emulation/linux-server.resc`, a busybox Linux) on the same switch as the EC's
+WF200:
+
+```
+cargo xtask std-net-cross-host-ci --no-verify   # build the cross-host image
+python3 tools/std-net-cross-host-ci.py          # start peer + DUT, provision peer, run
+```
+
+The two suites are mutually exclusive — the cross-host image registers only the
+`cross-host` theme (`src/tests/cross-host.rs`), because its real resolver is incompatible
+with loopback's self-hosted fake DNS. Cross-host covers: a **real DHCP** lease from the
+peer's `udhcpd` (the image is built with `net/renode-peer`, which skips the
+loopback static seed); **cross-host TCP/UDP** echo against the peer's `nc` servers,
+including an 8 KiB transfer that exercises real over-the-wire segmentation; a
+**real RST** on connect-to-a-dead-port; and **real DNS** resolved by the peer's
+`dnsd`. `tools/std-net-cross-host-ci.py` drives the peer's serial console (on a pty)
+to a passwordless root shell and brings its services up before the DUT takes its
+lease; the peer contract (IP, ports, DNS records) is duplicated in the driver
+and `src/tests/cross-host.rs` and must stay in lockstep. Scope limits follow the
+peer: IPv4 only, `dnsd` static A records only (no CNAME chains — loopback pins
+those), clock at 1970 (no TLS).
+
+## Known-good, known-broken
+
+The suite is green while every open bug stays visible: a test that reproduces a
+known defect asserts the *correct* behavior and is registered as an expected
+failure (`XFAIL`) rather than being weakened. If a bug is fixed, its test flips
+to `XPASS` and the run goes red until the registry is updated. Error *kinds* and
+some behaviors are a property of the `(rustc, xous-core)` pair, so the workflow
+pins both; each XFAIL's doc comment records the mechanism and suspected code
+path (grep the theme files under `src/tests/` for `XFAIL`).
+
+A few reproducers ship **disabled** (`#[allow(dead_code)]`, not registered)
+because they crash or wedge the `net` service, which would hang the rest of the
+run: binding/connecting an IPv6 address panics smoltcp on the v4-only interface,
+and a connect timeout that lingers as a session timeout aborts an established
+connection whose parked writer is then never woken. Their doc comments explain
+how to reproduce them by hand.
+
+## Adding a test
+
+Write a `pub fn` in the appropriate `src/tests/<theme>.rs` (panic to fail,
+return to pass), then add it to that file's `TESTS` table; `src/tests/mod.rs`
+aggregates the per-theme tables and states the authoring rules. The important
+hazards are documented there and worth repeating: allocate every port through
+`harness::next_port` and never reuse one; route any call that a bug can park
+forever through `harness::bounded` (a wedge counts as a hard failure even for an
+XFAIL) and release TCP sockets with `harness::discard` rather than dropping them
+on the test thread; target the device's own IP for UDP (127.0.0.1 does not loop
+back for UDP); log every few iterations in long loops so the driver's inactivity
+reaper does not mistake a busy test for a dead server; and use only the
+deterministic `harness::XorShift`, never the `rand` crate.

--- a/services/net-tests/src/harness.rs
+++ b/services/net-tests/src/harness.rs
@@ -1,0 +1,156 @@
+//! Shared plumbing for the net-tests suite: per-test port isolation, the
+//! upstream `check!`/`error_contains!` assertion macros, a deterministic RNG
+//! (OS randomness is unsupported on xous — do not use the `rand` crate), the
+//! DUT's own IP, an echo-server helper, and hang containment for blocking
+//! calls that known bugs can park forever. A superset toolkit: loopback uses all
+//! of it, cross-host only a subset (it talks to a real peer, not a self-hosted echo
+//! server), so unused helpers are tolerated in the cross-host build.
+#![cfg_attr(feature = "cross-host", allow(dead_code))]
+
+use std::io::{Read, Write};
+use std::net::{IpAddr, TcpListener};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::thread;
+use std::time::Duration;
+
+static PORT_COUNTER: AtomicU16 = AtomicU16::new(20000);
+
+/// Allocate a fresh port. Ports are NEVER reused across tests: `bounded` leaks
+/// blocked threads that keep their sockets alive, and the net server has no
+/// SO_REUSEADDR (re-bind fails SocketInUse). 20000+ avoids the ephemeral range.
+pub fn next_port() -> u16 { PORT_COUNTER.fetch_add(1, Ordering::SeqCst) }
+
+/// The DUT's own IP, queried from the net service once and cached. Under
+/// renode-minimal the net service seeds a static config at boot (10.0.2.15/24);
+/// the readiness gate guarantees it is present before any test runs.
+pub fn self_ip() -> IpAddr {
+    static SELF_IP: OnceLock<IpAddr> = OnceLock::new();
+    *SELF_IP.get_or_init(|| {
+        let cfg = net::NetManager::new()
+            .get_ipv4_config()
+            .expect("no IPv4 config (the readiness gate should have caught this)");
+        IpAddr::from(cfg.addr)
+    })
+}
+
+/// Run a blocking op on a throwaway thread, waiting up to `secs`. Converts a
+/// known class of net-server hangs (#880: read timeouts never serviced on quiet
+/// sockets) into a deterministic panic. On timeout the worker leaks with its
+/// sockets — fine because ports are never reused (see `next_port`).
+pub fn bounded<T: Send + 'static>(desc: &str, secs: u64, op: impl FnOnce() -> T + Send + 'static) -> T {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        tx.send(op()).ok();
+    });
+    match rx.recv_timeout(Duration::from_secs(secs)) {
+        Ok(v) => v,
+        Err(RecvTimeoutError::Timeout) => {
+            panic!("{} did not complete within {} s (worker thread leaked)", desc, secs)
+        }
+        Err(RecvTimeoutError::Disconnected) => panic!("{} worker thread panicked", desc),
+    }
+}
+
+/// Hand a value (usually a TCP socket) to a detached thread to drop it there.
+/// A TCP drop issues a blocking StdTcpClose the net server only services when
+/// iface.poll() reports activity (NTC-5): a traffic-free close blocks forever.
+/// Tests never drop TCP sockets inline; the worker leaks if it hangs. UDP is safe.
+pub fn discard<T: Send + 'static>(x: T) { thread::spawn(move || drop(x)); }
+
+/// Handle to a running `echo_server` thread; `wait` panics rather than
+/// hanging the suite if the thread never sees EOF.
+pub struct EchoServer {
+    done: mpsc::Receiver<Result<usize, String>>,
+}
+impl EchoServer {
+    /// Wait for the server thread to see EOF and exit; returns the byte count
+    /// it echoed.
+    pub fn wait(self) -> usize {
+        match self.done.recv_timeout(Duration::from_secs(10)) {
+            Ok(Ok(total)) => total,
+            Ok(Err(e)) => panic!("echo server failed: {}", e),
+            Err(_) => panic!("echo server did not exit within 10 s (EOF never delivered?)"),
+        }
+    }
+}
+
+/// Spawn a thread that accepts ONE connection on `listener` and echoes bytes
+/// back until EOF. I/O errors are reported through `EchoServer::wait`, not by
+/// panicking on the worker thread.
+pub fn echo_server(listener: TcpListener) -> EchoServer {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let result = (|| {
+            let (mut stream, _peer) = listener.accept().map_err(|e| format!("accept: {}", e))?;
+            let mut total = 0usize;
+            let mut chunks = 0usize;
+            let mut buf = [0u8; 1024];
+            loop {
+                let n = stream.read(&mut buf).map_err(|e| format!("server read: {}", e))?;
+                if n == 0 {
+                    return Ok(total);
+                }
+                stream.write_all(&buf[..n]).map_err(|e| format!("server write: {}", e))?;
+                total += n;
+                chunks += 1;
+                if chunks % 5 == 0 {
+                    // inactivity-reaper rule: long op loops must emit output
+                    log::info!("echo_server: {} chunks, {} bytes echoed", chunks, total);
+                }
+            }
+        })();
+        tx.send(result).ok();
+    });
+    EchoServer { done: rx }
+}
+
+/// Upstream idiom from rust's library/std tests: unwrap a Result with the
+/// failing expression in the panic message.
+macro_rules! check {
+    ($e:expr) => {
+        match $e {
+            Ok(t) => t,
+            Err(e) => panic!("{} failed with: {e}", stringify!($e)),
+        }
+    };
+}
+pub(crate) use check;
+
+/// Upstream idiom from rust's library/std tests: assert that a Result is an
+/// Err whose message contains `$s`.
+#[allow(unused_macros)]
+macro_rules! error_contains {
+    ($e:expr, $s:expr) => {
+        match $e {
+            Ok(_) => panic!("Unexpected success. Should've been: {:?}", $s),
+            Err(ref err) => {
+                assert!(err.to_string().contains($s), "`{}` did not contain `{}`", err, $s)
+            }
+        }
+    };
+}
+#[allow(unused_imports)]
+pub(crate) use error_contains;
+
+/// Deterministic xorshift32 RNG for generating test data.
+pub struct XorShift(u32);
+impl XorShift {
+    pub fn new(seed: u32) -> Self { XorShift(if seed == 0 { 0xDEAD_BEEF } else { seed }) }
+
+    pub fn next_u32(&mut self) -> u32 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        self.0 = x;
+        x
+    }
+
+    pub fn fill(&mut self, buf: &mut [u8]) {
+        for b in buf.iter_mut() {
+            *b = self.next_u32() as u8;
+        }
+    }
+}

--- a/services/net-tests/src/main.rs
+++ b/services/net-tests/src/main.rs
@@ -1,0 +1,168 @@
+//! std::net test runner for Renode CI.
+//!
+//! Joins the (emulated) wlan, waits for the net service to report an IPv4
+//! config (renode-minimal seeds a static one at boot, since no DHCP peer
+//! exists), then runs every test in `tests::TESTS` under `catch_unwind` and
+//! emits machine-parsable sentinels on the log console for the Renode driver.
+//! Sentinel grammar mirrors pddb-fs-tests, plus a `NET-TESTS DONE:` totals
+//! line so drivers cannot cross-match suites. Authoring rules: tests/mod.rs.
+
+mod harness;
+mod tests;
+
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::Mutex;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+/// The panic hook records the message here so the runner can report it as the
+/// one-line FAIL reason. Mandatory: the default hook prints a `PANIC in PID`
+/// banner the CI driver treats as a hard failure even for recovered panics.
+static PANIC_MSG: Mutex<Option<String>> = Mutex::new(None);
+
+/// Flatten a panic message to its first line, truncated to ~120 chars.
+fn one_line(reason: &str) -> String {
+    let first = reason.lines().next().unwrap_or("").replace('\r', " ");
+    let mut flat: String = first.chars().take(120).collect();
+    if first.chars().count() > 120 {
+        flat.push_str("...");
+    }
+    flat
+}
+
+fn main() -> ! {
+    log_server::init_wait().unwrap();
+    log::set_max_level(log::LevelFilter::Info);
+    log::info!("my PID is {}", xous::process::id());
+
+    // Record panics instead of printing the default banner (see PANIC_MSG).
+    panic::set_hook(Box::new(|info| {
+        let msg = if let Some(s) = info.payload().downcast_ref::<&str>() {
+            (*s).to_string()
+        } else if let Some(s) = info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "non-string panic payload".to_string()
+        };
+        let msg = match info.location() {
+            Some(loc) => format!("{} (at {}:{})", msg, loc.file(), loc.line()),
+            None => msg,
+        };
+        *PANIC_MSG.lock().unwrap() = Some(msg);
+    }));
+
+    let tt = ticktimer_server::Ticktimer::new().unwrap();
+
+    // The ticktimer arms a ~30 s hardware watchdog and feeds it only on
+    // message receipt; this minimal image can go quiet longer than that when a
+    // test parks in a long guard, resetting the SoC. Feed it for the run's life.
+    std::thread::spawn(|| {
+        let tt = ticktimer_server::Ticktimer::new().unwrap();
+        loop {
+            tt.ping_wdt();
+            tt.sleep_ms(5000).unwrap();
+        }
+    });
+
+    // let the rest of the boot sequence quiesce before driving the COM
+    tt.sleep_ms(1000).unwrap();
+    let all_tests = tests::all_tests();
+    let all_xfails = tests::all_xfails();
+
+    // Readiness: issue the wlan join (cf. services/libstd-test), then poll for
+    // the IPv4 config the net service acquires. Both failure paths emit a
+    // deterministic failing DONE line instead of hanging the run.
+    let xns = xous_names::XousNames::new().unwrap();
+    let mut com = com::Com::new(&xns).unwrap();
+    if let Err(e) = com.wlan_join() {
+        log::info!("TEST readiness::wlan_join FAIL couldn't issue join command: {:?}", e);
+        log::info!("NET-TESTS DONE: pass=0 fail=1 xfail=0 xpass=0 total=1");
+        log::info!("CI done");
+        xous::terminate_process(0);
+    }
+    log::info!("wlan join issued; waiting for an IPv4 config...");
+    let net_mgr = net::NetManager::new();
+    let mut net_cfg = None;
+    for poll in 1..=240u32 {
+        // 240 polls x 500 ms = 120 s budget
+        if let Some(cfg) = net_mgr.get_ipv4_config() {
+            net_cfg = Some(cfg);
+            break;
+        }
+        if poll % 5 == 0 {
+            // inactivity-reaper safety: show signs of life while waiting
+            log::info!("still waiting for an IPv4 config ({} polls)", poll);
+        }
+        tt.sleep_ms(500).unwrap();
+    }
+    let cfg = match net_cfg {
+        Some(cfg) => cfg,
+        None => {
+            log::info!("TEST readiness::ipv4_config FAIL no IPv4 config within 120 s");
+            log::info!("NET-TESTS DONE: pass=0 fail=1 xfail=0 xpass=0 total=1");
+            log::info!("CI done");
+            xous::terminate_process(0);
+        }
+    };
+    log::info!("net is up at {:?}; running {} tests", std::net::IpAddr::from(cfg.addr), all_tests.len());
+
+    let mut pass = 0usize;
+    let mut fail = 0usize;
+    let mut xfail = 0usize;
+    let mut xpass = 0usize;
+    for &(name, test) in all_tests.iter() {
+        PANIC_MSG.lock().unwrap().take();
+        log::info!("TEST {} START", name);
+        // Each test runs on a worker thread with a per-test verdict deadline:
+        // std::net calls lend blockingly into the net server and known bugs
+        // (NTC-1, NTC-5) can park them forever. On timeout the worker leaks,
+        // the test is a hard FAIL, and the run still reaches `NET-TESTS DONE`.
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            tx.send(panic::catch_unwind(AssertUnwindSafe(test)).is_ok()).ok();
+        });
+        let verdict = rx.recv_timeout(Duration::from_secs(60)).ok();
+        let expected_bug = all_xfails.iter().find_map(|&(n, bug)| if n == name { Some(bug) } else { None });
+        match (verdict, expected_bug) {
+            (Some(true), None) => {
+                pass += 1;
+                log::info!("TEST {} PASS", name);
+            }
+            (Some(true), Some(bug)) => {
+                xpass += 1;
+                log::info!("TEST {} XPASS {}", name, bug);
+            }
+            (Some(false), Some(bug)) => {
+                xfail += 1;
+                log::info!("TEST {} XFAIL {}", name, bug);
+            }
+            (Some(false), None) => {
+                fail += 1;
+                let reason = PANIC_MSG
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .unwrap_or_else(|| "panicked without a recorded message".to_string());
+                log::info!("TEST {} FAIL {}", name, one_line(&reason));
+            }
+            (None, _) => {
+                // a wedge is never an expected failure: XFAIL tests are
+                // structured to convert their bug's hang into a panic
+                fail += 1;
+                log::info!("TEST {} FAIL wedged: no verdict within 60 s (worker thread leaked)", name);
+            }
+        }
+    }
+
+    log::info!(
+        "NET-TESTS DONE: pass={} fail={} xfail={} xpass={} total={}",
+        pass,
+        fail,
+        xfail,
+        xpass,
+        all_tests.len()
+    );
+    log::info!("CI done");
+    xous::terminate_process(0)
+}

--- a/services/net-tests/src/tests/concur.rs
+++ b/services/net-tests/src/tests/concur.rs
@@ -1,0 +1,637 @@
+//! concur theme — cross-thread and multi-socket concurrency semantics: the
+//! suite's highest hang/leak-risk theme, every test coordinating at least two
+//! threads around blocking socket ops. Discipline on top of tests/mod.rs:
+//! cross-thread rendezvous go through mpsc recv_timeout (no unbounded
+//! join/recv); blocking ops run inside harness::bounded; TCP sockets travel
+//! back to the test thread in collect-discard-assert order and ride in
+//! ManuallyDrop when they must survive a panic. The disabled DANGER reproducer
+//! below (net-service panic) must NEVER be registered in TESTS.
+
+use core::mem::ManuallyDrop;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream, UdpSocket};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::harness::{XorShift, bounded, check, discard, echo_server, next_port, self_ip};
+use crate::tests::{TestEntry, XfailEntry};
+
+const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+/// One connect/accept/tagged-byte echo round against `addr`, accepting via
+/// the listener stowed in `listener` (restored before any panic-capable
+/// assert so a failing round leaks it rather than unwind-dropping it).
+fn echo_round(listener: &mut ManuallyDrop<Option<TcpListener>>, addr: SocketAddr, tag: u8, what: &str) {
+    let mut client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let l = listener.take().unwrap();
+    let (accepted, l) = bounded("accept", 10, move || {
+        let r = l.accept();
+        (r, l)
+    });
+    **listener = Some(l);
+    let (served, _peer) = check!(accepted);
+    check!(client.write_all(&[tag]));
+    let (server_read, served) = bounded("server read+reply", 10, move || {
+        let mut served = served;
+        let mut buf = [0u8; 1];
+        let r = served.read_exact(&mut buf).map(|_| buf[0]);
+        let r = r.and_then(|got| served.write_all(&[got ^ 0xff]).map(|_| got));
+        (r, served)
+    });
+    let (client_read, client) = bounded("client readback", 10, move || {
+        let mut client = client;
+        let mut buf = [0u8; 1];
+        let r = client.read_exact(&mut buf).map(|_| buf[0]);
+        (r, client)
+    });
+    discard(served);
+    discard(client);
+    assert_eq!(check!(server_read), tag, "{}: server read the wrong tag byte", what);
+    assert_eq!(check!(client_read), tag ^ 0xff, "{}: client read the wrong reply byte", what);
+}
+
+/// Two independent TCP connections make interleaved progress: every round
+/// writes a chunk on both before reading either echo back, so both always
+/// have data in flight, exercising NetPump rx fairness. Echo threads leak.
+pub fn two_pairs_interleaved_echo() {
+    const ROUNDS: u32 = 5;
+    const CHUNK: usize = 256;
+    let addr_a = SocketAddr::new(LOOPBACK, next_port());
+    let addr_b = SocketAddr::new(LOOPBACK, next_port());
+    let _srv_a = echo_server(check!(TcpListener::bind(addr_a)));
+    let _srv_b = echo_server(check!(TcpListener::bind(addr_b)));
+    let mut conn_a =
+        ManuallyDrop::new(Some(check!(bounded("connect A", 10, move || TcpStream::connect(addr_a)))));
+    let mut conn_b =
+        ManuallyDrop::new(Some(check!(bounded("connect B", 10, move || TcpStream::connect(addr_b)))));
+    let mut gen_a = XorShift::new(0xC1A0_0001);
+    let mut gen_b = XorShift::new(0xC1B0_0002);
+    for round in 0..ROUNDS {
+        log::info!("interleave round {}/{}", round, ROUNDS);
+        let mut chunk_a = vec![0u8; CHUNK];
+        gen_a.fill(&mut chunk_a);
+        let mut chunk_b = vec![0u8; CHUNK];
+        gen_b.fill(&mut chunk_b);
+        // both writes land before either echo is read back, so the two rx
+        // completions must interleave across the connections
+        check!(conn_a.as_mut().unwrap().write_all(&chunk_a));
+        check!(conn_b.as_mut().unwrap().write_all(&chunk_b));
+        let sa = conn_a.take().unwrap();
+        let (echo_a, sa) = bounded("echo readback A", 10, move || {
+            let mut sa = sa;
+            let mut buf = vec![0u8; CHUNK];
+            let r = sa.read_exact(&mut buf).map(|_| buf);
+            (r, sa)
+        });
+        *conn_a = Some(sa);
+        let sb = conn_b.take().unwrap();
+        let (echo_b, sb) = bounded("echo readback B", 10, move || {
+            let mut sb = sb;
+            let mut buf = vec![0u8; CHUNK];
+            let r = sb.read_exact(&mut buf).map(|_| buf);
+            (r, sb)
+        });
+        *conn_b = Some(sb);
+        // both clients are safely re-stowed (ManuallyDrop) before asserting
+        assert_eq!(check!(echo_a), chunk_a, "connection A echo corrupted in round {}", round);
+        assert_eq!(check!(echo_b), chunk_b, "connection B echo corrupted in round {}", round);
+    }
+    discard(conn_a.take().unwrap());
+    discard(conn_b.take().unwrap());
+}
+
+/// smoltcp has no listen backlog: conn#1's handshake completes against the
+/// single listener socket before any accept(), conn#2's SYN then draws an RST
+/// (surfacing as AddrNotAvailable), and the replenished listener admits conn#3.
+pub fn second_connect_while_unaccepted() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let mut listener = ManuallyDrop::new(Some(check!(TcpListener::bind(addr))));
+    // conn#1: completes its handshake against the listener's single smoltcp
+    // socket before any accept() is issued
+    let mut conn1 = ManuallyDrop::new(Some(check!(bounded("connect #1 (pre-accept)", 10, move || {
+        TcpStream::connect(addr)
+    }))));
+    // conn#2 while conn#1 sits un-accepted: nothing is listening on the port
+    // any more, so the SYN draws an RST
+    let started = Instant::now();
+    let second = bounded("connect #2 (expect no-backlog RST)", 10, move || {
+        TcpStream::connect_timeout(&addr, Duration::from_secs(5))
+    });
+    log::info!("second connect resolved in {:?}", started.elapsed());
+    // strip any unexpected socket out of the result immediately so no later
+    // panic can unwind-drop it on the test thread (NTC-5)
+    let second = match second {
+        Ok(s) => {
+            discard(s);
+            None
+        }
+        Err(e) => Some(e),
+    };
+    // accept() must now return conn#1 (already established) and, on its way
+    // out, replenish the listener via the client-side re-bind
+    let l = listener.take().unwrap();
+    let (accepted1, l) = bounded("accept #1", 10, move || {
+        let r = l.accept();
+        (r, l)
+    });
+    *listener = Some(l);
+    let (served1, _peer) = check!(accepted1);
+    check!(conn1.as_mut().unwrap().write_all(&[0xA1]));
+    let (read1, served1) = bounded("read on accepted #1", 10, move || {
+        let mut s = served1;
+        let mut buf = [0u8; 1];
+        let r = s.read_exact(&mut buf).map(|_| buf[0]);
+        (r, s)
+    });
+    let mut served1 = ManuallyDrop::new(Some(served1));
+    // ...and the replenished listener must admit conn#3
+    let mut conn3 = ManuallyDrop::new(Some(check!(bounded("connect #3 (post-replenish)", 10, move || {
+        TcpStream::connect(addr)
+    }))));
+    let l = listener.take().unwrap();
+    let (accepted3, l) = bounded("accept #3", 10, move || {
+        let r = l.accept();
+        (r, l)
+    });
+    *listener = Some(l);
+    let (served3, _peer) = check!(accepted3);
+    check!(conn3.as_mut().unwrap().write_all(&[0xA3]));
+    let (read3, served3) = bounded("read on accepted #3", 10, move || {
+        let mut s = served3;
+        let mut buf = [0u8; 1];
+        let r = s.read_exact(&mut buf).map(|_| buf[0]);
+        (r, s)
+    });
+    // collect-discard-assert
+    discard(served3);
+    discard(served1.take().unwrap());
+    discard(conn1.take().unwrap());
+    discard(conn3.take().unwrap());
+    discard(listener.take().unwrap());
+    match second {
+        None => panic!(
+            "connect #2 while conn#1 sat un-accepted unexpectedly succeeded (smoltcp has no backlog; want an RST)"
+        ),
+        Some(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::AddrNotAvailable,
+            "pre-replenish connect surfaced as {:?} ({}), want the NTC-6-pinned AddrNotAvailable",
+            e.kind(),
+            e
+        ),
+    }
+    assert_eq!(check!(read1), 0xA1, "conn#1 byte after the late accept");
+    assert_eq!(check!(read3), 0xA3, "conn#3 byte after the listener replenish");
+}
+
+/// Ten serial connect/accept/exchange/close cycles against one listener all
+/// succeed, hammering the accept-side listener replenish interleaved with
+/// close churn while the next round's traffic keeps the pump running.
+pub fn accept_loop_sequential_stress() {
+    const ROUNDS: u8 = 10;
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let mut listener = ManuallyDrop::new(Some(check!(TcpListener::bind(addr))));
+    for round in 0..ROUNDS {
+        log::info!("stress round {}/{}", round, ROUNDS);
+        echo_round(&mut listener, addr, round, "accept-loop stress");
+    }
+    discard(listener.take().unwrap());
+}
+
+/// TCP is full-duplex: a read parked on one thread must not serialize against
+/// a concurrent write from another on the same socket. The reader clone parks
+/// in rx first, the writer pushes the other way, then the server replies.
+pub fn full_duplex_one_socket() {
+    const N: usize = 512; // fits the 1530 B socket buffers: neither side can stall on a full window
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let mut client =
+        ManuallyDrop::new(Some(check!(bounded("connect", 10, move || { TcpStream::connect(addr) }))));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let mut listener = ManuallyDrop::new(Some(listener));
+    let (served, _peer) = check!(accepted);
+    let mut served = ManuallyDrop::new(Some(served));
+    let read_half = check!(client.as_ref().unwrap().try_clone());
+    let mut c2s = vec![0u8; N];
+    XorShift::new(0xC4_0001).fill(&mut c2s);
+    let mut s2c = vec![0u8; N];
+    XorShift::new(0xC4_0002).fill(&mut s2c);
+    // reader parks on the clone; nothing is inbound yet, so it stays parked
+    // while the writer half works
+    let (rd_tx, rd_rx) = mpsc::channel();
+    {
+        let mut sock = read_half;
+        thread::spawn(move || {
+            let mut buf = vec![0u8; N];
+            let r = sock.read_exact(&mut buf).map(|_| buf);
+            rd_tx.send((r, sock)).ok();
+        });
+    }
+    // writer pushes client->server through the original object concurrently
+    let (wr_tx, wr_rx) = mpsc::channel();
+    {
+        let mut sock = client.take().unwrap();
+        let data = c2s.clone();
+        thread::spawn(move || {
+            let r = sock.write_all(&data);
+            wr_tx.send((r, sock)).ok();
+        });
+    }
+    // server side: drain the writer's payload while the reader is still
+    // parked, then send the payload the reader is waiting for
+    let s = served.take().unwrap();
+    let (got_c2s, s) = bounded("server-side read of the writer's payload", 10, move || {
+        let mut s = s;
+        let mut buf = vec![0u8; N];
+        let r = s.read_exact(&mut buf).map(|_| buf);
+        (r, s)
+    });
+    *served = Some(s);
+    check!(served.as_mut().unwrap().write_all(&s2c));
+    let (got_s2c, read_half) = match rd_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(_) => panic!("full-duplex reader did not complete within 10 s (worker thread leaked)"),
+    };
+    let mut read_half = ManuallyDrop::new(Some(read_half));
+    let (write_res, client_back) = match wr_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(_) => panic!("full-duplex writer did not complete within 10 s (worker thread leaked)"),
+    };
+    // collect-discard-assert
+    discard(client_back);
+    discard(read_half.take().unwrap());
+    discard(served.take().unwrap());
+    discard(listener.take().unwrap());
+    check!(write_res);
+    assert_eq!(check!(got_c2s), c2s, "client->server payload corrupted (writer direction)");
+    assert_eq!(check!(got_s2c), s2c, "server->client payload corrupted (reader direction)");
+}
+
+/// A TCP listener and a UDP socket bound to the same (addr, port) coexist and
+/// demux by protocol, each exercised while the other is live — a cross-talk
+/// detector for the shared per-process fd table. UDP targets self_ip().
+pub fn tcp_udp_same_port() {
+    let ip = self_ip();
+    let shared_port = next_port();
+    let shared_addr = SocketAddr::new(ip, shared_port);
+    let listener = check!(TcpListener::bind(shared_addr)); // whitelist admits the DUT IP (std_tcplistener.rs:38-44)
+    let udp = check!(UdpSocket::bind(shared_addr));
+    // TCP exchange through the shared port while the UDP socket is bound
+    let mut client =
+        ManuallyDrop::new(Some(check!(bounded("connect", 10, move || { TcpStream::connect(shared_addr) }))));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let mut listener = ManuallyDrop::new(Some(listener));
+    let (served, _peer) = check!(accepted);
+    check!(client.as_mut().unwrap().write_all(b"tcp!"));
+    let (tcp_read, served) = bounded("read on accepted", 10, move || {
+        let mut s = served;
+        let mut buf = [0u8; 4];
+        let r = s.read_exact(&mut buf).map(|_| buf);
+        (r, s)
+    });
+    let mut served = ManuallyDrop::new(Some(served));
+    // UDP exchange to the same port while the TCP connection is still open
+    let sender_addr = SocketAddr::new(ip, next_port());
+    let sender = check!(UdpSocket::bind(sender_addr));
+    assert_eq!(check!(sender.send_to(b"udp?", shared_addr)), 4, "udp send_to length");
+    let (udp_read, buf, udp) = bounded("udp recv on the shared port", 10, move || {
+        let mut buf = [0u8; 16];
+        let r = udp.recv_from(&mut buf);
+        (r, buf, udp)
+    });
+    // collect-discard-assert (UDP drops are synchronous and safe inline)
+    drop(udp);
+    drop(sender);
+    discard(client.take().unwrap());
+    discard(served.take().unwrap());
+    discard(listener.take().unwrap());
+    assert_eq!(&check!(tcp_read), b"tcp!", "tcp payload wrong through the shared port");
+    let (n, from) = check!(udp_read);
+    assert_eq!(&buf[..n], b"udp?", "udp payload wrong through the shared port");
+    assert_eq!(from, sender_addr, "udp datagram source address");
+}
+
+/// 60 open/close cycles (a TCP listener + a UDP pair each) never exhaust fds,
+/// and every cycle's fresh sockets work (distinct payloads catch aliasing).
+/// Each cycle's UDP roundtrip pumps the prior closes so they retire.
+pub fn socket_slot_reuse() {
+    const CYCLES: u32 = 60;
+    let ip = self_ip();
+    for cycle in 0..CYCLES {
+        if cycle % 5 == 0 {
+            log::info!("slot-reuse cycle {}/{}", cycle, CYCLES);
+        }
+        let mut listener =
+            ManuallyDrop::new(Some(check!(TcpListener::bind(SocketAddr::new(LOOPBACK, next_port())))));
+        let rx_addr = SocketAddr::new(ip, next_port());
+        let tx_addr = SocketAddr::new(ip, next_port());
+        let rx_sock = check!(UdpSocket::bind(rx_addr));
+        let tx_sock = check!(UdpSocket::bind(tx_addr));
+        let mut payload = [0u8; 8];
+        XorShift::new(0xC600_0000 + cycle).fill(&mut payload);
+        assert_eq!(check!(tx_sock.send_to(&payload, rx_addr)), 8, "cycle {}: send_to length", cycle);
+        let (received, buf, rx_sock) = bounded("slot-reuse udp recv", 10, move || {
+            let mut buf = [0u8; 16];
+            let r = rx_sock.recv_from(&mut buf);
+            (r, buf, rx_sock)
+        });
+        // collect-discard-assert, per cycle
+        discard(listener.take().unwrap());
+        drop(rx_sock);
+        drop(tx_sock);
+        let (n, from) = check!(received);
+        assert_eq!(&buf[..n], &payload, "cycle {}: payload corrupted across slot reuse", cycle);
+        assert_eq!(from, tx_addr, "cycle {}: datagram source address", cycle);
+    }
+}
+
+/// DANGER — NEVER register in TESTS; run only by hand on a scratch image,
+/// because on dev it panics the net service: closing a listener while another
+/// thread's accept() is parked removes a smoltcp handle the parked accept
+/// still references (a stale-handle panic), which the CI driver treats as fatal.
+#[allow(dead_code)]
+pub fn drop_listener_while_accept_parked_danger() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    // bitwise alias: same fd, same (un-incremented) refcount Arc — dropping
+    // the alias below is therefore the LAST-handle drop even though the
+    // accept thread still owns the original
+    let alias = unsafe { core::ptr::read(&listener) };
+    let (acc_tx, acc_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let r = listener.accept();
+        acc_tx.send(r).ok();
+        // the alias drop consumed the refcount and closed the fd: forget the
+        // original instead of double-closing / double-freeing the shared Arc
+        core::mem::forget(listener);
+    });
+    // let the accept park in tcp_accept_waiting (std_tcplistener.rs:150-158)
+    thread::sleep(Duration::from_millis(1000));
+    // last-handle drop: fires StdTcpClose with the accept still parked. The
+    // close of an idle listener needs pump traffic to retire (NTC-5), so a
+    // UDP roundtrip below primes the pump — and with it, the panic window.
+    discard(alias);
+    let probe_addr = SocketAddr::new(self_ip(), next_port());
+    let probe = check!(UdpSocket::bind(probe_addr));
+    check!(probe.send_to(b"pump", probe_addr));
+    let (pumped, _buf, probe) = bounded("pump-priming udp recv", 10, move || {
+        let mut buf = [0u8; 8];
+        let r = probe.recv_from(&mut buf);
+        (r, buf, probe)
+    });
+    drop(probe);
+    check!(pumped);
+    // the contract half: the parked accept must now return rather than hang
+    match acc_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(Ok((stream, _peer))) => discard(stream),
+        Ok(Err(e)) => log::info!("parked accept returned Err({}) after the close — acceptable", e),
+        Err(_) => panic!(
+            "accept did not return within 10 s of its listener closing (the net service may just have panicked — H-1)"
+        ),
+    }
+}
+
+/// Accept one connection via the original listener, then one via its
+/// try_clone: clones share one fd Arc, so round 2 works only if accept()'s
+/// listener replenish is visible through both clones.
+pub fn listener_clone_accept_serial() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let l1 = check!(TcpListener::bind(addr));
+    let l2 = check!(l1.try_clone());
+    let mut l1 = ManuallyDrop::new(Some(l1));
+    let mut l2 = ManuallyDrop::new(Some(l2));
+    log::info!("clone-accept round 1: via the original");
+    echo_round(&mut l1, addr, 0x81, "clone-accept round 1 (original)");
+    log::info!("clone-accept round 2: via the clone");
+    echo_round(&mut l2, addr, 0x82, "clone-accept round 2 (clone)");
+    // first drop only decrements the shared refcount; the second closes the fd
+    discard(l1.take().unwrap());
+    discard(l2.take().unwrap());
+}
+
+/// Two threads parked in accept() on two clones of one listener, plus two
+/// connections, must yield two distinct working accepted streams.
+/// XFAIL: both AcceptingSocket entries reference the same smoltcp handle so both accepts return one connection, the pump accept scan in services/net/src/main.rs.
+pub fn listener_clone_accept_concurrent_probe() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let l1 = check!(TcpListener::bind(addr));
+    let l2 = check!(l1.try_clone());
+    // both acceptors park first, then the connects arrive
+    let (a_tx, a_rx) = mpsc::channel();
+    {
+        let l = l1;
+        thread::spawn(move || {
+            let r = l.accept();
+            a_tx.send((r, l)).ok();
+        });
+    }
+    let (b_tx, b_rx) = mpsc::channel();
+    {
+        let l = l2;
+        thread::spawn(move || {
+            let r = l.accept();
+            b_tx.send((r, l)).ok();
+        });
+    }
+    thread::sleep(Duration::from_millis(500)); // let both accepts park in tcp_accept_waiting
+    let mut conn1 =
+        ManuallyDrop::new(Some(check!(bounded("connect #1", 10, move || TcpStream::connect(addr)))));
+    // give the winning accept time to return and replenish the listener:
+    // pre-replenish, conn#2's SYN would draw the no-backlog RST (see C-2)
+    thread::sleep(Duration::from_millis(1000));
+    let mut conn2 =
+        ManuallyDrop::new(Some(check!(bounded("connect #2", 10, move || TcpStream::connect(addr)))));
+    // collect both acceptors (guarded rendezvous)
+    let (acc_a, l1) = match a_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(_) => panic!("PROBE: accept via clone #1 did not return within 10 s of both connects"),
+    };
+    let mut l1 = ManuallyDrop::new(Some(l1));
+    let mut srv_a = match acc_a {
+        Ok((s, _peer)) => ManuallyDrop::new(Some(s)),
+        Err(e) => panic!("PROBE: accept via clone #1 failed: {}", e),
+    };
+    let (acc_b, l2) = match b_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(_) => panic!("PROBE: accept via clone #2 did not return within 10 s of both connects"),
+    };
+    let mut l2 = ManuallyDrop::new(Some(l2));
+    let mut srv_b = match acc_b {
+        Ok((s, _peer)) => ManuallyDrop::new(Some(s)),
+        Err(e) => panic!("PROBE: accept via clone #2 failed: {}", e),
+    };
+    // each client tags its connection; each accepted stream must produce
+    // exactly one of the two tags (accept order is unspecified)
+    check!(conn1.as_mut().unwrap().write_all(&[0xB1]));
+    check!(conn2.as_mut().unwrap().write_all(&[0xB2]));
+    let s = srv_a.take().unwrap();
+    let (got_a, s) = bounded("read on accepted A", 10, move || {
+        let mut s = s;
+        let mut buf = [0u8; 1];
+        let r = s.read_exact(&mut buf).map(|_| buf[0]);
+        (r, s)
+    });
+    *srv_a = Some(s);
+    let s = srv_b.take().unwrap();
+    let (got_b, s) = bounded("read on accepted B", 10, move || {
+        let mut s = s;
+        let mut buf = [0u8; 1];
+        let r = s.read_exact(&mut buf).map(|_| buf[0]);
+        (r, s)
+    });
+    *srv_b = Some(s);
+    // collect-discard-assert (no waiter is parked once both accepts returned)
+    discard(conn1.take().unwrap());
+    discard(conn2.take().unwrap());
+    discard(srv_a.take().unwrap());
+    discard(srv_b.take().unwrap());
+    discard(l1.take().unwrap());
+    discard(l2.take().unwrap());
+    let mut got = [check!(got_a), check!(got_b)];
+    got.sort_unstable();
+    assert_eq!(
+        got,
+        [0xB1, 0xB2],
+        "PROBE: the two concurrent accepts did not serve the two distinct connections"
+    );
+}
+
+/// Two threads send one datagram each to a single receiver; both arrive with
+/// the right payload and source address. Exactly two are in flight, matching
+/// the rx queue's 2 slots; arrival order is unspecified, matched by source.
+pub fn udp_two_senders_one_receiver() {
+    let ip = self_ip();
+    let rx_addr = SocketAddr::new(ip, next_port());
+    let addr_1 = SocketAddr::new(ip, next_port());
+    let addr_2 = SocketAddr::new(ip, next_port());
+    let receiver = check!(UdpSocket::bind(rx_addr));
+    let sender_1 = check!(UdpSocket::bind(addr_1));
+    let sender_2 = check!(UdpSocket::bind(addr_2));
+    let mut payload_1 = [0u8; 16];
+    XorShift::new(0xC9_0001).fill(&mut payload_1);
+    let mut payload_2 = [0u8; 16];
+    XorShift::new(0xC9_0002).fill(&mut payload_2);
+    let (tx1, rx1) = mpsc::channel();
+    thread::spawn(move || {
+        let r = sender_1.send_to(&payload_1, rx_addr);
+        tx1.send((r, sender_1)).ok();
+    });
+    let (tx2, rx2) = mpsc::channel();
+    thread::spawn(move || {
+        let r = sender_2.send_to(&payload_2, rx_addr);
+        tx2.send((r, sender_2)).ok();
+    });
+    let (first, buf_first, receiver) = bounded("recv of the first datagram", 10, move || {
+        let mut buf = [0u8; 32];
+        let r = receiver.recv_from(&mut buf);
+        (r, buf, receiver)
+    });
+    let (second, buf_second, receiver) = bounded("recv of the second datagram", 10, move || {
+        let mut buf = [0u8; 32];
+        let r = receiver.recv_from(&mut buf);
+        (r, buf, receiver)
+    });
+    let (send_1, sender_1) = match rx1.recv_timeout(Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(_) => panic!("sender #1 did not finish within 10 s (worker thread leaked)"),
+    };
+    let (send_2, sender_2) = match rx2.recv_timeout(Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(_) => panic!("sender #2 did not finish within 10 s (worker thread leaked)"),
+    };
+    drop(sender_1);
+    drop(sender_2);
+    drop(receiver);
+    assert_eq!(check!(send_1), 16, "sender #1 send_to length");
+    assert_eq!(check!(send_2), 16, "sender #2 send_to length");
+    let (n_first, from_first) = check!(first);
+    let (n_second, from_second) = check!(second);
+    assert_ne!(from_first, from_second, "the same sender was received twice");
+    for (from, buf, n) in [(from_first, buf_first, n_first), (from_second, buf_second, n_second)] {
+        let expected: &[u8] = if from == addr_1 {
+            &payload_1
+        } else if from == addr_2 {
+            &payload_2
+        } else {
+            panic!("datagram from unexpected source {}", from)
+        };
+        assert_eq!(&buf[..n], expected, "payload from {} corrupted", from);
+    }
+}
+
+/// A connected TcpStream moved to another thread works from there: fds index
+/// the per-process socket table, so a socket is valid from any thread. Write
+/// and read both happen only on the destination thread.
+pub fn cross_thread_move() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    // hand the connected stream to a fresh thread and drive it only there
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut client = client;
+        let wrote = client.write_all(b"mova");
+        let mut buf = [0u8; 4];
+        let read = client.read_exact(&mut buf).map(|_| buf);
+        tx.send((wrote, read, client)).ok();
+    });
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let mut listener = ManuallyDrop::new(Some(listener));
+    let (served, _peer) = check!(accepted);
+    let (request, served) = bounded("server read", 10, move || {
+        let mut s = served;
+        let mut buf = [0u8; 4];
+        let r = s.read_exact(&mut buf).map(|_| buf);
+        (r, s)
+    });
+    let mut served = ManuallyDrop::new(Some(served));
+    check!(served.as_mut().unwrap().write_all(b"avom"));
+    let (wrote, read, client) = match rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(_) => panic!("moved-stream worker did not finish within 10 s (worker thread leaked)"),
+    };
+    // collect-discard-assert
+    discard(client);
+    discard(served.take().unwrap());
+    discard(listener.take().unwrap());
+    check!(wrote);
+    assert_eq!(&check!(request), b"mova", "server read the wrong request from the moved stream");
+    assert_eq!(&check!(read), b"avom", "moved stream read the wrong reply");
+}
+
+/// This theme's registry (aggregated by tests::all_tests / all_xfails). The
+/// DANGER reproducer (drop_listener_while_accept_parked_danger) is disabled
+/// and must never appear here.
+pub const TESTS: &[TestEntry] = &[
+    ("concur::two_pairs_interleaved_echo", two_pairs_interleaved_echo as fn()),
+    ("concur::second_connect_while_unaccepted", second_connect_while_unaccepted as fn()),
+    ("concur::accept_loop_sequential_stress", accept_loop_sequential_stress as fn()),
+    ("concur::full_duplex_one_socket", full_duplex_one_socket as fn()),
+    ("concur::tcp_udp_same_port", tcp_udp_same_port as fn()),
+    ("concur::socket_slot_reuse", socket_slot_reuse as fn()),
+    ("concur::listener_clone_accept_serial", listener_clone_accept_serial as fn()),
+    ("concur::listener_clone_accept_concurrent_probe", listener_clone_accept_concurrent_probe as fn()),
+    ("concur::udp_two_senders_one_receiver", udp_two_senders_one_receiver as fn()),
+    ("concur::cross_thread_move", cross_thread_move as fn()),
+];
+
+/// Known-bug registry: the concurrent-accept probe is XFAIL(NTC-19) — aliased
+/// fds make concurrent accept() on clones of one listener unsupported.
+pub const XFAILS: &[XfailEntry] = &[("concur::listener_clone_accept_concurrent_probe", "NTC-19")];

--- a/services/net-tests/src/tests/cross_host.rs
+++ b/services/net-tests/src/tests/cross_host.rs
@@ -1,0 +1,198 @@
+//! cross-host theme — cross-host tests against a REAL peer on the emulated switch.
+//! These talk to a second Renode machine (emulation/linux-server.resc, a
+//! busybox Linux) that the driver (tools/std-net-cross-host-ci.py) provisions
+//! before the suite runs; compiled only under the `cross-host` feature. The peer
+//! contract (addresses, ports, DNS records) is the consts below and MUST stay
+//! in lockstep with the driver. Same harness rules as loopback (tests/mod.rs):
+//! DUT-local ports via next_port(), blocking calls via bounded(), TCP via
+//! discard(), log long loops; error KINDS pinned to (rustc, xous-core).
+
+use std::io::{ErrorKind, Read, Write};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream, ToSocketAddrs, UdpSocket};
+
+use crate::harness::{bounded, check, discard, next_port, self_ip};
+use crate::tests::{TestEntry, XfailEntry};
+
+/// The peer's static eth0 address (linux-server.resc rcS).
+const PEER_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1));
+/// Peer TCP echo server port (driver: `nc -lk -p <port> -e /bin/cat`).
+const PEER_ECHO_TCP: u16 = 6001;
+/// Peer UDP echo server port (driver: `nc -u -lk -p <port> -e /bin/cat`).
+const PEER_ECHO_UDP: u16 = 6002;
+/// Peer bulk-source port: serves 8192 bytes of 'A' then closes (driver).
+const PEER_BULK_TCP: u16 = 6003;
+/// A peer port with nothing listening — a SYN draws a real RST.
+const PEER_DEAD_TCP: u16 = 6009;
+/// Static A records the peer's dnsd serves (driver PEER_DNS_RECORDS); the DUT's
+/// resolver (dns1, from the peer's udhcpd) points at the peer, so std lookups
+/// of these names reach that dnsd.
+const PEER_DNS: &[(&str, [u8; 4])] = &[("one.test", [10, 11, 12, 13]), ("two.test", [203, 0, 113, 7])];
+
+/// cross-host canary: asserts the DUT's interface address is in the peer subnet
+/// (192.168.0.0/24) and not the loopback static 10.0.2.15, proving a REAL DHCP
+/// lease from the peer's udhcpd rather than a static seed.
+pub fn dhcp_lease_from_peer() {
+    let ip = self_ip();
+    let v4 = match ip {
+        IpAddr::V4(v4) => v4,
+        IpAddr::V6(_) => panic!("expected an IPv4 lease, got {:?}", ip),
+    };
+    let o = v4.octets();
+    assert_eq!(
+        (o[0], o[1], o[2]),
+        (192, 168, 0),
+        "DUT address {} is not in the peer subnet 192.168.0.0/24 — real DHCP did not bind",
+        v4
+    );
+    assert!(o[3] >= 20, "DUT address {} is outside the udhcpd lease range (.20-.254)", v4);
+}
+
+/// cross-host cross-host TCP: connect to the peer's echo server, send a payload,
+/// read it back. Exercises a real remote stack (Linux) end to end rather than
+/// loopback — SYN/SYN-ACK over the emulated wire, the peer's `nc` echoing.
+pub fn tcp_echo_to_peer() {
+    let addr = SocketAddr::new(PEER_IP, PEER_ECHO_TCP);
+    let msg = b"cross-host-echo-probe";
+    let got = bounded("cross-host echo roundtrip", 20, move || -> std::io::Result<Vec<u8>> {
+        let mut s = TcpStream::connect(addr)?;
+        s.write_all(msg)?;
+        let mut buf = vec![0u8; msg.len()];
+        s.read_exact(&mut buf)?;
+        discard(s);
+        Ok(buf)
+    });
+    assert_eq!(&check!(got), msg, "peer echo mismatch");
+}
+
+/// cross-host real connect-refused: a SYN to a peer port with no listener draws a
+/// genuine RST, yet the client still surfaces AddrNotAvailable on the
+/// (rustc, xous-core) pair. Asserts Err with that pinned kind.
+pub fn connect_refused_from_peer() {
+    let addr = SocketAddr::new(PEER_IP, PEER_DEAD_TCP);
+    let result = bounded("connect to a dead peer port", 15, move || TcpStream::connect(addr));
+    match result {
+        Ok(s) => {
+            discard(s);
+            panic!("connect to the dead peer port {} unexpectedly succeeded", addr);
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::AddrNotAvailable,
+            "peer connect-refused surfaced as {:?} ({}), want the pinned AddrNotAvailable (NTC-6)",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// cross-host cross-host UDP: send a datagram to the peer's UDP echo server and
+/// read the echo back. The DUT socket binds its own DHCP address; the datagram
+/// crosses the emulated wire to the peer's `nc -u` and returns.
+pub fn udp_echo_to_peer() {
+    let local = SocketAddr::new(self_ip(), next_port());
+    let peer = SocketAddr::new(PEER_IP, PEER_ECHO_UDP);
+    let msg = b"cross-host-udp-probe";
+    let got = bounded("cross-host udp roundtrip", 25, move || -> std::io::Result<Vec<u8>> {
+        let sock = UdpSocket::bind(local)?;
+        // UDP is lossy and busybox `nc -u` echo is finicky, so burst several
+        // datagrams and block for the first reply. A read timeout can't retry
+        // (quiet-socket recv timeouts don't fire on dev, #880), so bounded() guards.
+        for _ in 0..5 {
+            sock.send_to(msg, peer)?;
+        }
+        let mut buf = vec![0u8; 64];
+        let (n, from) = sock.recv_from(&mut buf)?;
+        buf.truncate(n);
+        drop(sock);
+        Ok(if from.ip() == PEER_IP { buf } else { Vec::new() })
+    });
+    assert_eq!(&check!(got), msg, "peer udp echo mismatch (or wrong source addr)");
+}
+
+/// cross-host real DNS: resolve each `PEER_DNS` name against the peer's busybox
+/// dnsd through the full std path (`ToSocketAddrs`), decoding a genuine
+/// A-record response over the wire, and assert it maps to its configured address.
+pub fn dns_resolve_peer_records() {
+    for (i, &(name, ip)) in PEER_DNS.iter().enumerate() {
+        let want = SocketAddr::new(IpAddr::V4(Ipv4Addr::from(ip)), 80);
+        let hostport = format!("{}:80", name);
+        // A quiet/parked resolver socket could hang the lookup (net #880), so
+        // resolve off-thread with a deadline.
+        let addrs =
+            bounded("dns lookup", 20, move || hostport.to_socket_addrs().map(|it| it.collect::<Vec<_>>()));
+        let addrs = check!(addrs);
+        assert!(
+            addrs.contains(&want),
+            "lookup of {} resolved to {:?}, want {} (record {})",
+            name,
+            addrs,
+            want,
+            i
+        );
+    }
+}
+
+/// cross-host cross-host TCP windowing (receive side): the peer serves BULK_LEN
+/// bytes of a known fill and the DUT reads to EOF. Crossing the 1530-byte rx
+/// buffer ~5x exercises real over-the-wire segmentation and window updates.
+pub fn tcp_bulk_receive_from_peer() {
+    const BULK_LEN: usize = 8192;
+    const FILL: u8 = b'A'; // driver serves BULK_LEN bytes of this (PEER_BULK_TCP)
+    let addr = SocketAddr::new(PEER_IP, PEER_BULK_TCP);
+    let got = bounded("cross-host bulk receive", 30, move || -> std::io::Result<Vec<u8>> {
+        let mut stream = TcpStream::connect(addr)?;
+        let mut buf = vec![0u8; 2048];
+        let mut got = Vec::with_capacity(BULK_LEN);
+        loop {
+            let n = stream.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            got.extend_from_slice(&buf[..n]);
+            if got.len() % 2048 < n {
+                log::info!("cross-host bulk: {} bytes", got.len());
+            }
+            if got.len() > BULK_LEN * 2 {
+                break; // guard against a misbehaving server streaming forever
+            }
+        }
+        discard(stream);
+        Ok(got)
+    });
+    let got = check!(got);
+    assert_eq!(got.len(), BULK_LEN, "bulk receive got {} bytes, want {}", got.len(), BULK_LEN);
+    assert!(got.iter().all(|&b| b == FILL), "bulk stream content corrupted over the wire");
+}
+
+/// cross-host real NXDOMAIN: a name the peer's dnsd does not serve must fail to
+/// resolve. std maps the failed lookup to InvalidInput "DNS failure" (or an
+/// empty address set); an unresolved name reading back as success fails here.
+pub fn dns_unknown_name_errors() {
+    let hostport = "no-such-host.test:80".to_string();
+    let result = bounded("dns lookup of an unknown name", 20, move || {
+        hostport.to_socket_addrs().map(|it| it.collect::<Vec<_>>())
+    });
+    match result {
+        Ok(addrs) if addrs.is_empty() => {} // an empty success is also "no address"
+        Ok(addrs) => panic!("unknown name resolved to {:?}, want a lookup failure", addrs),
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::InvalidInput,
+            "unknown-name lookup failed with {:?} ({}), want InvalidInput",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+pub const TESTS: &[TestEntry] = &[
+    ("cross_host::dhcp_lease_from_peer", dhcp_lease_from_peer as fn()),
+    ("cross_host::tcp_echo_to_peer", tcp_echo_to_peer as fn()),
+    ("cross_host::tcp_bulk_receive_from_peer", tcp_bulk_receive_from_peer as fn()),
+    ("cross_host::connect_refused_from_peer", connect_refused_from_peer as fn()),
+    ("cross_host::udp_echo_to_peer", udp_echo_to_peer as fn()),
+    ("cross_host::dns_resolve_peer_records", dns_resolve_peer_records as fn()),
+    ("cross_host::dns_unknown_name_errors", dns_unknown_name_errors as fn()),
+];
+
+pub const XFAILS: &[XfailEntry] = &[];

--- a/services/net-tests/src/tests/dns.rs
+++ b/services/net-tests/src/tests/dns.rs
@@ -1,0 +1,499 @@
+//! dns theme: the resolver/decoder chain behind `ToSocketAddrs`, exercised
+//! hermetically with a fake DNS resolver bound inside the DUT. Lookups run the
+//! full std path (to_socket_addrs -> LookupHost -> dns RawLookup IPC ->
+//! resolver UDP query). Port 53 is the one deliberately REUSED port (the
+//! resolver always queries <dns1>:53); each test binds it to self_ip on the
+//! test thread before the lookup and drops it inline before asserting, always
+//! answers its one query (an unanswered query wedges the single-threaded dns
+//! loop, #880), and uses a unique hostname (lookups cache forever).
+
+use std::io::{self, ErrorKind};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream, ToSocketAddrs, UdpSocket};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use crate::harness::{bounded, check, discard, next_port, self_ip};
+use crate::tests::{TestEntry, XfailEntry};
+
+// ---------------------------------------------------------------------------
+// DNS wire-format response builders.
+// ---------------------------------------------------------------------------
+
+/// Build a wire-format DNS response header.
+/// id: 2 bytes; flags: 0x8180 (QR=1, RD=1, RA=1, RCODE=0);
+/// qdcount=1, `ancount`, nscount=0, arcount=0.
+fn header(id: u16, ancount: u16) -> Vec<u8> { header_with_flags(id, 0x8180, ancount) }
+
+/// `header` with caller-chosen flags, for rcode != 0 shapes (e.g. NXDOMAIN).
+fn header_with_flags(id: u16, flags: u16, ancount: u16) -> Vec<u8> {
+    let mut h = Vec::new();
+    h.extend_from_slice(&id.to_be_bytes());
+    h.extend_from_slice(&flags.to_be_bytes());
+    h.extend_from_slice(&1u16.to_be_bytes()); // qdcount
+    h.extend_from_slice(&ancount.to_be_bytes());
+    h.extend_from_slice(&0u16.to_be_bytes()); // nscount
+    h.extend_from_slice(&0u16.to_be_bytes()); // arcount
+    h
+}
+
+/// Encode a domain name as DNS wire labels terminated by a null byte.
+fn encode_name(name: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for label in name.split('.') {
+        buf.push(label.len() as u8);
+        buf.extend_from_slice(label.as_bytes());
+    }
+    buf.push(0);
+    buf
+}
+
+/// Build the question section: name + qtype + qclass.
+fn question(name: &str) -> Vec<u8> {
+    let mut q = encode_name(name);
+    q.extend_from_slice(&1u16.to_be_bytes()); // qtype = A
+    q.extend_from_slice(&1u16.to_be_bytes()); // qclass = IN
+    q
+}
+
+/// An A record with a compressed-pointer name.
+/// `name_offset` is the absolute offset in the datagram of the name to
+/// point to (typically 12 for the qname, but can be any valid offset).
+fn a_record(name_offset: u16, ttl: u32, ip: [u8; 4]) -> Vec<u8> {
+    let mut rr = Vec::new();
+    // Compressed pointer: high 2 bits = 11, remaining 14 bits = offset
+    let ptr = 0xc000 | (name_offset & 0x3fff);
+    rr.extend_from_slice(&ptr.to_be_bytes());
+    rr.extend_from_slice(&1u16.to_be_bytes()); // type A
+    rr.extend_from_slice(&1u16.to_be_bytes()); // class IN
+    rr.extend_from_slice(&ttl.to_be_bytes());
+    rr.extend_from_slice(&4u16.to_be_bytes()); // rdlength
+    rr.extend_from_slice(&ip);
+    rr
+}
+
+/// A CNAME record with a compressed-pointer name and an inline canonical
+/// name (no further compression in the RDATA, for test simplicity).
+fn cname_record(name_offset: u16, ttl: u32, canonical: &str) -> Vec<u8> {
+    let mut rr = Vec::new();
+    let ptr = 0xc000 | (name_offset & 0x3fff);
+    rr.extend_from_slice(&ptr.to_be_bytes());
+    rr.extend_from_slice(&5u16.to_be_bytes()); // type CNAME
+    rr.extend_from_slice(&1u16.to_be_bytes()); // class IN
+    rr.extend_from_slice(&ttl.to_be_bytes());
+    let rdata = encode_name(canonical);
+    rr.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
+    rr.extend_from_slice(&rdata);
+    rr
+}
+
+/// An NS record (type 2) — exercises "skip unknown type via rdlength".
+fn ns_record(name_offset: u16, ttl: u32, ns_name: &str) -> Vec<u8> {
+    let mut rr = Vec::new();
+    let ptr = 0xc000 | (name_offset & 0x3fff);
+    rr.extend_from_slice(&ptr.to_be_bytes());
+    rr.extend_from_slice(&2u16.to_be_bytes()); // type NS
+    rr.extend_from_slice(&1u16.to_be_bytes()); // class IN
+    rr.extend_from_slice(&ttl.to_be_bytes());
+    let rdata = encode_name(ns_name);
+    rr.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
+    rr.extend_from_slice(&rdata);
+    rr
+}
+
+// ---------------------------------------------------------------------------
+// Fake-resolver harness
+// ---------------------------------------------------------------------------
+
+/// Handle to a one-shot fake-resolver worker (mirrors `harness::EchoServer`).
+struct FakeResolver {
+    done: mpsc::Receiver<(UdpSocket, Result<(), String>)>,
+}
+
+impl FakeResolver {
+    /// Reap the worker: drops the port-53 socket inline (UDP closes are
+    /// synchronous — this frees the port for the next dns test), then returns
+    /// the worker's outcome. On reap timeout the worker, and port 53 with it,
+    /// leak.
+    fn finish(self) -> Result<(), String> {
+        match self.done.recv_timeout(Duration::from_secs(10)) {
+            Ok((sock, outcome)) => {
+                drop(sock);
+                outcome
+            }
+            Err(_) => Err("fake resolver did not finish within 10 s \
+                 (worker and port 53 leaked; later dns tests may fail to bind it)"
+                .to_string()),
+        }
+    }
+}
+
+/// Reap a fake-resolver worker, panicking if it failed — its diagnostics beat
+/// the lookup error it usually causes. Call between collecting the lookup
+/// result and asserting on it (collect-discard-assert).
+fn reap(resolver: FakeResolver) {
+    if let Err(e) = resolver.finish() {
+        panic!("fake resolver: {}", e);
+    }
+}
+
+/// Bind (self_ip, 53) ON THE TEST THREAD — the resolver must be listening
+/// before the lookup, or the query lands on an unbound port and the dns
+/// resolver recv parks forever (#880) — then serve ONE query on a worker
+/// thread: parse the 2-byte transaction id, hand it to `shapes`, and send each
+/// returned datagram back in order. The socket rides back through the channel
+/// so a worker-side drop cannot race the reap.
+fn fake_resolver(shapes: impl FnOnce(u16) -> Vec<Vec<u8>> + Send + 'static) -> FakeResolver {
+    let sock = match UdpSocket::bind(SocketAddr::new(self_ip(), 53)) {
+        Ok(s) => s,
+        Err(e) => panic!(
+            "bind of the fake resolver on {}:53 failed ({}); an earlier dns test likely leaked the port",
+            self_ip(),
+            e
+        ),
+    };
+    // Post-#880-fix safety net so a query-less worker can exit on its own; on
+    // dev a quiet socket never fires this timeout (NTC-1) and the worker leaks.
+    check!(sock.set_read_timeout(Some(Duration::from_secs(15))));
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let outcome = (|| {
+            let mut buf = [0u8; 512]; // DNS_PKT_MAX_LEN; queries are far smaller
+            let (len, peer) = sock.recv_from(&mut buf).map_err(|e| format!("recv_from(query): {}", e))?;
+            if len < 2 {
+                return Err(format!("runt query: {} bytes", len));
+            }
+            let id = u16::from_be_bytes([buf[0], buf[1]]);
+            log::info!("fake resolver: query id={:#06x} len={} from {}", id, len, peer);
+            for (seq, dgram) in shapes(id).into_iter().enumerate() {
+                sock.send_to(&dgram, peer).map_err(|e| format!("send_to(response {}): {}", seq, e))?;
+            }
+            Ok(())
+        })();
+        tx.send((sock, outcome)).ok();
+    });
+    FakeResolver { done: rx }
+}
+
+/// Resolve "<name>:<port>" through the full std chain, collected to a Vec.
+/// Bounded: on dev an unanswerable query parks the dns service's resolver
+/// recv forever (#880), which parks this lookup with it.
+fn std_lookup(name: &'static str, port: u16) -> io::Result<Vec<SocketAddr>> {
+    let desc = format!("std lookup of {}", name);
+    bounded(&desc, 20, move || {
+        format!("{}:{}", name, port).to_socket_addrs().map(|iter| iter.collect::<Vec<_>>())
+    })
+}
+
+/// Assert a lookup succeeded and returned exactly `ips` (as an unordered set:
+/// the dns service stores answers in a HashMap, so order is unspecified) with
+/// `port` propagated onto every address.
+fn assert_resolves_to(result: io::Result<Vec<SocketAddr>>, ips: &[[u8; 4]], port: u16) {
+    let addrs = match result {
+        Ok(addrs) => addrs,
+        Err(e) => {
+            panic!("lookup failed with {} (kind {:?}), want {} address(es)", e, e.kind(), ips.len())
+        }
+    };
+    assert_eq!(addrs.len(), ips.len(), "expected {} address(es), got {:?}", ips.len(), addrs);
+    for &ip in ips {
+        let want = SocketAddr::new(IpAddr::V4(Ipv4Addr::from(ip)), port);
+        assert!(addrs.contains(&want), "lookup result {:?} is missing {}", addrs, want);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// "localhost:<port>" resolves to 127.0.0.1:<port> with no network traffic —
+/// the dns service special-cases the name ahead of cache and resolver. Also the
+/// end-to-end canary for the ToSocketAddrs -> LookupHost -> RawLookup path.
+pub fn dns_localhost_builtin() {
+    let port = next_port(); // never bound — only propagated through the lookup
+    let result = bounded("localhost lookup", 20, move || {
+        format!("localhost:{}", port).to_socket_addrs().map(|iter| iter.collect::<Vec<_>>())
+    });
+    let addrs = check!(result);
+    assert_eq!(
+        addrs,
+        vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)],
+        "localhost must resolve to exactly 127.0.0.1 with the port propagated"
+    );
+}
+
+/// A numeric "ip:port" string parses entirely client-side (std tries a
+/// SocketAddr parse before any resolution), so it works even with the dns
+/// service wedged — deliberately unguarded, registered ahead of resolver tests.
+pub fn dns_numeric_addr_bypasses_resolver() {
+    let port = next_port();
+    let want = SocketAddr::new(self_ip(), port);
+    let addrs: Vec<SocketAddr> = check!(format!("{}:{}", self_ip(), port).to_socket_addrs()).collect();
+    assert_eq!(addrs, vec![want], "numeric addr string must parse verbatim, no DNS involved");
+}
+
+/// A plain all-A response with every answer name compressed to the qname
+/// (offset 0x0c) resolves to all records, port propagated — the positive
+/// control proving the fake-resolver rig before the parser tests run.
+pub fn dns_a_record_response_ok() {
+    const NAME: &str = "t3.a.test";
+    const IPS: [[u8; 4]; 3] = [[192, 0, 2, 1], [192, 0, 2, 2], [192, 0, 2, 3]];
+    let port = next_port();
+    let resolver = fake_resolver(move |id| {
+        let mut dgram = header(id, IPS.len() as u16);
+        dgram.extend_from_slice(&question(NAME));
+        for &ip in &IPS {
+            dgram.extend_from_slice(&a_record(12, 255, ip));
+        }
+        vec![dgram]
+    });
+    let result = std_lookup(NAME, port);
+    reap(resolver);
+    assert_resolves_to(result, &IPS, port);
+}
+
+/// A CNAME + A response whose A records compress to a mid-message offset must
+/// resolve to the A records: the resolver chases the CNAME server-side, so the
+/// client only skips the CNAME and follows the non-qname pointer.
+/// XFAIL: dev's answer walker rejects non-{A,AAAA} types and offsets != 0x0c as FormatError, services/dns/src/main.rs:140-159.
+pub fn dns_cname_chain_response() {
+    const NAME: &str = "t4.cn.test";
+    const IPS: [[u8; 4]; 2] = [[198, 51, 100, 7], [198, 51, 100, 8]];
+    let port = next_port();
+    let resolver = fake_resolver(move |id| {
+        let mut dgram = header(id, 3);
+        dgram.extend_from_slice(&question(NAME));
+        // The A records' names point at the canonical name stored inside the
+        // CNAME's RDATA — a non-qname offset. The RDATA starts 12 bytes into
+        // the CNAME record (2 ptr + 2 type + 2 class + 4 ttl + 2 rdlength),
+        // and the answer section starts at the current end of the datagram.
+        let canonical_offset = (dgram.len() + 12) as u16;
+        dgram.extend_from_slice(&cname_record(12, 296, "canon.t4.cn.test"));
+        for &ip in &IPS {
+            dgram.extend_from_slice(&a_record(canonical_offset, 296, ip));
+        }
+        vec![dgram]
+    });
+    let result = std_lookup(NAME, port);
+    reap(resolver);
+    assert_resolves_to(result, &IPS, port);
+}
+
+/// A non-address record (NS=2) in the answer section must be skipped via its
+/// rdlength, not treated as fatal; the A record after it still resolves.
+/// XFAIL: dev's walker rejects any type not in {A,AAAA} as FormatError, services/dns/src/main.rs:156-159.
+pub fn dns_ns_in_answer_tolerated() {
+    const NAME: &str = "t5.ns.test";
+    const IPS: [[u8; 4]; 1] = [[192, 0, 2, 53]];
+    let port = next_port();
+    let resolver = fake_resolver(move |id| {
+        let mut dgram = header(id, 2);
+        dgram.extend_from_slice(&question(NAME));
+        dgram.extend_from_slice(&ns_record(12, 60, "ns1.t5.ns.test"));
+        dgram.extend_from_slice(&a_record(12, 60, IPS[0]));
+        vec![dgram]
+    });
+    let result = std_lookup(NAME, port);
+    reap(resolver);
+    assert_resolves_to(result, &IPS, port);
+}
+
+/// A response whose question section carries a bogus qclass (99) must be
+/// rejected as malformed; through std the failure surfaces as InvalidInput
+/// "DNS failure".
+pub fn dns_bad_qclass_rejected() {
+    const NAME: &str = "t6.qc.test";
+    let port = next_port();
+    let resolver = fake_resolver(move |id| {
+        // Ported from 4012f51bd's rejects_bad_qclass; the question section is
+        // built inline because question() hardcodes the valid qclass.
+        let mut dgram = header(id, 0);
+        dgram.extend_from_slice(&encode_name(NAME));
+        dgram.extend_from_slice(&1u16.to_be_bytes()); // qtype = A
+        dgram.extend_from_slice(&99u16.to_be_bytes()); // qclass = bogus
+        vec![dgram]
+    });
+    let result = std_lookup(NAME, port);
+    reap(resolver);
+    match result {
+        Ok(addrs) => panic!("bad-qclass response unexpectedly resolved to {:?}", addrs),
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::InvalidInput,
+            "DNS failure surfaced as {:?} ({}), want InvalidInput (E-14 pin)",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// DANGER — NOT REGISTERED: a response whose rdata is shorter than its rdlength
+/// must be rejected as a clean FormatError. Disabled because on dev the answer
+/// walker slices past the datagram end (unchecked indexing) and PANICS the dns
+/// service, which the CI driver treats as a hard failure and wedges later lookups.
+#[allow(dead_code)]
+pub fn dns_truncated_rdata_disabled() {
+    const NAME: &str = "t7.tr.test";
+    let port = next_port();
+    let resolver = fake_resolver(move |id| {
+        let mut dgram = header(id, 1);
+        dgram.extend_from_slice(&question(NAME));
+        // An A record truncated mid-rdata: rdlength promises 4 bytes, the
+        // datagram ends after 2.
+        dgram.push(0xc0);
+        dgram.push(0x0c);
+        dgram.extend_from_slice(&1u16.to_be_bytes()); // type A
+        dgram.extend_from_slice(&1u16.to_be_bytes()); // class IN
+        dgram.extend_from_slice(&60u32.to_be_bytes()); // ttl
+        dgram.extend_from_slice(&4u16.to_be_bytes()); // rdlength = 4
+        dgram.extend_from_slice(&[1, 2]); // ...but only 2 bytes of rdata
+        vec![dgram]
+    });
+    let result = std_lookup(NAME, port);
+    reap(resolver);
+    match result {
+        Ok(addrs) => panic!("truncated response unexpectedly resolved to {:?}", addrs),
+        Err(e) => log::info!("truncated response rejected cleanly: {} (kind {:?})", e, e.kind()),
+    }
+}
+
+/// An A record whose rdlength is not 4 violates the RR contract, so the lookup
+/// must fail — both dev and the fix reject it (all 8 bytes present, no
+/// truncation in play).
+pub fn dns_a_rdlength_not_4() {
+    const NAME: &str = "t8.len.test";
+    let port = next_port();
+    let resolver = fake_resolver(move |id| {
+        // Ported from 4012f51bd's rejects_length_mismatched_a_record.
+        let mut dgram = header(id, 1);
+        dgram.extend_from_slice(&question(NAME));
+        dgram.push(0xc0);
+        dgram.push(0x0c);
+        dgram.extend_from_slice(&1u16.to_be_bytes()); // type A
+        dgram.extend_from_slice(&1u16.to_be_bytes()); // class IN
+        dgram.extend_from_slice(&60u32.to_be_bytes()); // ttl
+        dgram.extend_from_slice(&8u16.to_be_bytes()); // rdlength = 8 (wrong)
+        dgram.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        vec![dgram]
+    });
+    let result = std_lookup(NAME, port);
+    reap(resolver);
+    match result {
+        Ok(addrs) => panic!("length-mismatched A record unexpectedly resolved to {:?}", addrs),
+        Err(e) => log::info!("rdlength != 4 rejected as the contract requires: {} (kind {:?})", e, e.kind()),
+    }
+}
+
+/// A NOERROR response with zero answers must surface as a lookup error
+/// (getaddrinfo EAI_NODATA analog), never as a success carrying no addresses;
+/// the error kind is left unconstrained (platform-defined).
+/// XFAIL: dev encodes an empty resolve as SUCCESS entry_count=0 and caches it, so the lookup returns Ok([]), services/dns/src/main.rs:401-444.
+pub fn dns_zero_answers_is_error() {
+    const NAME: &str = "t10.zero.test";
+    let port = next_port();
+    let resolver = fake_resolver(move |id| {
+        let mut dgram = header(id, 0); // NOERROR flags, ancount = 0
+        dgram.extend_from_slice(&question(NAME));
+        vec![dgram]
+    });
+    let result = std_lookup(NAME, port);
+    reap(resolver);
+    match result {
+        Ok(addrs) => {
+            panic!("zero-answer NOERROR response must be a lookup error, got Ok({:?})", addrs)
+        }
+        Err(e) => {
+            log::info!("zero-answer response errored as the contract requires: {} (kind {:?})", e, e.kind())
+        }
+    }
+}
+
+/// An unresolvable name reached through TcpStream::connect("<name>:<port>")
+/// fails with kind InvalidInput — the xous pin for DNS failures. The kind is
+/// asserted, not the message; either funnel yields no address so connect never dials.
+pub fn dns_error_kind_via_std() {
+    const NAME: &str = "t11.nx.test";
+    let port = next_port();
+    let resolver = fake_resolver(move |id| {
+        // NXDOMAIN shape: QR|RD|RA with rcode=3, zero answers, question echoed.
+        let mut dgram = header_with_flags(id, 0x8183, 0);
+        dgram.extend_from_slice(&question(NAME));
+        vec![dgram]
+    });
+    let result = bounded("connect to an unresolvable name", 20, move || {
+        TcpStream::connect(format!("{}:{}", NAME, port))
+    });
+    reap(resolver);
+    match result {
+        Ok(stream) => {
+            discard(stream);
+            panic!("connect to an NXDOMAIN-answered name unexpectedly succeeded");
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::InvalidInput,
+            "DNS failure through connect surfaced as {:?} ({}), want InvalidInput (E-14 pin)",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// A response with a mismatched transaction id must not satisfy the query: the
+/// resolver keeps listening and returns the right-id answer. The worker sends a
+/// wrong-id decoy then the right-id answer; registered LAST (see the drain below).
+/// XFAIL: dev does a single recv per lookup, so an id mismatch errors immediately, services/dns/src/main.rs:351-367.
+pub fn dns_wrong_txn_id_ignored() {
+    const NAME: &str = "t9.id.test";
+    const DECOY_IP: [u8; 4] = [192, 0, 2, 66];
+    const REAL_IP: [u8; 4] = [192, 0, 2, 99];
+    let port = next_port();
+    let resolver = fake_resolver(move |id| {
+        let wrong_id = id ^ 0xa5a5; // xor with a nonzero constant: never equal to id
+        let mut wrong = header(wrong_id, 1);
+        wrong.extend_from_slice(&question(NAME));
+        wrong.extend_from_slice(&a_record(12, 60, DECOY_IP));
+        let mut right = header(id, 1);
+        right.extend_from_slice(&question(NAME));
+        right.extend_from_slice(&a_record(12, 60, REAL_IP));
+        vec![wrong, right]
+    });
+    let result = std_lookup(NAME, port);
+    let worker = resolver.finish();
+    if result.is_err() && worker.is_ok() {
+        // Dev deviation path: exactly one stale (right-id) datagram is queued
+        // on the resolver socket — consume it before any assert can panic.
+        let drained = bounded("drain of the stale right-id datagram", 20, move || {
+            "t9drain.id.test:80".to_socket_addrs().map(|iter| iter.count())
+        });
+        log::info!("drain lookup returned {:?} (outcome irrelevant; the queue is clean either way)", drained);
+    }
+    if let Err(e) = worker {
+        panic!("fake resolver: {}", e);
+    }
+    assert_resolves_to(result, &[REAL_IP], port);
+}
+
+/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// Ordering is load-bearing: the resolver-free canaries come first, then the
+/// positive-control rig test, and dns_wrong_txn_id_ignored stays LAST;
+/// dns_truncated_rdata_disabled is DANGER-disabled and deliberately absent.
+pub const TESTS: &[TestEntry] = &[
+    ("dns::dns_localhost_builtin", dns_localhost_builtin as fn()),
+    ("dns::dns_numeric_addr_bypasses_resolver", dns_numeric_addr_bypasses_resolver as fn()),
+    ("dns::dns_a_record_response_ok", dns_a_record_response_ok as fn()),
+    ("dns::dns_cname_chain_response", dns_cname_chain_response as fn()),
+    ("dns::dns_ns_in_answer_tolerated", dns_ns_in_answer_tolerated as fn()),
+    ("dns::dns_bad_qclass_rejected", dns_bad_qclass_rejected as fn()),
+    ("dns::dns_a_rdlength_not_4", dns_a_rdlength_not_4 as fn()),
+    ("dns::dns_zero_answers_is_error", dns_zero_answers_is_error as fn()),
+    ("dns::dns_error_kind_via_std", dns_error_kind_via_std as fn()),
+    ("dns::dns_wrong_txn_id_ignored", dns_wrong_txn_id_ignored as fn()),
+];
+
+pub const XFAILS: &[XfailEntry] = &[
+    ("dns::dns_cname_chain_response", "NTC-12"),
+    ("dns::dns_ns_in_answer_tolerated", "NTC-12"),
+    ("dns::dns_zero_answers_is_error", "NTC-17"),
+    ("dns::dns_wrong_txn_id_ignored", "NTC-18"),
+];

--- a/services/net-tests/src/tests/errors.rs
+++ b/services/net-tests/src/tests/errors.rs
@@ -1,0 +1,368 @@
+//! errors theme — io::Error kinds and error-path contracts of std::net.
+//!
+//! Error KINDS on xous are a property of the (rustc 1.96.1 xous std,
+//! xous-core dev) toolchain pair, not of POSIX: every kind assertion below is
+//! pinned to that pair and a toolchain move re-opens all of them.
+
+use core::mem::ManuallyDrop;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream, UdpSocket};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::harness::{XorShift, bounded, check, discard, next_port, self_ip};
+use crate::tests::{TestEntry, XfailEntry};
+
+const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+/// Binding a TcpListener to a foreign address (1.1.1.1) fails with
+/// AddrNotAvailable: the server whitelists 0.0.0.0/127.0.0.1/DUT-IP and
+/// answers anything else with Invalid, which the bind decode maps to that kind.
+pub fn tcp_bind_foreign_addr_kind() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), next_port());
+    match TcpListener::bind(addr) {
+        Ok(l) => {
+            discard(l);
+            panic!("bind to the foreign address {} unexpectedly succeeded", addr);
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::AddrNotAvailable,
+            "foreign-address bind surfaced as {:?} ({}), want AddrNotAvailable",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// Connecting to the unspecified address 0.0.0.0 fails with AddrNotAvailable:
+/// smoltcp rejects it up front and the connect decode maps every connect
+/// failure to that kind, inside the contract's allowed set.
+pub fn tcp_connect_unspecified_addr_kind() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), next_port());
+    let result = bounded("connect to 0.0.0.0", 10, move || TcpStream::connect(addr));
+    match result {
+        Ok(s) => {
+            discard(s);
+            panic!("connect to the unspecified address {} unexpectedly succeeded", addr);
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::AddrNotAvailable,
+            "connect to 0.0.0.0 surfaced as {:?} ({}), want AddrNotAvailable",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// accept() on a nonblocking listener with no pending connection returns
+/// WouldBlock: the server's nonblocking-accept path writes the code at byte 1,
+/// where the pinned client's accept-error decode reads it.
+pub fn tcp_nonblocking_accept_wouldblock() {
+    let addr = SocketAddr::new(LOOPBACK, next_port());
+    let listener = check!(TcpListener::bind(addr));
+    check!(listener.set_nonblocking(true));
+    // guarded: if the nonblocking flag were dropped on the wire, accept would
+    // park forever (accept has no timeout surface, TO-12)
+    let (result, listener) = bounded("nonblocking accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    discard(listener);
+    match result {
+        Ok((s, peer)) => {
+            discard(s);
+            panic!("nonblocking accept with no pending connection returned a stream from {}", peer);
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::WouldBlock,
+            "nonblocking accept surfaced as {:?} ({}), want WouldBlock",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// peek() on a nonblocking stream with an empty rx queue returns WouldBlock
+/// immediately, then sees the byte once the peer writes: TCP rx/peek errors
+/// mirror the code at bytes 1 and 4, so the client's rx decode reads it.
+pub fn tcp_nonblocking_peek_wouldblock() {
+    let addr = SocketAddr::new(LOOPBACK, next_port());
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (mut served, _peer) = check!(accepted);
+    check!(client.set_nonblocking(true));
+    // nonblocking peeks return immediately, so they are safe on the test thread
+    let started = Instant::now();
+    let mut buf = [0u8; 8];
+    let first = client.peek(&mut buf);
+    let first_elapsed = started.elapsed();
+    let write_res = served.write_all(&[0x5a]);
+    // poll for the byte; collect the outcome, defer the verdict until after
+    // the sockets are discarded
+    let mut polled = None;
+    let mut tries = 0u32;
+    while tries < 20 {
+        match client.peek(&mut buf) {
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                tries += 1;
+                if tries % 5 == 0 {
+                    log::info!("nonblocking peek poll {}: still WouldBlock", tries);
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+            other => {
+                polled = Some(other);
+                break;
+            }
+        }
+    }
+    let got = buf[0];
+    discard(client);
+    discard(served);
+    discard(listener);
+    match first {
+        Ok(n) => panic!("nonblocking peek with no pending data returned Ok({})", n),
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::WouldBlock,
+            "nonblocking peek surfaced as {:?} ({}), want WouldBlock",
+            e.kind(),
+            e
+        ),
+    }
+    assert!(
+        first_elapsed < Duration::from_secs(1),
+        "nonblocking peek took {:?}, want immediate",
+        first_elapsed
+    );
+    check!(write_res);
+    match polled {
+        Some(Ok(1)) => assert_eq!(got, 0x5a, "wrong byte after nonblocking peek poll"),
+        Some(Ok(n)) => panic!("nonblocking peek returned Ok({}), want exactly 1 byte", n),
+        Some(Err(e)) => panic!("nonblocking peek failed: {}", e),
+        None => panic!("data never arrived within 20 nonblocking peeks"),
+    }
+}
+
+/// recv_from() on a nonblocking UDP socket with no queued datagram returns
+/// WouldBlock immediately: the code is written at byte 1, where the pinned
+/// client's UDP-rx decode reads it. Bound to self_ip() (no UDP loopback).
+pub fn udp_nonblocking_recv_wouldblock() {
+    let addr = SocketAddr::new(self_ip(), next_port());
+    let socket = check!(UdpSocket::bind(addr));
+    check!(socket.set_nonblocking(true));
+    // guarded: if the nonblocking request byte were dropped on the wire, the
+    // recv would park forever on the empty socket
+    let (result, elapsed, socket) = bounded("nonblocking recv_from", 10, move || {
+        let started = Instant::now();
+        let mut buf = [0u8; 32];
+        let r = socket.recv_from(&mut buf);
+        (r, started.elapsed(), socket)
+    });
+    drop(socket); // UDP drops are synchronous and safe inline
+    match result {
+        Ok((n, from)) => {
+            panic!("nonblocking recv_from on an empty socket returned {} bytes from {}", n, from)
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::WouldBlock,
+            "nonblocking recv_from surfaced as {:?} ({}), want WouldBlock",
+            e.kind(),
+            e
+        ),
+    }
+    assert!(elapsed < Duration::from_secs(1), "nonblocking recv_from took {:?}, want immediate", elapsed);
+}
+
+/// A nonblocking write with both socket buffers full (~3060 B) must return
+/// WouldBlock; it parks forever instead.
+/// XFAIL: StdTcpTx carries no nonblocking flag, so the full-buffer tx parks in tcp_tx_waiting with no expiry, services/net/src/main.rs.
+pub fn tcp_nonblocking_write_wouldblock() {
+    let addr = SocketAddr::new(LOOPBACK, next_port());
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    check!(client.set_nonblocking(true));
+    // the peer must stay open (and never read) through the write loop, and
+    // the expected-failure path (NTC-10) panics out of the bounded call right
+    // past this frame: park the peer sockets in ManuallyDrop so the unwind
+    // cannot block on a close (NTC-5) — they leak on the panic path and are
+    // discarded on the happy path
+    let served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    let (outcome, total, client) = bounded("nonblocking write until WouldBlock", 15, move || {
+        let mut client = client;
+        let mut chunk = [0u8; 512];
+        XorShift::new(0xE8).fill(&mut chunk);
+        let mut total = 0usize;
+        let mut outcome = None;
+        // 20 * 512 B = 10240 B >> 3060 B of buffering: the loop must hit the
+        // full-buffer condition well before it runs out of iterations
+        for i in 0..20u32 {
+            match client.write(&chunk) {
+                Ok(n) => total += n,
+                Err(e) => {
+                    outcome = Some(e);
+                    break;
+                }
+            }
+            if (i + 1) % 5 == 0 {
+                log::info!("nonblocking write {}: {} bytes accepted so far", i + 1, total);
+            }
+        }
+        (outcome, total, client)
+    });
+    discard(client);
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    match outcome {
+        None => panic!("20 nonblocking writes ({} bytes) all succeeded on ~3060 B of buffering", total),
+        Some(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::WouldBlock,
+            "nonblocking write on full buffers surfaced as {:?} ({}) after {} accepted bytes, want WouldBlock",
+            e.kind(),
+            e,
+            total
+        ),
+    }
+}
+
+/// A write() after our own shutdown(Write) must fail; it succeeds instead.
+/// XFAIL: the shutdown handler aborts only already-parked messages and never
+/// closes the smoltcp socket, so a later StdTcpTx is accepted, services/net/src/main.rs.
+pub fn tcp_write_after_shutdown_write_errs() {
+    let addr = SocketAddr::new(LOOPBACK, next_port());
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    check!(client.shutdown(Shutdown::Write));
+    // the write should return promptly either way, but guard it — and park
+    // the peer sockets in ManuallyDrop so an unexpected bounded panic cannot
+    // unwind-drop them on the test thread (NTC-5); discarded on the happy path
+    let served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    let (result, client) = bounded("write after own shutdown(Write)", 10, move || {
+        let mut client = client;
+        let r = client.write(b"post-shutdown");
+        (r, client)
+    });
+    discard(client);
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    if let Ok(n) = result {
+        panic!("write after own shutdown(Write) succeeded with Ok({}), want an error", n);
+    }
+}
+
+/// shutdown(Read) through a clone wakes a read blocked on the same socket and
+/// makes it return Ok(0) (EOF); the woken read returns Err(Other) instead.
+/// XFAIL: the wake sets body.valid but never body.offset, so the rx decode takes the error path, services/net/src/main.rs.
+pub fn tcp_shutdown_read_wakes_blocked_read() {
+    let addr = SocketAddr::new(LOOPBACK, next_port());
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    let clone = check!(client.try_clone());
+    // hand-rolled bounded pattern (spawn + recv_timeout, as harness::bounded
+    // does internally): the shutdown must be issued from the test thread
+    // WHILE the worker's read is parked, so a single bounded() call cannot
+    // express the interleaving
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut client = client;
+        let mut buf = [0u8; 8];
+        let r = client.read(&mut buf);
+        tx.send((r, client)).ok();
+    });
+    // let the read reach the server and park in tcp_rx_waiting before the
+    // shutdown chases it
+    thread::sleep(Duration::from_millis(1500));
+    let shutdown_res = clone.shutdown(Shutdown::Read);
+    // the expected-failure path (NTC-11) panics below: park the test-thread
+    // sockets in ManuallyDrop so the unwind cannot block on a close (NTC-5) —
+    // leaked on the panic path, discarded on the happy path
+    let clone = ManuallyDrop::new(clone);
+    let served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    let woken = match rx.recv_timeout(Duration::from_secs(10)) {
+        Ok((r, client)) => {
+            discard(client);
+            Some(r)
+        }
+        // reader still parked: leak the worker thread and its socket handle
+        // (its port is never reused); the clone discard below only drops a
+        // refcount, so no close is issued against the parked handle (H-1)
+        Err(_) => None,
+    };
+    discard(ManuallyDrop::into_inner(clone));
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    check!(shutdown_res);
+    match woken {
+        None => panic!("read was not woken within 10 s of shutdown(Read) (worker thread leaked)"),
+        Some(r) => {
+            assert_eq!(check!(r), 0, "read woken by shutdown(Read) must return Ok(0) (EOF)")
+        }
+    }
+}
+
+/// take_error() returns Ok(None) on TcpStream, TcpListener, and UdpSocket:
+/// all three are client-side stubs that never store a pending error.
+pub fn take_error_none() {
+    let addr = SocketAddr::new(LOOPBACK, next_port());
+    let listener = check!(TcpListener::bind(addr));
+    // the smoltcp listener completes the handshake by itself; no accept is
+    // needed for the client to reach Established
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let udp = check!(UdpSocket::bind(SocketAddr::new(self_ip(), next_port())));
+    let stream_err = client.take_error();
+    let listener_err = listener.take_error();
+    let udp_err = udp.take_error();
+    discard(client);
+    discard(listener);
+    drop(udp); // UDP drops are synchronous and safe inline
+    assert!(check!(stream_err).is_none(), "TcpStream::take_error returned a pending error");
+    assert!(check!(listener_err).is_none(), "TcpListener::take_error returned a pending error");
+    assert!(check!(udp_err).is_none(), "UdpSocket::take_error returned a pending error");
+}
+
+/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+pub const TESTS: &[TestEntry] = &[
+    ("errors::tcp_bind_foreign_addr_kind", tcp_bind_foreign_addr_kind as fn()),
+    ("errors::tcp_connect_unspecified_addr_kind", tcp_connect_unspecified_addr_kind as fn()),
+    ("errors::tcp_nonblocking_accept_wouldblock", tcp_nonblocking_accept_wouldblock as fn()),
+    ("errors::tcp_nonblocking_peek_wouldblock", tcp_nonblocking_peek_wouldblock as fn()),
+    ("errors::udp_nonblocking_recv_wouldblock", udp_nonblocking_recv_wouldblock as fn()),
+    ("errors::tcp_nonblocking_write_wouldblock", tcp_nonblocking_write_wouldblock as fn()),
+    ("errors::tcp_write_after_shutdown_write_errs", tcp_write_after_shutdown_write_errs as fn()),
+    ("errors::tcp_shutdown_read_wakes_blocked_read", tcp_shutdown_read_wakes_blocked_read as fn()),
+    ("errors::take_error_none", take_error_none as fn()),
+];
+
+pub const XFAILS: &[XfailEntry] = &[
+    ("errors::tcp_nonblocking_write_wouldblock", "NTC-10"),
+    ("errors::tcp_write_after_shutdown_write_errs", "NTC-4"),
+    ("errors::tcp_shutdown_read_wakes_blocked_read", "NTC-11"),
+];

--- a/services/net-tests/src/tests/mod.rs
+++ b/services/net-tests/src/tests/mod.rs
@@ -1,0 +1,96 @@
+//! Test registry, plus the rules for adding a test.
+//!
+//! Each theme module owns its `TESTS` and `XFAILS` tables; this module only
+//! aggregates them. A test is a `pub fn` that panics to fail and returns to
+//! pass; register it in its theme's `TESTS`, and if it reproduces a known bug
+//! add it to `XFAILS` against an NTC id. Never weaken an assertion to make a
+//! test pass — assert the correct behavior and register the XFAIL; every XFAIL
+//! fn carries a doc stating the symptom, mechanism, and suspected code site.
+//!
+//! xous/net rules that trip up std::net habits:
+//! - Port isolation: allocate every port through `harness::next_port` and
+//!   never reuse one — the server has no SO_REUSEADDR and leaked blocked
+//!   threads keep old ports bound (a re-bind fails with SocketInUse).
+//! - HANG HAZARD: blocking calls a known bug can park forever go through
+//!   `harness::bounded`, which converts a hang into a deterministic panic.
+//! - CLOSE HAZARD: dropping a TCP socket issues a blocking close that can hang
+//!   forever, so never drop TCP sockets on the test thread — release them with
+//!   `harness::discard` (UDP drops are synchronous and safe inline). Inside a
+//!   `bounded` worker, return sockets to the test thread with the result and
+//!   discard there, in collect-discard-assert order.
+//! - A loop of >~10 socket ops must `log::info!` every ~5 iterations, or the
+//!   driver's inactivity reaper treats console silence as a dead server.
+//! - Deterministic data only: `harness::XorShift`, never the `rand` crate.
+//! - Never call `NetManager` wifi-stats/SSID-list APIs: under renode-minimal
+//!   the connection manager thread is not spawned and those requests hang.
+
+// the loopback suite and cross-host (cross-host) are mutually exclusive suites; each
+// image compiles only its own themes so the other's tests don't warn as unused.
+#[cfg(not(feature = "cross-host"))]
+pub mod concur;
+#[cfg(not(feature = "cross-host"))]
+pub mod dns;
+#[cfg(not(feature = "cross-host"))]
+pub mod errors;
+#[cfg(not(feature = "cross-host"))]
+pub mod smoke;
+#[cfg(not(feature = "cross-host"))]
+pub mod sockopts;
+#[cfg(not(feature = "cross-host"))]
+pub mod tcp;
+#[cfg(feature = "cross-host")]
+pub mod cross_host;
+#[cfg(not(feature = "cross-host"))]
+pub mod timeouts;
+#[cfg(not(feature = "cross-host"))]
+pub mod udp;
+
+/// (unique `theme::snake_case` name, test fn). A test panics to fail and
+/// returns normally to pass.
+pub type TestEntry = (&'static str, fn());
+/// (test name, NTC bug ID). A listed test that fails reports XFAIL; one that
+/// passes reports XPASS (bug apparently fixed — update the theme's table!).
+pub type XfailEntry = (&'static str, &'static str);
+
+/// Every registered test, aggregated from the theme modules. the loopback suite
+/// and cross-host (cross-host) are mutually exclusive suites sharing this harness
+/// and runner. Within loopback, `timeouts` runs LAST because it ends with the
+/// quarantined blackhole-connect tests that leak SynSent sockets toward
+/// unreachable addresses, containing any future connect-jam to the tail.
+pub fn all_tests() -> Vec<TestEntry> {
+    let mut v: Vec<TestEntry> = Vec::new();
+    #[cfg(not(feature = "cross-host"))]
+    {
+        v.extend_from_slice(smoke::TESTS);
+        v.extend_from_slice(tcp::TESTS);
+        v.extend_from_slice(udp::TESTS);
+        v.extend_from_slice(errors::TESTS);
+        v.extend_from_slice(sockopts::TESTS);
+        v.extend_from_slice(dns::TESTS);
+        v.extend_from_slice(concur::TESTS);
+        v.extend_from_slice(timeouts::TESTS);
+    }
+    #[cfg(feature = "cross-host")]
+    v.extend_from_slice(cross_host::TESTS);
+    v
+}
+
+/// The known-bug registry, aggregated from the theme modules (same suite
+/// split as all_tests).
+pub fn all_xfails() -> Vec<XfailEntry> {
+    let mut v: Vec<XfailEntry> = Vec::new();
+    #[cfg(not(feature = "cross-host"))]
+    {
+        v.extend_from_slice(smoke::XFAILS);
+        v.extend_from_slice(tcp::XFAILS);
+        v.extend_from_slice(udp::XFAILS);
+        v.extend_from_slice(errors::XFAILS);
+        v.extend_from_slice(sockopts::XFAILS);
+        v.extend_from_slice(dns::XFAILS);
+        v.extend_from_slice(concur::XFAILS);
+        v.extend_from_slice(timeouts::XFAILS);
+    }
+    #[cfg(feature = "cross-host")]
+    v.extend_from_slice(cross_host::XFAILS);
+    v
+}

--- a/services/net-tests/src/tests/smoke.rs
+++ b/services/net-tests/src/tests/smoke.rs
@@ -1,0 +1,390 @@
+//! Seed tests proving the std::net plumbing end-to-end under Renode.
+//! Assertions state the CORRECT behavior; known failures are registered in
+//! the XFAILS table below — never weaken an assertion here.
+//!
+//! Structural discipline (see also tests/mod.rs): every blocking socket op
+//! runs inside `harness::bounded`, workers hand their sockets back to the test
+//! thread BEFORE any drop, and TCP sockets are released via `harness::discard`
+//! — so neither a product hang nor a failing assert can wedge the suite (NTC-5).
+
+use core::mem::ManuallyDrop;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream, UdpSocket};
+use std::time::{Duration, Instant};
+
+use crate::harness::{XorShift, bounded, check, discard, echo_server, next_port, self_ip};
+
+const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+/// TCP echo roundtrip over 127.0.0.1: bind, connect, write, read back.
+pub fn tcp_echo_loopback() { tcp_echo_roundtrip(LOOPBACK); }
+
+/// Same roundtrip over the DUT's own (static) IP, which loops back via the
+/// dst-MAC==local path in services/net/src/device.rs.
+pub fn tcp_echo_self_ip() { tcp_echo_roundtrip(self_ip()); }
+
+fn tcp_echo_roundtrip(ip: IpAddr) {
+    let port = next_port();
+    let addr = SocketAddr::new(ip, port);
+    let listener = check!(TcpListener::bind(addr));
+    // the echo thread (and the listener it owns) leak by design: EOF-driven
+    // teardown is pinned separately by tcp_drop_close_delivers_eof (NTC-3)
+    let _server = echo_server(listener);
+    let mut client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let mut payload = vec![0u8; 1024];
+    XorShift::new(port as u32).fill(&mut payload);
+    check!(client.write_all(&payload));
+    let (result, client) = bounded("echo readback", 10, move || {
+        let mut buf = vec![0u8; 1024];
+        let r = client.read_exact(&mut buf).map(|_| buf);
+        (r, client)
+    });
+    discard(client);
+    assert_eq!(check!(result), payload, "echo payload corrupted");
+}
+
+/// A dropped (closed) TcpStream must deliver EOF to its peer: the echo
+/// server's blocking read returns Ok(0) and the thread exits.
+/// XFAIL: a reader parked in tcp_rx_waiting is never completed with EOF across CloseWait, services/net/src/main.rs NetPump.
+pub fn tcp_drop_close_delivers_eof() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let server = echo_server(listener);
+    let mut client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    check!(client.write_all(b"bye"));
+    let (result, client) = bounded("echo readback", 10, move || {
+        let mut buf = [0u8; 3];
+        let r = client.read_exact(&mut buf).map(|_| buf);
+        (r, client)
+    });
+    check!(result);
+    discard(client); // close on a worker thread; must FIN the peer
+    assert_eq!(server.wait(), 3, "echo server byte count at EOF");
+}
+
+/// One listener must serve two sequential connect/accept cycles.
+/// The listener rides in ManuallyDrop so a failing round cannot unwind-drop it
+/// on the test thread (blocking close, NTC-5); discarded on the happy path.
+pub fn tcp_accept_two_sequential() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let mut listener = ManuallyDrop::new(Some(check!(TcpListener::bind(addr))));
+    for round in 0u8..2 {
+        log::info!("accept round {}: connecting", round);
+        let mut client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+        log::info!("accept round {}: accepting", round);
+        let l = listener.take().unwrap();
+        let (accepted, l) = bounded("accept", 10, move || {
+            let r = l.accept();
+            (r, l)
+        });
+        *listener = Some(l);
+        let (served, _peer) = check!(accepted);
+        log::info!("accept round {}: exchanging", round);
+        check!(client.write_all(&[round]));
+        let (server_read, mut served) = bounded("server read", 10, move || {
+            let mut served = served;
+            let mut buf = [0u8; 1];
+            let r = served.read_exact(&mut buf).map(|_| buf[0]);
+            (r, served)
+        });
+        let reply_write = served.write_all(&[round ^ 0xff]);
+        let (client_read, client) = bounded("client read", 10, move || {
+            let mut buf = [0u8; 1];
+            let r = client.read_exact(&mut buf).map(|_| buf[0]);
+            (r, client)
+        });
+        discard(served);
+        discard(client);
+        assert_eq!(check!(server_read), round, "server read the wrong byte in round {}", round);
+        check!(reply_write);
+        assert_eq!(check!(client_read), round ^ 0xff, "client read the wrong byte in round {}", round);
+        log::info!("accept round {}: done", round);
+    }
+    discard(listener.take().unwrap());
+}
+
+/// Connecting to a port nobody listens on must fail with ConnectionRefused,
+/// quickly (the local stack RSTs the SYN over loopback).
+/// XFAIL: the connect fails up front as AddrNotAvailable via ConnectError::Unaddressable, services/net/src/std_tcpstream.rs.
+pub fn tcp_connect_refused() {
+    let addr = SocketAddr::new(self_ip(), next_port()); // never listened on
+    let started = Instant::now();
+    let result = bounded("connect to a closed port", 10, move || {
+        TcpStream::connect_timeout(&addr, Duration::from_secs(5))
+    });
+    let elapsed = started.elapsed();
+    match result {
+        Ok(s) => {
+            discard(s);
+            panic!("connect to a never-listened port unexpectedly succeeded");
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::ConnectionRefused,
+            "refused connect surfaced as {:?} ({}), want ConnectionRefused",
+            e.kind(),
+            e
+        ),
+    }
+    assert!(
+        elapsed < Duration::from_secs(4),
+        "refusal took {:?}, want well under the 5 s connect timeout",
+        elapsed
+    );
+}
+
+/// shutdown(Write) must deliver EOF to the peer: its read returns Ok(0).
+/// XFAIL: StdTcpStreamShutdown never calls socket.close(), so no FIN is
+/// emitted and the peer never sees EOF, services/net/src/main.rs.
+pub fn tcp_shutdown_write() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let mut client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    check!(client.write_all(b"x"));
+    let (first_read, served) = bounded("server read of the pre-shutdown byte", 10, move || {
+        let mut served = served;
+        let mut buf = [0u8; 1];
+        let r = served.read_exact(&mut buf);
+        (r, served)
+    });
+    check!(first_read);
+    check!(client.shutdown(Shutdown::Write));
+    // the expected-failure path panics past this frame, and client must stay
+    // open through the read (a close would race its own EOF into it): park
+    // both in ManuallyDrop so the unwind cannot block on a close (NTC-5) —
+    // they leak on the panic path and are discarded on the happy path
+    let client = ManuallyDrop::new(client);
+    let listener = ManuallyDrop::new(listener);
+    let (result, served) = bounded("read after peer shutdown(Write)", 10, move || {
+        let mut served = served;
+        let mut buf = [0u8; 8];
+        let r = served.read(&mut buf);
+        (r, served)
+    });
+    discard(served);
+    discard(ManuallyDrop::into_inner(client));
+    discard(ManuallyDrop::into_inner(listener));
+    assert_eq!(check!(result), 0, "peer read after shutdown(Write) must see EOF (Ok(0))");
+}
+
+/// Closing a TCP socket that generated no traffic must complete: dropping a
+/// never-connected listener returns promptly.
+/// XFAIL: StdTcpClose parks in tcp_tx_closing, serviced only when the pump poll() reports activity — never on a quiet socket, services/net/src/main.rs.
+pub fn tcp_close_idle_listener() {
+    let port = next_port();
+    let listener = check!(TcpListener::bind(SocketAddr::new(LOOPBACK, port)));
+    // the close IS the operation under test, so here (and only here) a drop
+    // runs inside the bounded worker itself
+    bounded("close of an idle listener", 10, move || drop(listener));
+}
+
+/// local_addr/peer_addr must be coherent across both ends of a connection.
+pub fn tcp_local_peer_addr() {
+    let port = next_port();
+    let bind_addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(bind_addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(bind_addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, accept_peer) = check!(accepted);
+    let c_local = client.local_addr();
+    let c_peer = client.peer_addr();
+    let s_local = served.local_addr();
+    let s_peer = served.peer_addr();
+    discard(client);
+    discard(served);
+    discard(listener);
+    let c_local = check!(c_local);
+    let c_peer = check!(c_peer);
+    let s_local = check!(s_local);
+    let s_peer = check!(s_peer);
+    assert_eq!(c_peer, bind_addr, "client peer_addr");
+    assert_eq!(s_local, bind_addr, "server local_addr");
+    assert_eq!(s_peer, c_local, "server peer_addr vs client local_addr");
+    assert_eq!(accept_peer, s_peer, "accept()'s peer address vs peer_addr()");
+    assert_ne!(c_local.port(), 0, "client local port was never assigned");
+}
+
+/// UDP send_to/recv_from roundtrip between two sockets bound to the DUT's own
+/// (static) IP, both directions. (UDP closes are synchronous on the server,
+/// so plain drops are safe here.)
+pub fn udp_send_recv_self_ip() { udp_roundtrip(self_ip()); }
+
+/// Same roundtrip over 127.0.0.1.
+/// XFAIL: std_udp force-rebinds every socket to iface.ipv4_addr(), so a
+/// datagram addressed to 127.0.0.1 matches no socket, services/net/src/std_udp.rs.
+pub fn udp_send_recv_loopback() { udp_roundtrip(LOOPBACK); }
+
+fn udp_roundtrip(ip: IpAddr) {
+    let port_a = next_port();
+    let port_b = next_port();
+    let a = check!(UdpSocket::bind(SocketAddr::new(ip, port_a)));
+    let b = check!(UdpSocket::bind(SocketAddr::new(ip, port_b)));
+
+    assert_eq!(check!(a.send_to(b"ping", SocketAddr::new(ip, port_b))), 4, "send_to(ping) length");
+    // contained: an undeliverable datagram parks recv_from forever
+    let (result, buf, b) = bounded("udp recv_from on b", 10, move || {
+        let mut buf = [0u8; 32];
+        let r = b.recv_from(&mut buf);
+        (r, buf, b)
+    });
+    let (n, from) = check!(result);
+    assert_eq!(&buf[..n], b"ping", "b received the wrong payload");
+    assert_eq!(from, SocketAddr::new(ip, port_a), "b saw the wrong source address");
+
+    assert_eq!(check!(b.send_to(b"pong", SocketAddr::new(ip, port_a))), 4, "send_to(pong) length");
+    let (result, buf, _a) = bounded("udp recv_from on a", 10, move || {
+        let mut buf = [0u8; 32];
+        let r = a.recv_from(&mut buf);
+        (r, buf, a)
+    });
+    let (n, from) = check!(result);
+    assert_eq!(&buf[..n], b"pong", "a received the wrong payload");
+    assert_eq!(from, SocketAddr::new(ip, port_b), "a saw the wrong source address");
+}
+
+/// A 2 s read timeout on a quiet connected socket must surface as WouldBlock
+/// or TimedOut after roughly 2 s.
+/// XFAIL: the timeout reapers run only past the pump poll() early-return that a quiet socket never trips, services/net/src/main.rs.
+pub fn tcp_read_timeout_quiet() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let mut client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    // the peer must stay open AND quiet through the read window, and the
+    // expected-failure path (NTC-1) panics right past this frame: park the
+    // peer sockets in ManuallyDrop so the unwind cannot block on a close
+    // (NTC-5) — they leak on the panic path, discarded on the happy path
+    let served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    check!(client.set_read_timeout(Some(Duration::from_secs(2))));
+    let (result, elapsed, client) = bounded("read with a 2 s timeout on a quiet socket", 8, move || {
+        let started = Instant::now();
+        let mut buf = [0u8; 8];
+        let r = client.read(&mut buf);
+        (r, started.elapsed(), client)
+    });
+    discard(client);
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    match result {
+        Ok(n) => panic!("read on a quiet socket returned Ok({}) instead of a timeout error", n),
+        Err(e) => assert!(
+            e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut,
+            "read timeout surfaced as {:?} ({}), want WouldBlock or TimedOut",
+            e.kind(),
+            e
+        ),
+    }
+    assert!(
+        elapsed >= Duration::from_millis(1500) && elapsed <= Duration::from_secs(4),
+        "read returned after {:?}, want roughly the 2 s timeout",
+        elapsed
+    );
+}
+
+/// set_nonblocking(true): a read with no pending data must return WouldBlock
+/// immediately; once the peer writes, a bounded poll loop must see the data.
+pub fn tcp_nonblocking_read_wouldblock() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let mut client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (mut served, _peer) = check!(accepted);
+    check!(client.set_nonblocking(true));
+    // nonblocking reads return immediately, so they are safe on the test thread
+    let started = Instant::now();
+    let mut buf = [0u8; 8];
+    let first = client.read(&mut buf);
+    let first_elapsed = started.elapsed();
+    let write_res = served.write_all(&[42]);
+    // poll for the byte; collect the outcome, defer the verdict until after
+    // the sockets are discarded
+    let mut polled = None;
+    let mut tries = 0u32;
+    while tries < 20 {
+        match client.read(&mut buf) {
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                tries += 1;
+                if tries % 5 == 0 {
+                    log::info!("nonblocking poll {}: still WouldBlock", tries);
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            other => {
+                polled = Some(other);
+                break;
+            }
+        }
+    }
+    let got = buf[0];
+    discard(client);
+    discard(served);
+    discard(listener);
+    match first {
+        Ok(n) => panic!("nonblocking read with no pending data returned Ok({})", n),
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::WouldBlock,
+            "nonblocking read surfaced as {:?} ({}), want WouldBlock",
+            e.kind(),
+            e
+        ),
+    }
+    assert!(
+        first_elapsed < Duration::from_secs(1),
+        "nonblocking read took {:?}, want immediate",
+        first_elapsed
+    );
+    check!(write_res);
+    match polled {
+        Some(Ok(1)) => assert_eq!(got, 42, "wrong byte after nonblocking poll"),
+        Some(Ok(n)) => panic!("nonblocking read returned Ok({}), want exactly 1 byte", n),
+        Some(Err(e)) => panic!("nonblocking read failed: {}", e),
+        None => panic!("data never arrived within 20 nonblocking polls"),
+    }
+}
+
+/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+pub const TESTS: &[(&str, fn())] = &[
+    ("smoke::tcp_echo_loopback", tcp_echo_loopback as fn()),
+    ("smoke::tcp_echo_self_ip", tcp_echo_self_ip as fn()),
+    ("smoke::tcp_drop_close_delivers_eof", tcp_drop_close_delivers_eof as fn()),
+    ("smoke::tcp_accept_two_sequential", tcp_accept_two_sequential as fn()),
+    ("smoke::tcp_connect_refused", tcp_connect_refused as fn()),
+    ("smoke::tcp_shutdown_write", tcp_shutdown_write as fn()),
+    ("smoke::tcp_close_idle_listener", tcp_close_idle_listener as fn()),
+    ("smoke::tcp_local_peer_addr", tcp_local_peer_addr as fn()),
+    ("smoke::udp_send_recv_self_ip", udp_send_recv_self_ip as fn()),
+    ("smoke::udp_send_recv_loopback", udp_send_recv_loopback as fn()),
+    ("smoke::tcp_read_timeout_quiet", tcp_read_timeout_quiet as fn()),
+    ("smoke::tcp_nonblocking_read_wouldblock", tcp_nonblocking_read_wouldblock as fn()),
+];
+
+pub const XFAILS: &[(&str, &str)] = &[
+    ("smoke::tcp_drop_close_delivers_eof", "NTC-3"),
+    ("smoke::tcp_connect_refused", "NTC-6"),
+    ("smoke::tcp_shutdown_write", "NTC-4"),
+    ("smoke::tcp_close_idle_listener", "NTC-5"),
+    ("smoke::udp_send_recv_loopback", "NTC-2"),
+    ("smoke::tcp_read_timeout_quiet", "NTC-1"),
+];

--- a/services/net-tests/src/tests/sockopts.rs
+++ b/services/net-tests/src/tests/sockopts.rs
@@ -1,0 +1,305 @@
+//! socket-option (SO_*/IP_*-level) surface — ttl, nodelay, only_v6,
+//! broadcast/multicast, the nonblocking flag, and IPv6 rejection. All
+//! assertions state the correct/documented behavior; see tests/mod.rs for the
+//! shared discipline (port isolation, hang/close hazards, collect-discard-
+//! assert). No test here is XFAIL-registered: each is an as-is PASS or a
+//! deviation-pin (asserting documented xous behavior), plus one PROBE
+//! (ipv6_surface_rejected) whose UDP-v6 sub-case has no allocated bug id.
+
+use std::io::{self, ErrorKind};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream, UdpSocket};
+
+use crate::harness::{bounded, check, discard, next_port, self_ip};
+
+const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+/// set_ttl(100) then ttl()==100 round-trips on a live TcpStream, TcpListener,
+/// and UdpSocket alike — the server dispatches all three to one StdSetTtl/
+/// StdGetTtl opcode pair, so this also covers fd/type dispatch.
+pub fn ttl_roundtrip_stream_listener_udp() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+
+    let client_set = client.set_ttl(100);
+    let client_get = client.ttl();
+    let listener_set = listener.set_ttl(100);
+    let listener_get = listener.ttl();
+
+    discard(client);
+    discard(served);
+    discard(listener);
+
+    check!(client_set);
+    assert_eq!(check!(client_get), 100, "TcpStream ttl round-trip");
+    check!(listener_set);
+    assert_eq!(check!(listener_get), 100, "TcpListener ttl round-trip");
+
+    // Independent UDP leg — synchronous drop, no hazard, no discard() needed.
+    let udp_port = next_port();
+    let udp = check!(UdpSocket::bind(SocketAddr::new(self_ip(), udp_port)));
+    check!(udp.set_ttl(100));
+    assert_eq!(check!(udp.ttl()), 100, "UdpSocket ttl round-trip");
+}
+
+/// Deviation-pin: unlike Linux (EINVAL), set_ttl(0) succeeds and ttl() reads
+/// back 64 — the server maps ttl==0 to smoltcp's default hop limit rather than
+/// forwarding a literal 0 (which would trip smoltcp's panic-on-zero).
+pub fn ttl_zero_reads_back_default() {
+    let port = next_port();
+    let udp = check!(UdpSocket::bind(SocketAddr::new(self_ip(), port)));
+    check!(udp.set_ttl(0));
+    assert_eq!(check!(udp.ttl()), 64, "ttl(0) must read back as the smoltcp default (64), not 0");
+}
+
+/// set_ttl(256) fails InvalidInput before reaching the server — TTL is a
+/// single wire byte, so out-of-range values are rejected client-side, same
+/// as every other std::net platform backend.
+pub fn ttl_gt_255_invalid_input() {
+    let port = next_port();
+    let udp = check!(UdpSocket::bind(SocketAddr::new(self_ip(), port)));
+    match udp.set_ttl(256) {
+        Ok(()) => panic!("set_ttl(256) unexpectedly succeeded"),
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::InvalidInput,
+            "set_ttl(256) surfaced as {:?} ({}), want InvalidInput",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// nodelay() defaults to false (Nagle enabled); set_nodelay(true)/false
+/// round-trips.
+pub fn nodelay_default_and_roundtrip() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+
+    let default = client.nodelay();
+    let set_true = client.set_nodelay(true);
+    let after_true = client.nodelay();
+    let set_false = client.set_nodelay(false);
+    let after_false = client.nodelay();
+
+    discard(client);
+    discard(served);
+    discard(listener);
+
+    assert_eq!(check!(default), false, "nodelay default should be false (Nagle enabled by default)");
+    check!(set_true);
+    assert_eq!(check!(after_true), true, "nodelay after set_nodelay(true)");
+    check!(set_false);
+    assert_eq!(check!(after_false), false, "nodelay after set_nodelay(false)");
+}
+
+/// UDP broadcast/multicast has no smoltcp backing and no server opcode: all
+/// 12 methods in this surface fail Unsupported client-side, without ever
+/// reaching the server.
+pub fn udp_broadcast_multicast_unsupported() {
+    let port = next_port();
+    let udp = check!(UdpSocket::bind(SocketAddr::new(self_ip(), port)));
+    let v4_group = Ipv4Addr::new(224, 0, 0, 1);
+    let v4_iface = Ipv4Addr::UNSPECIFIED;
+    let v6_group = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1);
+
+    let checks: Vec<(&str, io::Result<()>)> = vec![
+        ("set_broadcast", udp.set_broadcast(true)),
+        ("broadcast", udp.broadcast().map(|_| ())),
+        ("join_multicast_v4", udp.join_multicast_v4(&v4_group, &v4_iface)),
+        ("leave_multicast_v4", udp.leave_multicast_v4(&v4_group, &v4_iface)),
+        ("join_multicast_v6", udp.join_multicast_v6(&v6_group, 0)),
+        ("leave_multicast_v6", udp.leave_multicast_v6(&v6_group, 0)),
+        ("multicast_loop_v4", udp.multicast_loop_v4().map(|_| ())),
+        ("set_multicast_loop_v4", udp.set_multicast_loop_v4(true)),
+        ("multicast_loop_v6", udp.multicast_loop_v6().map(|_| ())),
+        ("set_multicast_loop_v6", udp.set_multicast_loop_v6(true)),
+        ("multicast_ttl_v4", udp.multicast_ttl_v4().map(|_| ())),
+        ("set_multicast_ttl_v4", udp.set_multicast_ttl_v4(2)),
+    ];
+    for (i, (name, result)) in checks.into_iter().enumerate() {
+        if (i + 1) % 5 == 0 {
+            // inactivity-reaper rule: loops of >10 ops must emit output
+            log::info!("udp_broadcast_multicast_unsupported: checked {} of 12", i + 1);
+        }
+        match result {
+            Ok(()) => panic!("{} unexpectedly succeeded on xous (no smoltcp backing)", name),
+            Err(e) => assert_eq!(
+                e.kind(),
+                ErrorKind::Unsupported,
+                "{} surfaced as {:?} ({}), want Unsupported",
+                name,
+                e.kind(),
+                e
+            ),
+        }
+    }
+}
+
+/// No IPv6 stack on xous, so TcpListener::only_v6/set_only_v6 are stubbed to
+/// fail Unsupported client-side rather than reach a nonexistent server opcode.
+#[allow(deprecated)]
+pub fn listener_only_v6_unsupported() {
+    let port = next_port();
+    let listener = check!(TcpListener::bind(SocketAddr::new(LOOPBACK, port)));
+
+    let set_result = listener.set_only_v6(true);
+    let get_result = listener.only_v6();
+
+    discard(listener);
+
+    match set_result {
+        Ok(()) => panic!("set_only_v6 unexpectedly succeeded on xous (no IPv6 stack at all)"),
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::Unsupported,
+            "set_only_v6 surfaced as {:?} ({}), want Unsupported",
+            e.kind(),
+            e
+        ),
+    }
+    match get_result {
+        Ok(v) => panic!("only_v6 unexpectedly succeeded on xous, returned {}", v),
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::Unsupported,
+            "only_v6 surfaced as {:?} ({}), want Unsupported",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// set_nonblocking(true) then (false) returns Ok on every socket kind — a
+/// client-side flag only; the behavioral WouldBlock checks live in errors.
+pub fn set_nonblocking_toggle_all_types() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+
+    let listener_on = listener.set_nonblocking(true);
+    let listener_off = listener.set_nonblocking(false);
+    let client_on = client.set_nonblocking(true);
+    let client_off = client.set_nonblocking(false);
+    let served_on = served.set_nonblocking(true);
+    let served_off = served.set_nonblocking(false);
+
+    discard(client);
+    discard(served);
+    discard(listener);
+
+    check!(listener_on);
+    check!(listener_off);
+    check!(client_on);
+    check!(client_off);
+    check!(served_on);
+    check!(served_off);
+
+    // Independent UDP leg — synchronous drop, no hazard, no discard() needed.
+    let udp_port = next_port();
+    let udp = check!(UdpSocket::bind(SocketAddr::new(self_ip(), udp_port)));
+    check!(udp.set_nonblocking(true));
+    check!(udp.set_nonblocking(false));
+}
+
+/// xous is IPv4-only, so only TcpListener::bind(v6) is asserted live: the
+/// listen whitelist rejects it before any smoltcp socket exists, surfacing as
+/// AddrNotAvailable. The connect/bind v6 cases panic the service (disabled below).
+pub fn ipv6_surface_rejected() {
+    let v6_listen_port = next_port();
+    match TcpListener::bind(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), v6_listen_port)) {
+        Ok(l) => {
+            discard(l);
+            panic!("TcpListener::bind on a v6 address unexpectedly succeeded");
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::AddrNotAvailable,
+            "v6 listen bind surfaced as {:?} ({}), want AddrNotAvailable",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// DANGER — disabled, NOT registered: TcpStream::connect to an IPv6 address
+/// panics the net service. std_tcp_connect applies no v4 whitelist, so the v6
+/// remote reaches smoltcp and the next poll unwraps None during source
+/// selection. Fix: a v4-only check mirroring the listen whitelist.
+#[allow(dead_code)]
+pub fn tcp_connect_v6_panics_net_service() {
+    let v6_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), next_port());
+    match bounded("connect to a v6 address", 10, move || TcpStream::connect(v6_addr)) {
+        Ok(s) => {
+            discard(s);
+            panic!(
+                "TcpStream::connect(v6) returned Ok — the net service panics on the following poll (NTC-16)"
+            );
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::AddrNotAvailable,
+            "v6 connect surfaced as {:?} ({}), want AddrNotAvailable",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// DANGER — disabled, NOT registered: UdpSocket::bind on an IPv6 address
+/// panics the net service the same way — std_udp_bind has no whitelist, so the
+/// v6 endpoint reaches smoltcp and the next poll unwraps None. Fix: a v4-only
+/// check in std_udp_bind.
+#[allow(dead_code)]
+pub fn udp_bind_v6_panics_net_service() {
+    let v6_udp_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), next_port());
+    match UdpSocket::bind(v6_udp_addr) {
+        Ok(sock) => {
+            drop(sock);
+            panic!("UdpSocket::bind(v6) returned Ok — the net service panics on the following poll (NTC-16)");
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::AddrNotAvailable,
+            "v6 UDP bind surfaced as {:?} ({}), want AddrNotAvailable",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+pub const TESTS: &[(&str, fn())] = &[
+    ("sockopts::ttl_roundtrip_stream_listener_udp", ttl_roundtrip_stream_listener_udp as fn()),
+    ("sockopts::ttl_zero_reads_back_default", ttl_zero_reads_back_default as fn()),
+    ("sockopts::ttl_gt_255_invalid_input", ttl_gt_255_invalid_input as fn()),
+    ("sockopts::nodelay_default_and_roundtrip", nodelay_default_and_roundtrip as fn()),
+    ("sockopts::udp_broadcast_multicast_unsupported", udp_broadcast_multicast_unsupported as fn()),
+    ("sockopts::listener_only_v6_unsupported", listener_only_v6_unsupported as fn()),
+    ("sockopts::set_nonblocking_toggle_all_types", set_nonblocking_toggle_all_types as fn()),
+    ("sockopts::ipv6_surface_rejected", ipv6_surface_rejected as fn()),
+];
+
+/// No XFAILs in this theme: every registered test is an as-is PASS or a
+/// deviation-pin. The ipv6_surface_rejected UDP-v6 sub-case is an unregistered
+/// PROBE, not an XFAIL entry.
+pub const XFAILS: &[(&str, &str)] = &[];

--- a/services/net-tests/src/tests/tcp.rs
+++ b/services/net-tests/src/tests/tcp.rs
@@ -1,0 +1,1064 @@
+//! tcp theme — TCP loopback semantics beyond the smoke seeds: EOF/half-close,
+//! short writes against the 1530-byte buffers (TCP_BUFFER_SIZE = NET_MTU),
+//! peek, listener lifecycle, clones, vectored/zero-length ops, blocked writes.
+//!
+//! Live constraints (see also tests/mod.rs): accepted sockets auto-close on
+//! remote FIN (tcp_server_remote_close_poll, main.rs); idle TCP closes hang
+//! (NTC-5), so a must-be-GONE listener closes via `close_listener_with_pump_kick`
+//! and a non-load-bearing idle one is `discard`ed (worker may leak; ports never reuse).
+
+use core::mem::ManuallyDrop;
+use std::io::{ErrorKind, IoSlice, IoSliceMut, Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream, UdpSocket};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::harness::{XorShift, bounded, check, discard, echo_server, next_port, self_ip};
+use crate::tests::{TestEntry, XfailEntry};
+
+const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+/// bind + connect + accept on a fresh port; the standard three-socket fixture.
+/// Panics (via check!/bounded) on any setup failure.
+fn connected_pair() -> (TcpStream, TcpStream, TcpListener, SocketAddr) {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    (client, served, listener, addr)
+}
+
+/// Close a TCP listener and force the close to COMPLETE: StdTcpClose parks until
+/// a pump pass where iface.poll() reports activity (NTC-5), so a UDP kicker fires
+/// at a dead port every 100 ms until it lands; panics (leaking the closer) if not.
+fn close_listener_with_pump_kick(desc: &str, listener: TcpListener) {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        drop(listener); // blocking StdTcpClose
+        tx.send(()).ok();
+    });
+    let kicker = check!(UdpSocket::bind(SocketAddr::new(self_ip(), next_port())));
+    let dead = SocketAddr::new(self_ip(), next_port()); // nobody listens: fire-and-forget (U-7)
+    for kick in 0..100u32 {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(()) => {
+                log::info!("{}: close completed after {} pump kicks", desc, kick);
+                return; // kicker's UDP drop is synchronous and safe here
+            }
+            Err(_) => {}
+        }
+        kicker.send_to(&[0xEE], dead).ok();
+        if (kick + 1) % 5 == 0 {
+            log::info!("{}: pump kick {} (close still pending)", desc, kick + 1);
+        }
+    }
+    panic!("{}: listener close did not complete within 100 pump kicks (~10 s)", desc);
+}
+
+/// After the peer drops (FIN), read returns Ok(0), and Ok(0) again on repeat.
+/// XFAIL: a read issued after the FIN parks forever, the same rx-completion gap
+/// as smoke::tcp_drop_close_delivers_eof, services/net/src/main.rs.
+pub fn tcp_read_eof_after_peer_drop() {
+    let (client, served, listener, _addr) = connected_pair();
+    discard(client); // FIN toward the accepted socket
+    thread::sleep(Duration::from_secs(2)); // let the FIN (and any auto-close) land first
+    // expected-failure paths panic below; keep the listener out of unwind-drop
+    let listener = ManuallyDrop::new(listener);
+    let (first, second, served) = bounded("read after peer drop", 10, move || {
+        let mut served = served;
+        let mut buf = [0u8; 8];
+        let first = served.read(&mut buf);
+        let second = served.read(&mut buf);
+        (first, second, served)
+    });
+    discard(served);
+    discard(ManuallyDrop::into_inner(listener));
+    assert_eq!(check!(first), 0, "read after peer drop must return EOF (Ok(0))");
+    assert_eq!(check!(second), 0, "repeated read after EOF must return Ok(0) again");
+}
+
+/// Writes on the accepted socket after the client drops must eventually fail
+/// (early Ok()s allowed; xous-pinned kind BrokenPipe).
+/// XFAIL: the write parks in tcp_tx_waiting forever, the state-Closed tx reaper never running on a quiet pump, services/net/src/main.rs.
+pub fn tcp_write_after_peer_drop() {
+    let (client, served, listener, _addr) = connected_pair();
+    discard(client); // FIN + auto-close of `served`
+    thread::sleep(Duration::from_secs(2));
+    let listener = ManuallyDrop::new(listener);
+    let (outcome, served) = bounded("writes after peer drop", 15, move || {
+        let mut served = served;
+        let mut outcome = None;
+        for i in 0..30u32 {
+            match served.write(&[0x5A; 32]) {
+                Ok(_) => {
+                    if (i + 1) % 5 == 0 {
+                        log::info!("write {} after peer drop still Ok", i + 1);
+                    }
+                    thread::sleep(Duration::from_millis(100));
+                }
+                Err(e) => {
+                    outcome = Some((i, e));
+                    break;
+                }
+            }
+        }
+        (outcome, served)
+    });
+    discard(served);
+    discard(ManuallyDrop::into_inner(listener));
+    match outcome {
+        None => panic!("30 writes after peer drop all returned Ok — want an eventual BrokenPipe"),
+        Some((i, e)) => assert_eq!(
+            e.kind(),
+            ErrorKind::BrokenPipe,
+            "write {} after peer drop failed with {:?} ({}), want the pinned BrokenPipe",
+            i,
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// With 1 byte pending, a read into a 10-byte buffer returns Ok(1) immediately
+/// instead of blocking for more.
+pub fn tcp_partial_read() {
+    let (mut client, served, listener, _addr) = connected_pair();
+    check!(client.write_all(&[0xC3]));
+    let (result, buf, served) = bounded("partial read", 10, move || {
+        let mut served = served;
+        let mut buf = [0u8; 10];
+        let r = served.read(&mut buf);
+        (r, buf, served)
+    });
+    discard(client);
+    discard(served);
+    discard(listener);
+    assert_eq!(check!(result), 1, "read with a 10-byte buffer must return the single pending byte");
+    assert_eq!(buf[0], 0xC3, "partial read returned the wrong byte");
+}
+
+/// 64 KiB each direction through the echo server, verifying end-to-end
+/// integrity across the 1530-byte buffers. Writer (try_clone) and reader run
+/// concurrently — sequential write-then-read deadlocks past ~3060 bytes in flight.
+pub fn tcp_large_transfer_echo_64k() {
+    const CHUNK: usize = 1024;
+    const CHUNKS: usize = 64;
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    // echo thread + listener leak by design: EOF teardown is pinned separately
+    // (smoke::tcp_drop_close_delivers_eof, NTC-3)
+    let _server = echo_server(listener);
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let writer_half = check!(client.try_clone());
+    let seed = 0x64AB_0000 ^ port as u32;
+    let (write_res, read_res, client, writer_half) = bounded("64 KiB echo transfer", 120, move || {
+        let (wtx, wrx) = mpsc::channel();
+        thread::spawn(move || {
+            let mut writer = writer_half;
+            let mut rng = XorShift::new(seed);
+            let mut chunk = vec![0u8; CHUNK];
+            let res: Result<(), String> = (|| {
+                for i in 0..CHUNKS {
+                    rng.fill(&mut chunk);
+                    writer.write_all(&chunk).map_err(|e| format!("write chunk {}: {}", i, e))?;
+                    if (i + 1) % 5 == 0 {
+                        log::info!("64k writer: {} KiB sent", i + 1);
+                    }
+                }
+                Ok(())
+            })();
+            wtx.send((res, writer)).ok();
+        });
+        let mut client = client;
+        let mut rng = XorShift::new(seed);
+        let mut expect = vec![0u8; CHUNK];
+        let mut got = vec![0u8; CHUNK];
+        let read_res: Result<(), String> = (|| {
+            for i in 0..CHUNKS {
+                rng.fill(&mut expect);
+                client.read_exact(&mut got).map_err(|e| format!("read chunk {}: {}", i, e))?;
+                if got != expect {
+                    return Err(format!("chunk {} corrupted in the 64 KiB echo", i));
+                }
+                if (i + 1) % 5 == 0 {
+                    log::info!("64k reader: {} KiB verified", i + 1);
+                }
+            }
+            Ok(())
+        })();
+        let (write_res, writer_half) = match wrx.recv_timeout(Duration::from_secs(60)) {
+            Ok((r, w)) => (r, Some(w)),
+            Err(_) => (Err("writer thread never reported (stalled?)".to_string()), None),
+        };
+        (write_res, read_res, client, writer_half)
+    });
+    discard(client);
+    if let Some(w) = writer_half {
+        discard(w);
+    }
+    check!(write_res);
+    check!(read_res);
+}
+
+/// A single write() may be short: an 8192-byte write returns 0 < n <= 1530
+/// (client one-page cap plus the 1530-byte tx buffer), and the peer drains and
+/// verifies exactly n bytes.
+pub fn tcp_single_write_is_short() {
+    let (client, served, listener, _addr) = connected_pair();
+    let mut payload = vec![0u8; 8192];
+    XorShift::new(0x51C0_0DE1).fill(&mut payload);
+    let expected = payload.clone();
+    let (wrote, client) = bounded("single 8 KiB write", 10, move || {
+        let mut client = client;
+        let r = client.write(&payload);
+        (r, client)
+    });
+    let n = match wrote {
+        Ok(n) => n,
+        Err(e) => {
+            discard(client);
+            discard(served);
+            discard(listener);
+            panic!("single 8 KiB write failed with: {}", e);
+        }
+    };
+    let (drained, served) = bounded("drain the short write", 10, move || {
+        let mut served = served;
+        let mut got = vec![0u8; n];
+        let r = served.read_exact(&mut got).map(|_| got);
+        (r, served)
+    });
+    discard(client);
+    discard(served);
+    discard(listener);
+    assert!(n > 0 && n <= 1530, "single write returned {} bytes, want 0 < n <= 1530", n);
+    assert_eq!(check!(drained), expected[..n], "short-write payload corrupted");
+}
+
+/// Peek twice returns the same 4 bytes without consuming them, a read still
+/// gets them, and a nonblocking peek on an empty queue returns WouldBlock.
+pub fn tcp_peek_does_not_consume() {
+    let (client, served, listener, _addr) = connected_pair();
+    let mut served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    check!(served.write_all(b"peek"));
+    let (peek1, peek2, readback, client) = bounded("peek twice then read", 15, move || {
+        let mut client = client;
+        let mut p1 = [0u8; 4];
+        // wait until all 4 bytes are pending so both peeks see identical data
+        let mut tries = 0u32;
+        let peek1 = loop {
+            match client.peek(&mut p1) {
+                Ok(4) => break Ok(4usize),
+                Ok(n) => {
+                    tries += 1;
+                    if tries % 5 == 0 {
+                        log::info!("peek warmup: {} of 4 bytes pending (try {})", n, tries);
+                    }
+                    if tries >= 50 {
+                        break Ok(n);
+                    }
+                    thread::sleep(Duration::from_millis(100));
+                }
+                Err(e) => break Err(e),
+            }
+        };
+        let mut p2 = [0u8; 4];
+        let peek2 = client.peek(&mut p2);
+        let mut r = [0u8; 4];
+        let readback = client.read_exact(&mut r).map(|_| r);
+        (peek1.map(|n| (n, p1)), peek2.map(|n| (n, p2)), readback, client)
+    });
+    // nonblocking peek returns immediately: safe on the test thread
+    check!(client.set_nonblocking(true));
+    let mut b = [0u8; 4];
+    let empty_peek = client.peek(&mut b);
+    discard(client);
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    let (n1, p1) = check!(peek1);
+    let (n2, p2) = check!(peek2);
+    assert_eq!((n1, &p1), (4, b"peek"), "first peek");
+    assert_eq!((n2, &p2), (4, b"peek"), "second peek must see the same unconsumed bytes");
+    assert_eq!(&check!(readback), b"peek", "read after two peeks must still get the bytes");
+    match empty_peek {
+        Ok(n) => panic!("nonblocking peek on an empty queue returned Ok({})", n),
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::WouldBlock,
+            "nonblocking empty peek surfaced as {:?} ({}), want WouldBlock",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// With 4 bytes pending, a peek into a 2-byte buffer returns Ok(2) and a
+/// following 4-byte read still gets all 4 — peek leaves the queue intact.
+pub fn tcp_peek_shorter_buffer() {
+    let (client, served, listener, _addr) = connected_pair();
+    let mut served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    check!(served.write_all(b"wxyz"));
+    let (short_peek, readback, client) = bounded("short peek then full read", 15, move || {
+        let mut client = client;
+        // warm up until all 4 bytes are pending (determinism for the 2-byte peek)
+        let mut warm = [0u8; 4];
+        let mut tries = 0u32;
+        loop {
+            match client.peek(&mut warm) {
+                Ok(4) => break,
+                Ok(n) => {
+                    tries += 1;
+                    if tries % 5 == 0 {
+                        log::info!("short-peek warmup: {} of 4 bytes pending (try {})", n, tries);
+                    }
+                    if tries >= 50 {
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(100));
+                }
+                Err(_) => break, // surfaced again by the asserts below
+            }
+        }
+        let mut two = [0u8; 2];
+        let short_peek = client.peek(&mut two).map(|n| (n, two));
+        let mut four = [0u8; 4];
+        let readback = client.read_exact(&mut four).map(|_| four);
+        (short_peek, readback, client)
+    });
+    discard(client);
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    let (n, two) = check!(short_peek);
+    assert_eq!((n, &two), (2, b"wx"), "2-byte peek of 4 pending bytes");
+    assert_eq!(&check!(readback), b"wxyz", "read after a short peek must return the whole queue");
+}
+
+/// Half-close: the client sends a request then drops (FIN); the server reads it,
+/// sees EOF, and its reply write must succeed (full drop since shutdown(Write) emits no FIN — NTC-4).
+/// XFAIL: the request read itself parks forever, the same FIN-adjacent rx gap as smoke::tcp_drop_close_delivers_eof, services/net/src/main.rs.
+pub fn tcp_half_close_server_replies_after_client_fin() {
+    let (mut client, served, listener, _addr) = connected_pair();
+    check!(client.write_all(b"req?"));
+    discard(client); // FIN right behind the request
+    thread::sleep(Duration::from_secs(2));
+    let listener = ManuallyDrop::new(listener);
+    let (request, eof, reply, served) = bounded("read request+EOF then reply", 15, move || {
+        let mut served = served;
+        let mut req = [0u8; 4];
+        let request = served.read_exact(&mut req).map(|_| req);
+        let mut b = [0u8; 8];
+        let eof = served.read(&mut b);
+        let reply = served.write_all(b"resp");
+        (request, eof, reply, served)
+    });
+    discard(served);
+    discard(ManuallyDrop::into_inner(listener));
+    assert_eq!(&check!(request), b"req?", "request bytes sent just before the FIN");
+    assert_eq!(check!(eof), 0, "read after the request must see EOF (Ok(0))");
+    check!(reply);
+}
+
+/// Reverse half-close: the accepted stream drops (graceful FIN), the client
+/// reads Ok(0), and its first small write after EOF still completes locally.
+/// XFAIL: the client read parks forever; the EOF gap is in the rx wait path itself, not the accepted-socket auto-close, services/net/src/main.rs.
+pub fn tcp_half_close_server_fin_client_still_writes() {
+    let (client, served, listener, _addr) = connected_pair();
+    discard(served); // graceful FIN from the accepted side
+    thread::sleep(Duration::from_secs(2));
+    let listener = ManuallyDrop::new(listener);
+    let (eof, first_write, client) = bounded("client read EOF after server drop", 10, move || {
+        let mut client = client;
+        let mut b = [0u8; 8];
+        let eof = client.read(&mut b);
+        let first_write = client.write(b"after-fin");
+        (eof, first_write, client)
+    });
+    discard(client);
+    discard(ManuallyDrop::into_inner(listener));
+    assert_eq!(check!(eof), 0, "client read after server drop must see EOF (Ok(0))");
+    let n = check!(first_write);
+    assert!(n > 0, "first small write after EOF returned Ok({}), want a local success", n);
+}
+
+/// Deviation-pin: a second shutdown() in the same direction returns Ok — the
+/// server's StdTcpStreamShutdown unconditionally return_scalar(1). The std
+/// contract only requires no crash, so pinning Ok stays within contract.
+pub fn tcp_double_shutdown_is_ok() {
+    let (client, served, listener, _addr) = connected_pair();
+    let w1 = client.shutdown(Shutdown::Write);
+    let w2 = client.shutdown(Shutdown::Write);
+    let r1 = client.shutdown(Shutdown::Read);
+    let r2 = client.shutdown(Shutdown::Read);
+    discard(client);
+    discard(served);
+    discard(listener);
+    check!(w1);
+    check!(w2);
+    check!(r1);
+    check!(r2);
+}
+
+/// Name bookkeeping across a connection: listener.local_addr() equals the bound
+/// address, stream.peer_addr() == listener.local_addr(), and accepted.peer_addr()
+/// == stream.local_addr(). Adds the listener query (StdGetAddress) over smoke.
+pub fn tcp_socket_and_peer_name() {
+    let port = next_port();
+    let bind_addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(bind_addr));
+    let l_local = listener.local_addr();
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(bind_addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    let c_local = client.local_addr();
+    let c_peer = client.peer_addr();
+    let s_local = served.local_addr();
+    let s_peer = served.peer_addr();
+    discard(client);
+    discard(served);
+    discard(listener);
+    let l_local = check!(l_local);
+    assert_eq!(l_local, bind_addr, "listener.local_addr() vs the bound address");
+    assert_eq!(check!(c_peer), l_local, "stream.peer_addr() vs listener.local_addr()");
+    assert_eq!(check!(s_local), bind_addr, "accepted.local_addr() vs the bound address");
+    assert_eq!(check!(s_peer), check!(c_local), "accepted.peer_addr() vs stream.local_addr()");
+}
+
+/// Binding port 0 assigns a real ephemeral port in [49152, 65535] and two
+/// listeners get distinct ports (the only sanctioned exception to next_port()).
+/// The distinct-ports assert has 1-in-16384 collision odds — a lone failure means rerun, a repeat means broken trng.
+pub fn tcp_listener_port_zero_assigned() {
+    let l1 = check!(TcpListener::bind(SocketAddr::new(LOOPBACK, 0)));
+    let a1 = l1.local_addr();
+    let l2 = check!(TcpListener::bind(SocketAddr::new(LOOPBACK, 0)));
+    let a2 = l2.local_addr();
+    discard(l1);
+    discard(l2);
+    let a1 = check!(a1);
+    let a2 = check!(a2);
+    assert!(
+        (49152..=65535).contains(&a1.port()),
+        "assigned port {} outside the documented ephemeral range [49152, 65535]",
+        a1.port()
+    );
+    assert!(
+        (49152..=65535).contains(&a2.port()),
+        "assigned port {} outside the documented ephemeral range [49152, 65535]",
+        a2.port()
+    );
+    assert_ne!(a1.port(), a2.port(), "two port-0 listeners drew the same ephemeral port");
+}
+
+/// connect_timeout(addr, Duration::MAX) to a live listener must succeed, not
+/// overflow into an immediate failure.
+/// XFAIL: the saturated u64 timeout-ms overflow smoltcp's i64-ms Instant math and poison the connect before the SYN, services/net/src/std_tcpstream.rs.
+pub fn tcp_connect_timeout_duration_max_ok() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let result = bounded("connect_timeout(Duration::MAX)", 10, move || {
+        TcpStream::connect_timeout(&addr, Duration::MAX)
+    });
+    let verdict = match result {
+        Ok(s) => {
+            discard(s);
+            Ok(())
+        }
+        Err(e) => Err(e),
+    };
+    discard(listener);
+    check!(verdict);
+}
+
+/// Five serial connections each accepted through the incoming() iterator,
+/// echoing one byte both ways. Exercises the xous listener-replenish path:
+/// accept() converts the listener fd to the stream fd and rebinds a replacement.
+pub fn tcp_incoming_iterator_serial() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    // ManuallyDrop so a failing round cannot unwind-drop the listener on the
+    // test thread (blocking close, NTC-5); explicitly discarded on success
+    let mut listener = ManuallyDrop::new(Some(check!(TcpListener::bind(addr))));
+    for round in 0u8..5 {
+        log::info!("incoming round {}: connecting", round);
+        let mut client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+        let l = listener.take().unwrap();
+        let (accepted, l) = bounded("incoming().next()", 10, move || {
+            let r = l.incoming().next().expect("incoming() returned None for a listener");
+            (r, l)
+        });
+        *listener = Some(l);
+        let served = check!(accepted);
+        check!(client.write_all(&[round]));
+        let (server_read, mut served) = bounded("server read", 10, move || {
+            let mut served = served;
+            let mut b = [0u8; 1];
+            let r = served.read_exact(&mut b).map(|_| b[0]);
+            (r, served)
+        });
+        let reply = served.write_all(&[round ^ 0xAA]);
+        let (client_read, client) = bounded("client read", 10, move || {
+            let mut client = client;
+            let mut b = [0u8; 1];
+            let r = client.read_exact(&mut b).map(|_| b[0]);
+            (r, client)
+        });
+        discard(served);
+        discard(client);
+        assert_eq!(check!(server_read), round, "server byte in round {}", round);
+        check!(reply);
+        assert_eq!(check!(client_read), round ^ 0xAA, "client byte in round {}", round);
+        log::info!("incoming round {}: done", round);
+    }
+    discard(listener.take().unwrap());
+}
+
+/// Deviation-pin: a second bind of a bound port should fail EADDRINUSE, but on
+/// xous BOTH binds succeed — each bind makes a fresh smoltcp socket and nothing
+/// checks for cross-socket port conflicts; a conflict check would flip this to Err.
+pub fn tcp_double_bind_same_port() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let first = check!(TcpListener::bind(addr));
+    let second = TcpListener::bind(addr);
+    let verdict = match second {
+        Ok(l) => {
+            discard(l); // idle listener: worker may leak (NTC-5)
+            Ok(())
+        }
+        Err(e) => Err((e.kind(), e.to_string())),
+    };
+    discard(first);
+    match verdict {
+        Ok(()) => {
+            log::info!("second bind of {} succeeded (pinned: no cross-socket conflict detection)", addr)
+        }
+        Err((kind, msg)) => panic!(
+            "second bind of {} was refused with {:?} ({}) — the no-conflict-detection pin no longer holds; \
+             re-point this test at the contract (AddrInUse) and drop the pin",
+            addr, kind, msg
+        ),
+    }
+}
+
+/// After tearing a listener down, an immediate rebind of the same port succeeds
+/// and the rebound listener actually serves — a stale Listen socket from an
+/// incomplete close would steal the SYN and park the accept (pump-kicker closes).
+pub fn tcp_fast_rebind_after_close() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    // round 1: give the sockets traffic so their closes can complete (NTC-5)
+    let mut client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    check!(client.write_all(&[0x17]));
+    let (got1, served) = bounded("server read (round 1)", 10, move || {
+        let mut served = served;
+        let mut b = [0u8; 1];
+        let r = served.read_exact(&mut b).map(|_| b[0]);
+        (r, served)
+    });
+    discard(served);
+    discard(client);
+    // the rebind is only meaningful once the old listener socket is GONE
+    close_listener_with_pump_kick("T-17 old listener", listener);
+    let relisten = check!(TcpListener::bind(addr)); // the immediate rebind under test
+    // round 2: the rebound listener must actually serve
+    let mut client2 = check!(bounded("connect after rebind", 10, move || TcpStream::connect(addr)));
+    let (accepted2, relisten) = bounded("accept after rebind", 10, move || {
+        let r = relisten.accept();
+        (r, relisten)
+    });
+    let (served2, _peer) = check!(accepted2);
+    check!(client2.write_all(&[0x71]));
+    let (got2, served2) = bounded("server read (round 2)", 10, move || {
+        let mut served2 = served2;
+        let mut b = [0u8; 1];
+        let r = served2.read_exact(&mut b).map(|_| b[0]);
+        (r, served2)
+    });
+    discard(served2);
+    discard(client2);
+    discard(relisten);
+    assert_eq!(check!(got1), 0x17, "pre-close roundtrip byte");
+    assert_eq!(check!(got2), 0x71, "post-rebind roundtrip byte");
+}
+
+/// Deviation-pin: connecting to a just-dropped listener's port fails fast; the
+/// contract kind is ConnectionRefused but on this toolchain it decodes as
+/// AddrNotAvailable (NTC-6 family, pinned here). Teardown uses the pump-kicker.
+pub fn tcp_connect_to_dropped_listener_refused() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    // give the connection sockets traffic so their closes complete (NTC-5)
+    let mut client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    check!(client.write_all(&[0x18]));
+    let (got, served) = bounded("server read", 10, move || {
+        let mut served = served;
+        let mut b = [0u8; 1];
+        let r = served.read_exact(&mut b).map(|_| b[0]);
+        (r, served)
+    });
+    discard(served);
+    discard(client);
+    assert_eq!(check!(got), 0x18, "setup roundtrip byte");
+    close_listener_with_pump_kick("T-18 listener", listener);
+    let started = Instant::now();
+    let result = bounded("connect to the dropped listener's port", 10, move || {
+        TcpStream::connect_timeout(&addr, Duration::from_secs(5))
+    });
+    let elapsed = started.elapsed();
+    match result {
+        Ok(s) => {
+            discard(s);
+            panic!("connect to a just-dropped listener's port unexpectedly succeeded");
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::AddrNotAvailable,
+            "dropped-listener connect surfaced as {:?} ({}), want the pinned AddrNotAvailable \
+             (contract kind on fix-day: ConnectionRefused)",
+            e.kind(),
+            e
+        ),
+    }
+    assert!(elapsed < Duration::from_secs(4), "refusal took {:?}, want well under the 5 s budget", elapsed);
+}
+
+/// read(&mut []) with data already pending returns Ok(0) promptly and does not
+/// consume the pending byte; the follow-up read proves it was left intact.
+pub fn tcp_read_zero_len_buffer_pending() {
+    let (client, served, listener, _addr) = connected_pair();
+    let mut served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    check!(served.write_all(&[0x77]));
+    thread::sleep(Duration::from_secs(1)); // let the byte land in the rx buffer
+    let (zero, follow, client) = bounded("zero-len read with pending data", 10, move || {
+        let mut client = client;
+        let zero = client.read(&mut []);
+        let mut b = [0u8; 1];
+        let follow = client.read_exact(&mut b).map(|_| b[0]);
+        (zero, follow, client)
+    });
+    discard(client);
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    assert_eq!(check!(zero), 0, "read(&mut []) with pending data must return Ok(0)");
+    assert_eq!(check!(follow), 0x77, "zero-len read must not consume the pending byte");
+}
+
+/// read(&mut []) with NO pending data must still return Ok(0) promptly.
+/// XFAIL: the server parks any read while can_recv() is false without checking
+/// the buffer length, so a zero-length read waits forever, services/net/src/std_tcpstream.rs.
+pub fn tcp_read_zero_len_buffer_quiet() {
+    let (client, served, listener, _addr) = connected_pair();
+    // the peer must stay open and quiet through the read window, and the
+    // expected-failure path panics past this frame: park both in ManuallyDrop
+    // (leaked on panic, discarded on the happy path — NTC-5)
+    let served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    let (zero, elapsed, client) = bounded("zero-len read on a quiet socket", 8, move || {
+        let started = Instant::now();
+        let mut client = client;
+        let r = client.read(&mut []);
+        (r, started.elapsed(), client)
+    });
+    discard(client);
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    assert_eq!(check!(zero), 0, "read(&mut []) on a quiet socket must return Ok(0)");
+    assert!(elapsed < Duration::from_secs(2), "zero-len read took {:?}, want prompt", elapsed);
+}
+
+/// write(&[]) returns Ok(0), the peer receives NOTHING, and a following 1-byte
+/// marker arrives alone and first.
+/// XFAIL: on valid=0 the server falls back to length=data.len() and send_slice injects up to 1530 garbage bytes, services/net/src/std_tcpstream.rs.
+pub fn tcp_write_zero_len() {
+    let (client, served, listener, _addr) = connected_pair();
+    let mut served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    check!(served.set_nonblocking(true));
+    let (zero_write, client) = bounded("zero-length write", 10, move || {
+        let mut client = client;
+        let r = client.write(&[]);
+        (r, client)
+    });
+    // (b) watch window: nothing may arrive (nonblocking reads, safe inline)
+    let mut buf = [0u8; 2048];
+    let mut leaked: Option<String> = None;
+    for i in 0..10u32 {
+        match served.read(&mut buf) {
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                if (i + 1) % 5 == 0 {
+                    log::info!("zero-write watch {}: peer still quiet", i + 1);
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+            Ok(n) => {
+                leaked = Some(format!("Ok({}), first bytes {:02x?}", n, &buf[..n.min(8)]));
+                break;
+            }
+            Err(e) => {
+                leaked = Some(format!("Err({:?}: {})", e.kind(), e));
+                break;
+            }
+        }
+    }
+    // (c) the marker must be the FIRST thing the peer ever receives
+    let (marker_write, client) = bounded("marker write", 10, move || {
+        let mut client = client;
+        let r = client.write_all(b"M");
+        (r, client)
+    });
+    let mut marker: Option<Result<(usize, u8), String>> = None;
+    for i in 0..30u32 {
+        match served.read(&mut buf) {
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                if (i + 1) % 5 == 0 {
+                    log::info!("marker poll {}: still WouldBlock", i + 1);
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+            Ok(n) => {
+                marker = Some(Ok((n, if n > 0 { buf[0] } else { 0 })));
+                break;
+            }
+            Err(e) => {
+                marker = Some(Err(format!("{:?}: {}", e.kind(), e)));
+                break;
+            }
+        }
+    }
+    discard(client);
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    assert_eq!(check!(zero_write), 0, "write(&[]) must return Ok(0)");
+    if let Some(l) = leaked {
+        panic!("peer received data after a zero-length write: {} (NTC-7 garbage injection)", l);
+    }
+    check!(marker_write);
+    match marker {
+        Some(Ok((1, b'M'))) => {}
+        Some(Ok((n, first))) => panic!(
+            "peer read {} bytes with first byte 0x{:02x} after the marker write, want exactly \
+             the 1-byte marker 0x4d (garbage prepended? NTC-7)",
+            n, first
+        ),
+        Some(Err(e)) => panic!("marker readback failed: {}", e),
+        None => panic!("the marker byte never arrived within 30 nonblocking polls"),
+    }
+}
+
+/// try_clone interop: a write through the clone is echoed back through the
+/// original, and dropping the clone does NOT close the fd (refcounted via
+/// handle_count; only the last drop closes) — proven by a second roundtrip.
+pub fn tcp_clone_smoke() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    // echo thread + listener leak by design (EOF teardown is NTC-3's business)
+    let _server = echo_server(listener);
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let clone = check!(client.try_clone());
+    let mut p1 = vec![0u8; 256];
+    XorShift::new(0xC10E_0001).fill(&mut p1);
+    let p1_send = p1.clone();
+    let (w1, clone) = bounded("write via clone", 10, move || {
+        let mut clone = clone;
+        let r = clone.write_all(&p1_send);
+        (r, clone)
+    });
+    let (r1, client) = bounded("echo readback via original", 10, move || {
+        let mut client = client;
+        let mut got = vec![0u8; 256];
+        let r = client.read_exact(&mut got).map(|_| got);
+        (r, client)
+    });
+    // a clone drop is a client-side handle_count decrement (no server close
+    // while other handles live); discarded off-thread for uniformity, with a
+    // sleep to order it before the survival roundtrip
+    discard(clone);
+    thread::sleep(Duration::from_secs(1));
+    let mut p2 = vec![0u8; 256];
+    XorShift::new(0xC10E_0002).fill(&mut p2);
+    let p2_send = p2.clone();
+    let (w2, client) = bounded("write via original after clone drop", 10, move || {
+        let mut client = client;
+        let r = client.write_all(&p2_send);
+        (r, client)
+    });
+    let (r2, client) = bounded("echo readback after clone drop", 10, move || {
+        let mut client = client;
+        let mut got = vec![0u8; 256];
+        let r = client.read_exact(&mut got).map(|_| got);
+        (r, client)
+    });
+    discard(client);
+    check!(w1);
+    assert_eq!(check!(r1), p1, "echo payload written via the clone");
+    check!(w2);
+    assert_eq!(check!(r2), p2, "echo payload after the clone was dropped — fd must survive");
+}
+
+/// PROBE: two clones each blocked in read() on their own thread receive one
+/// byte apiece when the peer sends two — none lost or duplicated. Both park in
+/// tcp_rx_waiting on the same handle; on a hang the parked readers/sockets leak.
+pub fn tcp_clone_two_threads_read() {
+    let (client, served, listener, _addr) = connected_pair();
+    let mut served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    let c2 = check!(client.try_clone());
+    let (tx, rx) = mpsc::channel();
+    for (idx, mut sock) in vec![(0u8, client), (1u8, c2)] {
+        let tx = tx.clone();
+        thread::spawn(move || {
+            let mut b = [0u8; 1];
+            let r = sock.read_exact(&mut b).map(|_| b[0]);
+            tx.send((idx, r, sock)).ok();
+        });
+    }
+    thread::sleep(Duration::from_millis(500)); // let both readers park
+    let w1 = served.write_all(b"A");
+    thread::sleep(Duration::from_millis(300));
+    let w2 = served.write_all(b"B");
+    let mut got: Vec<(u8, std::io::Result<u8>)> = Vec::new();
+    for k in 0..2 {
+        match rx.recv_timeout(Duration::from_secs(10)) {
+            Ok((idx, r, sock)) => {
+                discard(sock);
+                got.push((idx, r));
+            }
+            Err(_) => {
+                // leak the parked reader(s) and their clone handles (H-1)
+                discard(ManuallyDrop::into_inner(served));
+                discard(ManuallyDrop::into_inner(listener));
+                panic!("clone reader {} of 2 never completed within 10 s (PROBE T-22)", k + 1);
+            }
+        }
+    }
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    check!(w1);
+    check!(w2);
+    let mut bytes = Vec::new();
+    for (idx, r) in got {
+        match r {
+            Ok(b) => bytes.push(b),
+            Err(e) => panic!("clone reader {} failed with: {}", idx, e),
+        }
+    }
+    bytes.sort_unstable();
+    assert_eq!(
+        bytes,
+        vec![b'A', b'B'],
+        "two clone readers must receive exactly the two sent bytes, none lost or duplicated"
+    );
+}
+
+/// Vectored ops fall back to single-buffer behavior: the xous client reports
+/// is_read/write_vectored() == false, so std's default fallbacks service only
+/// the first non-empty buffer per call.
+pub fn tcp_vectored_fallback() {
+    let (client, served, listener, _addr) = connected_pair();
+    let (wres, client) = bounded("write_vectored", 10, move || {
+        let mut client = client;
+        let r = client.write_vectored(&[IoSlice::new(b"he"), IoSlice::new(b"llo")]);
+        (r, client)
+    });
+    let wn = match wres {
+        Ok(n) => n,
+        Err(e) => {
+            discard(client);
+            discard(served);
+            discard(listener);
+            panic!("write_vectored failed with: {}", e);
+        }
+    };
+    let (drained, mut served) = bounded("drain the vectored write", 10, move || {
+        let mut served = served;
+        let mut got = vec![0u8; wn];
+        let r = served.read_exact(&mut got).map(|_| got);
+        (r, served)
+    });
+    let reply = served.write_all(b"xyz");
+    let (rres, a, b, client) = bounded("read_vectored", 10, move || {
+        let mut client = client;
+        let mut a = [0u8; 2];
+        let mut b = [0u8; 2];
+        let r = {
+            let mut bufs = [IoSliceMut::new(&mut a), IoSliceMut::new(&mut b)];
+            client.read_vectored(&mut bufs)
+        };
+        (r, a, b, client)
+    });
+    discard(client);
+    discard(served);
+    discard(listener);
+    assert!((1..=5).contains(&wn), "write_vectored returned {}, want 1..=5", wn);
+    assert_eq!(check!(drained), b"hello"[..wn], "vectored write payload");
+    check!(reply);
+    let rn = check!(rres);
+    assert!(rn >= 1, "read_vectored returned Ok(0) with data pending");
+    let mut joined = Vec::new();
+    joined.extend_from_slice(&a);
+    joined.extend_from_slice(&b);
+    assert_eq!(joined[..rn.min(3)], b"xyz"[..rn.min(3)], "vectored read payload");
+}
+
+/// flush() returns Ok and Debug formatting of the listener and both streams
+/// produces a non-empty string without panicking (xous has its own Debug
+/// impls, so only non-emptiness is asserted).
+pub fn tcp_flush_and_debug_no_panic() {
+    let (mut client, served, listener, _addr) = connected_pair();
+    check!(client.write_all(b"f"));
+    let flush = client.flush();
+    let dbg_listener = format!("{:?}", listener);
+    let dbg_client = format!("{:?}", client);
+    let dbg_served = format!("{:?}", served);
+    let (drain, served) = bounded("drain the flushed byte", 10, move || {
+        let mut served = served;
+        let mut b = [0u8; 1];
+        let r = served.read_exact(&mut b).map(|_| b[0]);
+        (r, served)
+    });
+    discard(client);
+    discard(served);
+    discard(listener);
+    check!(flush);
+    assert_eq!(check!(drain), b'f', "flushed byte must reach the peer");
+    assert!(
+        !dbg_listener.is_empty() && !dbg_client.is_empty() && !dbg_served.is_empty(),
+        "Debug output must be non-empty (listener {:?} / client {:?} / served {:?})",
+        dbg_listener.len(),
+        dbg_client.len(),
+        dbg_served.len()
+    );
+}
+
+/// A writer blocked on full buffers resumes when the peer drains: 8 KiB pushed
+/// through ~3060 bytes of tx+rx buffering parks the writer after ~3 KiB, then
+/// the peer's drain and window-update traffic re-arm the pump so the tx completes.
+pub fn tcp_blocked_write_resumes_on_peer_read() {
+    const CHUNK: usize = 1024;
+    const CHUNKS: usize = 8;
+    const SEED: u32 = 0xB10C_ED01;
+    let (client, served, listener, _addr) = connected_pair();
+    let listener = ManuallyDrop::new(listener);
+    let (wtx, wrx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut client = client;
+        let mut rng = XorShift::new(SEED);
+        let mut chunk = vec![0u8; CHUNK];
+        let res: Result<(), String> = (|| {
+            for i in 0..CHUNKS {
+                rng.fill(&mut chunk);
+                client.write_all(&chunk).map_err(|e| format!("write chunk {}: {}", i, e))?;
+                if (i + 1) % 4 == 0 {
+                    log::info!("blocked-writer: {} KiB written", i + 1);
+                }
+            }
+            Ok(())
+        })();
+        wtx.send((res, client)).ok();
+    });
+    thread::sleep(Duration::from_millis(1500)); // let the writer fill 1530+1530 and park
+    let (read_res, served) = bounded("drain 8 KiB from the blocked writer", 30, move || {
+        let mut served = served;
+        let mut rng = XorShift::new(SEED);
+        let mut expect = vec![0u8; CHUNK];
+        let mut got = vec![0u8; CHUNK];
+        let res: Result<(), String> = (|| {
+            for i in 0..CHUNKS {
+                rng.fill(&mut expect);
+                served.read_exact(&mut got).map_err(|e| format!("read chunk {}: {}", i, e))?;
+                if got != expect {
+                    return Err(format!("chunk {} corrupted after the write stall", i));
+                }
+                if (i + 1) % 4 == 0 {
+                    log::info!("blocked-writer drain: {} KiB verified", i + 1);
+                }
+            }
+            Ok(())
+        })();
+        (res, served)
+    });
+    let (write_res, client) = match wrx.recv_timeout(Duration::from_secs(20)) {
+        Ok((r, c)) => (r, Some(c)),
+        Err(_) => {
+            (Err("writer never resumed after the peer drained (parked tx not woken?)".to_string()), None)
+        }
+    };
+    discard(served);
+    if let Some(c) = client {
+        discard(c);
+    }
+    discard(ManuallyDrop::into_inner(listener));
+    check!(read_res);
+    check!(write_res);
+}
+
+/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+pub const TESTS: &[TestEntry] = &[
+    ("tcp::tcp_read_eof_after_peer_drop", tcp_read_eof_after_peer_drop as fn()),
+    ("tcp::tcp_write_after_peer_drop", tcp_write_after_peer_drop as fn()),
+    ("tcp::tcp_partial_read", tcp_partial_read as fn()),
+    ("tcp::tcp_large_transfer_echo_64k", tcp_large_transfer_echo_64k as fn()),
+    ("tcp::tcp_single_write_is_short", tcp_single_write_is_short as fn()),
+    ("tcp::tcp_peek_does_not_consume", tcp_peek_does_not_consume as fn()),
+    ("tcp::tcp_peek_shorter_buffer", tcp_peek_shorter_buffer as fn()),
+    (
+        "tcp::tcp_half_close_server_replies_after_client_fin",
+        tcp_half_close_server_replies_after_client_fin as fn(),
+    ),
+    (
+        "tcp::tcp_half_close_server_fin_client_still_writes",
+        tcp_half_close_server_fin_client_still_writes as fn(),
+    ),
+    ("tcp::tcp_double_shutdown_is_ok", tcp_double_shutdown_is_ok as fn()),
+    ("tcp::tcp_socket_and_peer_name", tcp_socket_and_peer_name as fn()),
+    ("tcp::tcp_listener_port_zero_assigned", tcp_listener_port_zero_assigned as fn()),
+    ("tcp::tcp_connect_timeout_duration_max_ok", tcp_connect_timeout_duration_max_ok as fn()),
+    ("tcp::tcp_incoming_iterator_serial", tcp_incoming_iterator_serial as fn()),
+    ("tcp::tcp_double_bind_same_port", tcp_double_bind_same_port as fn()),
+    ("tcp::tcp_fast_rebind_after_close", tcp_fast_rebind_after_close as fn()),
+    ("tcp::tcp_connect_to_dropped_listener_refused", tcp_connect_to_dropped_listener_refused as fn()),
+    ("tcp::tcp_read_zero_len_buffer_pending", tcp_read_zero_len_buffer_pending as fn()),
+    ("tcp::tcp_read_zero_len_buffer_quiet", tcp_read_zero_len_buffer_quiet as fn()),
+    ("tcp::tcp_write_zero_len", tcp_write_zero_len as fn()),
+    ("tcp::tcp_clone_smoke", tcp_clone_smoke as fn()),
+    ("tcp::tcp_clone_two_threads_read", tcp_clone_two_threads_read as fn()),
+    ("tcp::tcp_vectored_fallback", tcp_vectored_fallback as fn()),
+    ("tcp::tcp_flush_and_debug_no_panic", tcp_flush_and_debug_no_panic as fn()),
+    ("tcp::tcp_blocked_write_resumes_on_peer_read", tcp_blocked_write_resumes_on_peer_read as fn()),
+];
+
+pub const XFAILS: &[XfailEntry] = &[
+    ("tcp::tcp_read_eof_after_peer_drop", "NTC-3"),
+    ("tcp::tcp_write_after_peer_drop", "NTC-1"),
+    ("tcp::tcp_half_close_server_replies_after_client_fin", "NTC-3"),
+    ("tcp::tcp_half_close_server_fin_client_still_writes", "NTC-3"),
+    ("tcp::tcp_connect_timeout_duration_max_ok", "NTC-13"),
+    ("tcp::tcp_read_zero_len_buffer_quiet", "NTC-14"),
+    ("tcp::tcp_write_zero_len", "NTC-7"),
+];

--- a/services/net-tests/src/tests/timeouts.rs
+++ b/services/net-tests/src/tests/timeouts.rs
@@ -1,0 +1,569 @@
+//! timeouts theme: read/peek/write/recv/connect timeout semantics; Renode's
+//! virtual clock makes every elapsed-time assertion deterministic.
+//! Theme-wide hazard (#880 / NTC-1): on dev the timeout reapers run only in
+//! the NetPump handler, whose `if !iface.poll(..) { continue; }` early-return
+//! skips them while the interface is quiet — exactly when a timeout matters.
+//! Every quiet-socket timeout op therefore runs inside `harness::bounded`
+//! (generous guard) that turns the hang into a deterministic panic; such tests
+//! are XFAIL NTC-1. Assertions state the correct contract; never weaken one.
+
+use core::mem::ManuallyDrop;
+use std::io::{self, ErrorKind, Read, Write};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream, UdpSocket};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::harness::{XorShift, bounded, check, discard, next_port, self_ip};
+use crate::tests::{TestEntry, XfailEntry};
+
+const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+/// Off-subnet blackhole (the DUT is 10.0.2.15/24): under Loopback nothing
+/// answers the gateway ARP, so a SYN toward this address is never delivered,
+/// never acknowledged, and never reset — only a timeout can end the attempt.
+const BLACKHOLE: Ipv4Addr = Ipv4Addr::new(10, 254, 254, 254);
+
+/// With a 2 s read timeout set, a first read on a socket with data pending
+/// returns that data, and a second read on the now-quiet socket must err
+/// WouldBlock-or-TimedOut after roughly the timeout.
+/// XFAIL: the quiet-socket rx reaper is skipped by the NetPump early-return, so the second read never returns, services/net/src/main.rs:1305-1308.
+pub fn tcp_read_timeout_after_data() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (mut served, _peer) = check!(accepted);
+    check!(client.set_read_timeout(Some(Duration::from_secs(2))));
+    check!(served.write_all(b"data"));
+    // the peer must stay open AND quiet through the timeout window, and the
+    // expected-failure path (NTC-1) panics right past this frame: park the
+    // peer sockets in ManuallyDrop so the unwind cannot block on a close
+    // (NTC-5) — they leak on the panic path, discarded on the happy path
+    let served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    let (first, first_buf, client) = bounded("first read with data pending", 10, move || {
+        let mut client = client;
+        let mut buf = [0u8; 4];
+        let r = client.read_exact(&mut buf);
+        (r, buf, client)
+    });
+    let (second, second_elapsed, client) =
+        bounded("second read with a 2 s timeout on a quiet socket", 8, move || {
+            let mut client = client;
+            let started = Instant::now();
+            let mut buf = [0u8; 8];
+            let r = client.read(&mut buf);
+            (r, started.elapsed(), client)
+        });
+    discard(client);
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    check!(first);
+    assert_eq!(&first_buf, b"data", "first read returned the wrong bytes");
+    match second {
+        Ok(n) => panic!("second read on a quiet socket returned Ok({}) instead of a timeout error", n),
+        Err(e) => assert!(
+            e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut,
+            "read timeout surfaced as {:?} ({}), want WouldBlock or TimedOut",
+            e.kind(),
+            e
+        ),
+    }
+    assert!(
+        second_elapsed >= Duration::from_millis(1500) && second_elapsed <= Duration::from_secs(4),
+        "second read returned after {:?}, want roughly the 2 s timeout",
+        second_elapsed
+    );
+}
+
+/// With a 2 s read timeout set, peek() on a quiet connected socket must err
+/// WouldBlock-or-TimedOut after roughly 2 s (SO_RCVTIMEO applies to MSG_PEEK).
+/// XFAIL: the tcp_peek_waiting reaper sits behind the NetPump quiet-iface early-return, so peek never returns, services/net/src/main.rs:1413-1476.
+pub fn tcp_peek_timeout_quiet() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    // peer sockets stay open and quiet through the window; ManuallyDrop so
+    // the expected NTC-1 panic cannot unwind into a blocking close (NTC-5)
+    let served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    check!(client.set_read_timeout(Some(Duration::from_secs(2))));
+    let (result, elapsed, client) = bounded("peek with a 2 s timeout on a quiet socket", 8, move || {
+        let started = Instant::now();
+        let mut buf = [0u8; 8];
+        let r = client.peek(&mut buf);
+        (r, started.elapsed(), client)
+    });
+    discard(client);
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    match result {
+        Ok(n) => panic!("peek on a quiet socket returned Ok({}) instead of a timeout error", n),
+        Err(e) => assert!(
+            e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut,
+            "peek timeout surfaced as {:?} ({}), want WouldBlock or TimedOut",
+            e.kind(),
+            e
+        ),
+    }
+    assert!(
+        elapsed >= Duration::from_millis(1500) && elapsed <= Duration::from_secs(4),
+        "peek returned after {:?}, want roughly the 2 s timeout",
+        elapsed
+    );
+}
+
+/// With the peer not reading and a 2 s write timeout set, a write past the
+/// ~3060 B of buffering must error after roughly the timeout, not park. Kinds:
+/// WouldBlock/TimedOut (contract) or BrokenPipe (xous tx maps NetError::TimedOut).
+/// XFAIL: the tcp_tx_waiting reaper is skipped by the NetPump quiet-iface early-return, services/net/src/main.rs:1305-1308.
+pub fn tcp_write_timeout_full_buffers() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    // the peer must stay open and must NOT read through the whole test, and
+    // the expected NTC-1 panic unwinds past this frame: ManuallyDrop (NTC-5)
+    let served = ManuallyDrop::new(served);
+    let listener = ManuallyDrop::new(listener);
+    check!(client.set_write_timeout(Some(Duration::from_secs(2))));
+    let (outcome, client) = bounded("write past full buffers with a 2 s write timeout", 10, move || {
+        let mut client = client;
+        let chunk = [0x5Au8; 512]; // deterministic filler
+        let mut total = 0usize;
+        let mut verdict = None;
+        for i in 1..=32u32 {
+            let started = Instant::now();
+            match client.write(&chunk) {
+                Ok(n) => total += n,
+                Err(e) => {
+                    verdict = Some((e, started.elapsed()));
+                    break;
+                }
+            }
+            if i % 5 == 0 {
+                log::info!("write {}: {} bytes accepted so far, still not blocked", i, total);
+            }
+            if total > 8192 {
+                break; // buffering is ~3060 B; way past means writes never block
+            }
+        }
+        ((total, verdict), client)
+    });
+    discard(client);
+    discard(ManuallyDrop::into_inner(served));
+    discard(ManuallyDrop::into_inner(listener));
+    let (total, verdict) = outcome;
+    let (err, err_elapsed) = verdict.unwrap_or_else(|| {
+        panic!(
+            "writes never blocked or errored: {} bytes accepted with the peer not reading \
+             (~3060 B of buffering expected)",
+            total
+        )
+    });
+    assert!(
+        err.kind() == ErrorKind::WouldBlock
+            || err.kind() == ErrorKind::TimedOut
+            || err.kind() == ErrorKind::BrokenPipe,
+        "write timeout surfaced as {:?} ({}), want WouldBlock/TimedOut (contract) or BrokenPipe (pinned xous tx map)",
+        err.kind(),
+        err
+    );
+    assert!(
+        err_elapsed >= Duration::from_millis(1500) && err_elapsed <= Duration::from_secs(4),
+        "blocked write returned after {:?}, want roughly the 2 s timeout",
+        err_elapsed
+    );
+    log::info!("{} bytes accepted before the blocking write", total);
+}
+
+/// Shared body for the two UDP recv-timeout tests: bind a UDP socket on the
+/// DUT's own IP (never 127.0.0.1 — NTC-2), set a 2 s read timeout, recv_from on
+/// the quiet socket under an 8 s bounded guard, and hand back (result,
+/// elapsed); the socket leaks with the worker on the hang path.
+fn udp_recv_timeout_quiet_outcome(desc: &str) -> (io::Result<(usize, SocketAddr)>, Duration) {
+    let port = next_port();
+    let sock = check!(UdpSocket::bind(SocketAddr::new(self_ip(), port)));
+    check!(sock.set_read_timeout(Some(Duration::from_secs(2))));
+    let (result, elapsed, _sock) = bounded(desc, 8, move || {
+        let started = Instant::now();
+        let mut buf = [0u8; 32];
+        let r = sock.recv_from(&mut buf);
+        (r, started.elapsed(), sock)
+    });
+    (result, elapsed)
+}
+
+/// recv_from with a 2 s read timeout on a quiet UDP socket must return an error
+/// after roughly 2 s. This owns the returns-at-all + elapsed contract; the
+/// error kind is asserted separately by udp_recv_timeout_error_kind.
+/// XFAIL: the udp_rx_waiting reaper sits behind the NetPump quiet-iface early-return, so recv_from never returns, services/net/src/main.rs:1561-1590.
+pub fn udp_recv_timeout_quiet() {
+    let (result, elapsed) =
+        udp_recv_timeout_quiet_outcome("udp recv_from with a 2 s timeout on a quiet socket");
+    match result {
+        Ok((n, from)) => {
+            panic!("recv_from on a quiet socket returned Ok(({}, {})) — nobody sent anything", n, from)
+        }
+        Err(e) => log::info!(
+            "recv_from errored as {:?} ({}) after {:?} (kind pinned by udp_recv_timeout_error_kind)",
+            e.kind(),
+            e,
+            elapsed
+        ),
+    }
+    assert!(
+        elapsed >= Duration::from_millis(1500) && elapsed <= Duration::from_secs(4),
+        "recv_from returned after {:?}, want roughly the 2 s timeout",
+        elapsed
+    );
+}
+
+/// The timeout error from recv_from must be WouldBlock-or-TimedOut, per the
+/// contract. Split from the hang layer so the kind is asserted independently.
+/// XFAIL: the recv_from never returns (same NetPump quiet-iface early-return), so the kind is never observed, services/net/src/main.rs:1305-1308.
+pub fn udp_recv_timeout_error_kind() {
+    let (result, _elapsed) = udp_recv_timeout_quiet_outcome("udp recv_from with a 2 s timeout (kind layer)");
+    match result {
+        Ok((n, from)) => {
+            panic!("recv_from on a quiet socket returned Ok(({}, {})) — nobody sent anything", n, from)
+        }
+        Err(e) => assert!(
+            e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut,
+            "udp recv timeout surfaced as {:?} ({}), want WouldBlock or TimedOut",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// set/get read & write timeout roundtrips — including reset to None and a
+/// large 15410 s value surviving intact — on both TcpStream and UdpSocket.
+/// Timeouts are client-side state stored in whole milliseconds.
+pub fn timeout_get_set_roundtrip() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let stream = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let udp = check!(UdpSocket::bind(SocketAddr::new(self_ip(), next_port())));
+    let big = Duration::new(15410, 0); // rust std's `timeouts` test value
+
+    // collect every outcome, release the sockets, then assert
+    // (collect-discard-assert: a failing assert must not unwind-drop a live
+    // TCP socket on the test thread — NTC-5)
+    let t_defaults = (stream.read_timeout(), stream.write_timeout());
+    let t_set = (stream.set_read_timeout(Some(big)), stream.set_write_timeout(Some(big)));
+    let t_get = (stream.read_timeout(), stream.write_timeout());
+    let t_clear = (stream.set_read_timeout(None), stream.set_write_timeout(None));
+    let t_cleared = (stream.read_timeout(), stream.write_timeout());
+    let u_defaults = (udp.read_timeout(), udp.write_timeout());
+    let u_set = (udp.set_read_timeout(Some(big)), udp.set_write_timeout(Some(big)));
+    let u_get = (udp.read_timeout(), udp.write_timeout());
+    let u_clear = (udp.set_read_timeout(None), udp.set_write_timeout(None));
+    let u_cleared = (udp.read_timeout(), udp.write_timeout());
+    discard(stream);
+    discard(listener);
+    drop(udp); // UDP closes are synchronous — safe inline
+
+    assert_eq!(check!(t_defaults.0), None, "TcpStream read_timeout default");
+    assert_eq!(check!(t_defaults.1), None, "TcpStream write_timeout default");
+    check!(t_set.0);
+    check!(t_set.1);
+    assert_eq!(check!(t_get.0), Some(big), "TcpStream read_timeout after set(15410 s)");
+    assert_eq!(check!(t_get.1), Some(big), "TcpStream write_timeout after set(15410 s)");
+    check!(t_clear.0);
+    check!(t_clear.1);
+    assert_eq!(check!(t_cleared.0), None, "TcpStream read_timeout after reset to None");
+    assert_eq!(check!(t_cleared.1), None, "TcpStream write_timeout after reset to None");
+    assert_eq!(check!(u_defaults.0), None, "UdpSocket read_timeout default");
+    assert_eq!(check!(u_defaults.1), None, "UdpSocket write_timeout default");
+    check!(u_set.0);
+    check!(u_set.1);
+    assert_eq!(check!(u_get.0), Some(big), "UdpSocket read_timeout after set(15410 s)");
+    assert_eq!(check!(u_get.1), Some(big), "UdpSocket write_timeout after set(15410 s)");
+    check!(u_clear.0);
+    check!(u_clear.1);
+    assert_eq!(check!(u_cleared.0), None, "UdpSocket read_timeout after reset to None");
+    assert_eq!(check!(u_cleared.1), None, "UdpSocket write_timeout after reset to None");
+}
+
+/// set_read_timeout/set_write_timeout(Some(ZERO)) must fail with InvalidInput
+/// on both protocols — Duration::ZERO is reserved to mean "unset". The check is
+/// client-side and never reaches the server.
+pub fn timeout_zero_duration_invalid_input() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let stream = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let udp = check!(UdpSocket::bind(SocketAddr::new(self_ip(), next_port())));
+    let outcomes = vec![
+        ("TcpStream::set_read_timeout", stream.set_read_timeout(Some(Duration::ZERO))),
+        ("TcpStream::set_write_timeout", stream.set_write_timeout(Some(Duration::ZERO))),
+        ("UdpSocket::set_read_timeout", udp.set_read_timeout(Some(Duration::ZERO))),
+        ("UdpSocket::set_write_timeout", udp.set_write_timeout(Some(Duration::ZERO))),
+    ];
+    let after = (stream.read_timeout(), udp.read_timeout());
+    discard(stream);
+    discard(listener);
+    drop(udp); // UDP closes are synchronous — safe inline
+    for (what, r) in outcomes {
+        match r {
+            Ok(()) => panic!("{}(Some(ZERO)) unexpectedly succeeded, want InvalidInput", what),
+            Err(e) => assert_eq!(
+                e.kind(),
+                ErrorKind::InvalidInput,
+                "{}(Some(ZERO)) surfaced as {:?} ({}), want InvalidInput",
+                what,
+                e.kind(),
+                e
+            ),
+        }
+    }
+    // the rejected set must not have clobbered the (default None) state
+    assert_eq!(check!(after.0), None, "TcpStream read_timeout after a rejected zero set");
+    assert_eq!(check!(after.1), None, "UdpSocket read_timeout after a rejected zero set");
+}
+
+/// Deviation-pin: Some(1 ns) is a valid std timeout, but the xous client stores
+/// timeouts via as_millis(), truncating 1 ns to the 0-ms "unset" sentinel, so
+/// the setter returns Ok and the getter reports None. Getter assertions only.
+pub fn timeout_submillisecond_getter_none() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let stream = check!(bounded("connect", 10, move || TcpStream::connect(addr)));
+    let udp = check!(UdpSocket::bind(SocketAddr::new(self_ip(), next_port())));
+    let one_ns = Duration::from_nanos(1);
+    let set_r = stream.set_read_timeout(Some(one_ns));
+    let get_r = stream.read_timeout();
+    let set_w = stream.set_write_timeout(Some(one_ns));
+    let get_w = stream.write_timeout();
+    let set_u = udp.set_read_timeout(Some(one_ns));
+    let get_u = udp.read_timeout();
+    discard(stream);
+    discard(listener);
+    drop(udp); // UDP closes are synchronous — safe inline
+    check!(set_r);
+    check!(set_w);
+    check!(set_u);
+    assert_eq!(check!(get_r), None, "pinned: TcpStream read_timeout(1 ns) truncates to the None sentinel");
+    assert_eq!(check!(get_w), None, "pinned: TcpStream write_timeout(1 ns) truncates to the None sentinel");
+    assert_eq!(check!(get_u), None, "pinned: UdpSocket read_timeout(1 ns) truncates to the None sentinel");
+}
+
+/// connect_timeout(500 ms) to an off-subnet blackhole must err after >= the
+/// timeout and within budget; the pinned kind is AddrNotAvailable (contract:
+/// TimedOut). Quarantined at the theme tail — it leaks a SynSent socket.
+/// XFAIL: the connect-timeout abort is serviced only via the NetPump connect scan, skipped by the quiet-iface early-return, services/net/src/main.rs:1336-1362.
+pub fn tcp_connect_timeout_fires() {
+    let addr = SocketAddr::new(IpAddr::V4(BLACKHOLE), 1);
+    let (result, elapsed) = bounded("connect_timeout(500 ms) to a blackhole", 10, move || {
+        let started = Instant::now();
+        let r = TcpStream::connect_timeout(&addr, Duration::from_millis(500));
+        (r, started.elapsed())
+    });
+    match result {
+        Ok(s) => {
+            discard(s);
+            panic!("connect_timeout to a blackhole unexpectedly succeeded");
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::AddrNotAvailable,
+            "blackhole connect_timeout surfaced as {:?} ({}), want the pinned AddrNotAvailable \
+             (the contract kind would be TimedOut)",
+            e.kind(),
+            e
+        ),
+    }
+    assert!(
+        elapsed >= Duration::from_millis(450) && elapsed <= Duration::from_secs(5),
+        "connect_timeout(500 ms) returned after {:?}, want >= the timeout and well under the guard",
+        elapsed
+    );
+}
+
+/// Documented-hang pin: a PLAIN connect() to the blackhole parks forever — the
+/// client sends timeout 0, so smoltcp sets no socket timeout and never gives up
+/// SYN retransmission; PASSES only if the connect is still parked after a 10 s inverted guard, any completion means reclassify.
+pub fn tcp_plain_connect_blackhole_parks() {
+    let addr = SocketAddr::new(IpAddr::V4(BLACKHOLE), 2);
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        tx.send(TcpStream::connect(addr)).ok();
+    });
+    match rx.recv_timeout(Duration::from_secs(10)) {
+        Err(RecvTimeoutError::Timeout) => {
+            log::info!(
+                "plain blackhole connect still parked after 10 s — pinned behavior holds; leaking the worker"
+            );
+        }
+        Ok(Ok(s)) => {
+            discard(s);
+            panic!(
+                "plain connect to a blackhole succeeded — the documented park-forever pin no longer \
+                 holds; reclassify TO-10"
+            );
+        }
+        Ok(Err(e)) => panic!(
+            "plain connect to a blackhole returned {:?} ({}) within 10 s — the documented \
+             park-forever pin no longer holds (smoltcp SYN give-up?); reclassify TO-10",
+            e.kind(),
+            e
+        ),
+        Err(RecvTimeoutError::Disconnected) => panic!("blackhole connect worker panicked"),
+    }
+}
+
+/// DANGER — disabled, NOT registered: asserts a connect timeout must affect
+/// only the connect, not linger as a session timeout. Disabled because the
+/// reproducer WEDGES rather than failing cleanly (the aborted connection's tx
+/// waiter never completes, NTC-1), and the runner counts any wedge as a hard fail.
+#[allow(dead_code)]
+pub fn connect_timeout_not_a_session_timeout() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    let client = check!(bounded("connect_timeout(1 s) to a live listener", 10, move || {
+        TcpStream::connect_timeout(&addr, Duration::from_secs(1))
+    }));
+    let (accepted, listener) = bounded("accept", 10, move || {
+        let r = listener.accept();
+        (r, listener)
+    });
+    let (served, _peer) = check!(accepted);
+    // guard-panic paths below must not unwind-drop the listener (NTC-5)
+    let listener = ManuallyDrop::new(listener);
+
+    // 4096 B > the ~3060 B of buffering (1530 tx + 1530 peer rx)
+    let mut payload = vec![0u8; 4096];
+    XorShift::new(0x7011).fill(&mut payload);
+    let expected = payload.clone();
+
+    // hand-rolled worker instead of bounded(): bounded blocks the test
+    // thread, which must spend the next 3 s stalling as the non-reading peer
+    let (wtx, wrx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut client = client;
+        let r = client.write_all(&payload);
+        wtx.send((r, client)).ok();
+    });
+
+    log::info!("peer stalling 3 s (virtual) with client tx data pending");
+    thread::sleep(Duration::from_secs(3));
+    log::info!("stall over, draining 4096 B");
+
+    let (drained, served) = bounded("peer drain after the 3 s stall", 10, move || {
+        let mut served = served;
+        let mut got = Vec::with_capacity(4096);
+        let mut buf = [0u8; 1024];
+        let mut chunks = 0usize;
+        let r = loop {
+            match served.read(&mut buf) {
+                Ok(0) => break Err(format!("EOF after {} bytes — connection died mid-stall", got.len())),
+                Ok(n) => {
+                    got.extend_from_slice(&buf[..n]);
+                    chunks += 1;
+                    if chunks % 5 == 0 {
+                        log::info!("drain: {} chunks, {} bytes", chunks, got.len());
+                    }
+                    if got.len() >= 4096 {
+                        break Ok(got);
+                    }
+                }
+                Err(e) => break Err(format!("peer read failed after the stall: {}", e)),
+            }
+        };
+        (r, served)
+    });
+    let write_outcome = match wrx.recv_timeout(Duration::from_secs(10)) {
+        Ok((r, client)) => {
+            discard(client);
+            Some(r)
+        }
+        // writer thread and its socket leak (ports are never reused)
+        Err(RecvTimeoutError::Timeout) => None,
+        Err(RecvTimeoutError::Disconnected) => panic!("writer thread panicked"),
+    };
+    discard(served);
+    discard(ManuallyDrop::into_inner(listener));
+    match write_outcome {
+        None => panic!(
+            "PROBE TO-11: write_all(4096) never completed within 10 s of the drain — possible \
+             lingering-session-timeout abort with the tx waiter stranded (writer leaked)"
+        ),
+        Some(Err(e)) => panic!(
+            "PROBE TO-11: write_all failed with {:?} ({}) — the connect timeout appears to persist \
+             as a session timeout",
+            e.kind(),
+            e
+        ),
+        Some(Ok(())) => {}
+    }
+    match drained {
+        Ok(got) => assert_eq!(got, expected, "payload corrupted across the 3 s stall"),
+        Err(msg) => panic!("PROBE TO-11: {}", msg),
+    }
+}
+
+/// Regression guard — MUST stay the FINAL registered test in the suite: a loopback
+/// connect to a live listener must still succeed after the two preceding blackhole
+/// tests each leak a SynSent socket; its 10 s bounded guard fires on any post-blackhole connect jam.
+pub fn tcp_connect_after_blackhole_still_works() {
+    let port = next_port();
+    let addr = SocketAddr::new(LOOPBACK, port);
+    let listener = check!(TcpListener::bind(addr));
+    // if a jam ever reintroduces itself the connect panics out of bounded()
+    // past this frame: park the listener in ManuallyDrop so the unwind cannot
+    // block on a close (NTC-5) — leaked on the panic path, discarded on the
+    // happy path (the one-socket listener completes the handshake without an
+    // accept)
+    let listener = ManuallyDrop::new(listener);
+    let client = check!(bounded("connect after blackhole", 10, move || TcpStream::connect(addr)));
+    discard(client);
+    discard(ManuallyDrop::into_inner(listener));
+}
+
+/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+pub const TESTS: &[TestEntry] = &[
+    ("timeouts::tcp_read_timeout_after_data", tcp_read_timeout_after_data as fn()),
+    ("timeouts::tcp_peek_timeout_quiet", tcp_peek_timeout_quiet as fn()),
+    ("timeouts::tcp_write_timeout_full_buffers", tcp_write_timeout_full_buffers as fn()),
+    ("timeouts::udp_recv_timeout_quiet", udp_recv_timeout_quiet as fn()),
+    ("timeouts::udp_recv_timeout_error_kind", udp_recv_timeout_error_kind as fn()),
+    ("timeouts::timeout_get_set_roundtrip", timeout_get_set_roundtrip as fn()),
+    ("timeouts::timeout_zero_duration_invalid_input", timeout_zero_duration_invalid_input as fn()),
+    ("timeouts::timeout_submillisecond_getter_none", timeout_submillisecond_getter_none as fn()),
+    // connect_timeout_not_a_session_timeout (NTC-20) is DISABLED, not
+    // registered — it wedges rather than failing cleanly (see its doc comment).
+    // The two blackhole tests below leak SynSent sockets, so
+    // tcp_connect_after_blackhole_still_works stays the FINAL entry as a guard.
+    ("timeouts::tcp_connect_timeout_fires", tcp_connect_timeout_fires as fn()),
+    ("timeouts::tcp_plain_connect_blackhole_parks", tcp_plain_connect_blackhole_parks as fn()),
+    ("timeouts::tcp_connect_after_blackhole_still_works", tcp_connect_after_blackhole_still_works as fn()),
+];
+
+pub const XFAILS: &[XfailEntry] = &[
+    ("timeouts::tcp_read_timeout_after_data", "NTC-1"),
+    ("timeouts::tcp_peek_timeout_quiet", "NTC-1"),
+    ("timeouts::tcp_write_timeout_full_buffers", "NTC-1"),
+    ("timeouts::udp_recv_timeout_quiet", "NTC-1"),
+    ("timeouts::udp_recv_timeout_error_kind", "NTC-1"),
+    ("timeouts::tcp_connect_timeout_fires", "NTC-1"),
+];

--- a/services/net-tests/src/tests/udp.rs
+++ b/services/net-tests/src/tests/udp.rs
@@ -1,0 +1,432 @@
+//! udp theme — datagram semantics over the DUT's self-IP loopback path.
+//!
+//! Live constraints (see also tests/mod.rs): every socket binds self_ip(),
+//! never 127.0.0.1 (std_udp force-rebinds to iface.ipv4_addr()); every port is
+//! explicit because UDP bind to port 0 FAILS on xous; the rx queue holds at
+//! most TWO undelivered datagrams (2 PacketMetadata slots), so tests drain
+//! between sends. UDP closes are synchronous, so plain drops are safe inline
+//! but blocking recv/peek still runs inside bounded().
+
+use std::io::ErrorKind;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
+use std::time::Duration;
+
+use crate::harness::{XorShift, bounded, check, next_port, self_ip};
+use crate::tests::{TestEntry, XfailEntry};
+
+/// Bind a UDP socket on the DUT's own IP at a fresh port and return it with its
+/// address. Always explicit — UDP port-0 assignment does not exist on xous (see
+/// udp_bind_port_zero_fails).
+fn bind_self() -> (UdpSocket, SocketAddr) {
+    let addr = SocketAddr::new(self_ip(), next_port());
+    (check!(UdpSocket::bind(addr)), addr)
+}
+
+/// peek_from must not consume: two consecutive peeks return the same datagram
+/// and source, recv_from then consumes it, and the queue is empty afterwards.
+pub fn udp_peek_from_does_not_consume() {
+    let (tx, tx_addr) = bind_self();
+    let (rx, rx_addr) = bind_self();
+    let mut payload = [0u8; 32];
+    XorShift::new(rx_addr.port() as u32).fill(&mut payload);
+    assert_eq!(check!(tx.send_to(&payload, rx_addr)), 32, "send_to length");
+    let (first, first_buf, rx) = bounded("first peek_from", 10, move || {
+        let mut buf = [0u8; 64];
+        let r = rx.peek_from(&mut buf);
+        (r, buf, rx)
+    });
+    let (n, from) = check!(first);
+    assert_eq!(&first_buf[..n], &payload[..], "first peek payload");
+    assert_eq!(from, tx_addr, "first peek source address");
+    let (second, second_buf, rx) = bounded("second peek_from", 10, move || {
+        let mut buf = [0u8; 64];
+        let r = rx.peek_from(&mut buf);
+        (r, buf, rx)
+    });
+    let (n, from) = check!(second);
+    assert_eq!(&second_buf[..n], &payload[..], "second peek payload (peek must not consume)");
+    assert_eq!(from, tx_addr, "second peek source address");
+    let (consumed, recv_buf, rx) = bounded("recv_from after two peeks", 10, move || {
+        let mut buf = [0u8; 64];
+        let r = rx.recv_from(&mut buf);
+        (r, buf, rx)
+    });
+    let (n, from) = check!(consumed);
+    assert_eq!(&recv_buf[..n], &payload[..], "recv payload after peeks");
+    assert_eq!(from, tx_addr, "recv source address");
+    check!(rx.set_nonblocking(true));
+    let mut buf = [0u8; 64];
+    assert!(
+        rx.recv_from(&mut buf).is_err(),
+        "queue must be empty once recv_from consumed the peeked datagram"
+    );
+}
+
+/// recv_from into a buffer smaller than the datagram (10-byte buffer, 100-byte
+/// datagram) must return Ok(n <= 10) with the excess discarded.
+/// XFAIL: the client copies min(buf, rxlen) bytes but returns the full datagram length — Ok(100) from a 10-byte buffer (client-side), xous udp.rs.
+pub fn udp_recv_buffer_smaller_than_datagram() {
+    let (tx, tx_addr) = bind_self();
+    let (rx, rx_addr) = bind_self();
+    let mut payload = [0u8; 100];
+    XorShift::new(rx_addr.port() as u32).fill(&mut payload);
+    assert_eq!(check!(tx.send_to(&payload, rx_addr)), 100, "send_to length");
+    let (result, buf, _rx) = bounded("recv_from into a 10-byte buffer", 10, move || {
+        let mut buf = [0u8; 10];
+        let r = rx.recv_from(&mut buf);
+        (r, buf, rx)
+    });
+    let (n, from) = check!(result);
+    assert_eq!(from, tx_addr, "source address");
+    assert_eq!(&buf[..], &payload[..10], "buffer must hold the datagram's first 10 bytes");
+    assert!(
+        n <= 10,
+        "recv_from returned {} from a 10-byte buffer — client reports the full datagram \
+         length instead of bytes written (NTC-8, xous_udp.rs:182-185)",
+        n
+    );
+    assert_eq!(n, 10, "recv length must be min(buffer, datagram)");
+}
+
+/// PROBE: zero-length datagrams are legal — send_to(&[]) returns Ok(0) and the
+/// peer's recv_from returns Ok((0, sender)). Unverified on xous; asserts the
+/// standard contract, and the bounded recv reclassifies it if never delivered.
+pub fn udp_zero_len_datagram() {
+    let (tx, tx_addr) = bind_self();
+    let (rx, rx_addr) = bind_self();
+    assert_eq!(check!(tx.send_to(&[], rx_addr)), 0, "send_to(&[]) length");
+    let (result, rx) = bounded("recv_from of a zero-length datagram", 10, move || {
+        let mut buf = [0u8; 16];
+        let r = rx.recv_from(&mut buf);
+        (r, rx)
+    });
+    drop(rx); // UDP close is synchronous; safe inline
+    let (n, from) = check!(result);
+    assert_eq!(n, 0, "zero-length datagram recv length");
+    assert_eq!(from, tx_addr, "zero-length datagram source address");
+}
+
+/// Deviation-pin: the rx queue holds at most TWO undelivered datagrams (2
+/// PacketMetadata slots) — a third sent unread is dropped; draining yields #1
+/// and #2 in order, then empty. Sends are spaced 2 s to serialize the loopback trip.
+pub fn udp_rx_queue_depth_two() {
+    let (tx, tx_addr) = bind_self();
+    let (rx, rx_addr) = bind_self();
+    let payloads: [&[u8]; 3] = [b"dgram-one", b"dgram-two", b"dgram-three"];
+    for (i, p) in payloads.iter().enumerate() {
+        assert_eq!(check!(tx.send_to(p, rx_addr)), p.len(), "send_to length for datagram {}", i);
+        log::info!("queue-depth: datagram {} sent, letting it land", i);
+        std::thread::sleep(Duration::from_millis(2000));
+    }
+    let mut rx = rx;
+    for i in 0..2usize {
+        let (result, buf, rx_back) = bounded("drain recv_from", 10, move || {
+            let mut buf = [0u8; 32];
+            let r = rx.recv_from(&mut buf);
+            (r, buf, rx)
+        });
+        rx = rx_back;
+        let (n, from) = check!(result);
+        assert_eq!(&buf[..n], payloads[i], "drained datagram {} out of order or corrupted", i);
+        assert_eq!(from, tx_addr, "drained datagram {} source address", i);
+        log::info!("queue-depth: drained datagram {}", i);
+    }
+    check!(rx.set_nonblocking(true));
+    let mut buf = [0u8; 32];
+    assert!(
+        rx.recv_from(&mut buf).is_err(),
+        "third datagram must have been dropped (2 metadata slots), but the queue still has data"
+    );
+}
+
+/// UDP is fire-and-forget: send_to a never-bound port returns Ok(len), later
+/// sends still work, and nothing ever arrives back (xous never propagates ICMP
+/// port-unreachable to UDP sockets).
+pub fn udp_send_to_dead_port_ok() {
+    let (sock, _sock_addr) = bind_self();
+    let dead = SocketAddr::new(self_ip(), next_port()); // allocated, never bound
+    assert_eq!(check!(sock.send_to(b"nobody-home", dead)), 11, "send_to a dead port length");
+    // give any hypothetical error propagation time to land, then prove the
+    // socket is still healthy and its queue still quiet
+    std::thread::sleep(Duration::from_millis(2000));
+    assert_eq!(check!(sock.send_to(b"still-alive", dead)), 11, "second send_to after the first");
+    check!(sock.set_nonblocking(true));
+    let mut buf = [0u8; 32];
+    assert!(sock.recv_from(&mut buf).is_err(), "nothing must ever arrive back on the sender");
+}
+
+/// Deviation-pin: connected-UDP does NOT filter by peer on xous — the client's
+/// connect() is bookkeeping only and never tells the server, so recv() behaves
+/// like recv_from(); a third socket's datagram reaches a socket connected elsewhere.
+pub fn udp_connect_does_not_filter_peer() {
+    let (receiver, receiver_addr) = bind_self();
+    let (_peer, peer_addr) = bind_self();
+    let (third, third_addr) = bind_self();
+    check!(receiver.connect(peer_addr));
+    assert_eq!(check!(third.send_to(b"interloper", receiver_addr)), 10, "third-party send_to length");
+    let (result, buf, _receiver) = bounded("recv on a connected socket", 10, move || {
+        let mut buf = [0u8; 32];
+        let r = receiver.recv(&mut buf);
+        (r, buf, receiver)
+    });
+    let n = check!(result);
+    assert_eq!(
+        &buf[..n],
+        b"interloper",
+        "pin: recv() on a socket connected to {:?} must still deliver the third party's ({:?}) datagram",
+        peer_addr,
+        third_addr
+    );
+}
+
+/// Unconnected-socket errors are client-side and correct: send() and peer_addr()
+/// before connect() both fail NotConnected; after connect(), peer_addr() returns
+/// the address and send() delivers to it.
+pub fn udp_send_before_connect_notconnected() {
+    let (sock, sock_addr) = bind_self();
+    let (peer, peer_addr) = bind_self();
+    match sock.send(b"early") {
+        Ok(n) => panic!("send() before connect() returned Ok({})", n),
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::NotConnected,
+            "send() before connect() surfaced as {:?} ({}), want NotConnected",
+            e.kind(),
+            e
+        ),
+    }
+    match sock.peer_addr() {
+        Ok(a) => panic!("peer_addr() before connect() returned {:?}", a),
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::NotConnected,
+            "peer_addr() before connect() surfaced as {:?} ({}), want NotConnected",
+            e.kind(),
+            e
+        ),
+    }
+    check!(sock.connect(peer_addr));
+    assert_eq!(check!(sock.peer_addr()), peer_addr, "peer_addr() after connect()");
+    assert_eq!(check!(sock.send(b"hello-peer")), 10, "send() after connect() length");
+    let (result, buf, _peer) = bounded("recv_from on the connected-send peer", 10, move || {
+        let mut buf = [0u8; 32];
+        let r = peer.recv_from(&mut buf);
+        (r, buf, peer)
+    });
+    let (n, from) = check!(result);
+    assert_eq!(&buf[..n], b"hello-peer", "connected send() payload");
+    assert_eq!(from, sock_addr, "connected send() source address");
+}
+
+/// Deviation-pin: binding UDP to port 0 FAILS on xous instead of assigning an
+/// ephemeral port — smoltcp rejects port 0 and std_udp_bind has no assignment
+/// path; the kind is pinned to Other on this toolchain (hence every test uses next_port()).
+pub fn udp_bind_port_zero_fails() {
+    match UdpSocket::bind(SocketAddr::new(self_ip(), 0)) {
+        Ok(sock) => {
+            let got = sock.local_addr();
+            drop(sock); // UDP close is synchronous; safe inline
+            panic!("bind to port 0 unexpectedly succeeded (local_addr {:?}) — re-evaluate the U-10 pin", got);
+        }
+        Err(e) => assert_eq!(
+            e.kind(),
+            ErrorKind::Other,
+            "port-0 bind error surfaced as {:?} ({}), pinned as Other on this toolchain",
+            e.kind(),
+            e
+        ),
+    }
+}
+
+/// DANGER, NOT REGISTERED — an oversized send_to PANICS THE NET SERVICE: the
+/// client declares len=buf.len() uncapped and the server slices bytes[21..21+len]
+/// out of the 4096-byte page (OOB for any buf > 4075), hanging the run. Kept as
+/// the contract reproducer: an oversize send must fail cleanly or send the whole buffer.
+#[allow(dead_code)]
+pub fn udp_send_to_oversize_payload_disabled() {
+    let (tx, _tx_addr) = bind_self();
+    let (rx, rx_addr) = bind_self();
+    let mut payload = vec![0u8; 4096]; // > 4075 == 4096 - 21-byte header
+    XorShift::new(rx_addr.port() as u32).fill(&mut payload);
+    match tx.send_to(&payload, rx_addr) {
+        Ok(n) => assert_eq!(
+            n,
+            payload.len(),
+            "oversize send_to silently truncated: sent {} of {} bytes",
+            n,
+            payload.len()
+        ),
+        Err(e) => log::info!("oversize send_to failed cleanly: {} ({:?})", e, e.kind()),
+    }
+    drop(rx);
+}
+
+/// Deviation-pin: a 2000-byte datagram (> NET_MTU=1530) silently vanishes —
+/// send_to returns Ok(2000) but smoltcp emits no IPv4 fragments, so it is
+/// dropped at dispatch. Payload <= 4075 B keeps clear of the oversize-send panic.
+pub fn udp_datagram_larger_than_mtu() {
+    let (tx, _tx_addr) = bind_self();
+    let (rx, rx_addr) = bind_self();
+    let mut payload = vec![0u8; 2000];
+    XorShift::new(rx_addr.port() as u32).fill(&mut payload);
+    assert_eq!(check!(tx.send_to(&payload, rx_addr)), 2000, "send_to(2000 B) length");
+    check!(rx.set_nonblocking(true));
+    let mut buf = vec![0u8; 4096];
+    let mut outcome = None;
+    for try_n in 1..=20u32 {
+        match rx.recv_from(&mut buf) {
+            Err(_) => {
+                if try_n % 5 == 0 {
+                    log::info!("mtu pin: poll {} of 20, queue still empty", try_n);
+                }
+                std::thread::sleep(Duration::from_millis(250));
+            }
+            got => {
+                outcome = Some(got);
+                break;
+            }
+        }
+    }
+    match outcome {
+        None => log::info!(
+            "2000-byte datagram sent Ok and never delivered within 20 polls (~5 s) \
+             (pinned: no IPv4 fragmentation past NET_MTU=1530)"
+        ),
+        Some(Ok((n, from))) => panic!(
+            "a {}-byte datagram from {} was delivered — the no-fragmentation pin no longer \
+             holds; re-point this test at the contract (intact 2000-byte delivery) and drop \
+             the pin",
+            n, from
+        ),
+        Some(Err(e)) => {
+            panic!("recv_from failed with {:?} ({}) instead of the queue staying empty", e.kind(), e)
+        }
+    }
+}
+
+/// Deviation-pin: a second bind of an already-bound port should fail EADDRINUSE,
+/// but on xous BOTH binds succeed — every bind makes a fresh smoltcp socket and
+/// nothing scans for cross-socket conflicts (UDP mirror of tcp_double_bind_same_port).
+pub fn udp_double_bind_same_port() {
+    let addr = SocketAddr::new(self_ip(), next_port());
+    let first = check!(UdpSocket::bind(addr));
+    let second = UdpSocket::bind(addr);
+    // UDP closes are synchronous: inline drops are safe, even mid-panic
+    match second {
+        Ok(sock) => {
+            drop(sock);
+            drop(first);
+            log::info!("second bind of {} succeeded (pinned: no cross-socket conflict detection)", addr);
+        }
+        Err(e) => {
+            let (kind, msg) = (e.kind(), e.to_string());
+            drop(first);
+            panic!(
+                "second bind of {} was refused with {:?} ({}) — the no-conflict-detection pin \
+                 no longer holds; re-point this test at the contract (AddrInUse) and drop the pin",
+                addr, kind, msg
+            );
+        }
+    }
+}
+
+/// Deviation-pin: binding UDP to a foreign address (1.1.1.1) SUCCEEDS on xous —
+/// std_udp_bind has no bind-address whitelist and smoltcp accepts any endpoint.
+/// local_addr() echoes the foreign address verbatim (the client never queries the server).
+pub fn udp_bind_foreign_addr_succeeds() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), next_port());
+    let sock = check!(UdpSocket::bind(addr));
+    assert_eq!(check!(sock.local_addr()), addr, "local_addr echoes the foreign bind address");
+}
+
+/// local_addr() returns the bound address exactly for explicit binds — the
+/// client stores the requested SocketAddr at bind time and returns it verbatim
+/// without a server round-trip.
+pub fn udp_local_addr_is_bound_addr() {
+    let (sock, addr) = bind_self();
+    assert_eq!(check!(sock.local_addr()), addr, "local_addr vs bind address");
+}
+
+/// Drop a UDP socket and immediately rebind its port: must succeed (StdUdpClose
+/// synchronously removes the socket, no UDP TIME_WAIT) and the rebound socket
+/// must receive. The suite's ONLY deliberate port reuse — reuse is under test.
+pub fn udp_fast_rebind_after_drop() {
+    let port = next_port();
+    let addr = SocketAddr::new(self_ip(), port);
+    let first = check!(UdpSocket::bind(addr));
+    drop(first); // synchronous close: the port is free once this returns
+    let rebound = check!(UdpSocket::bind(addr));
+    let (helper, helper_addr) = bind_self();
+    assert_eq!(check!(helper.send_to(b"rebound", addr)), 7, "send_to the rebound socket");
+    let (result, buf, _rebound) = bounded("recv_from on the rebound socket", 10, move || {
+        let mut buf = [0u8; 32];
+        let r = rebound.recv_from(&mut buf);
+        (r, buf, rebound)
+    });
+    let (n, from) = check!(result);
+    assert_eq!(&buf[..n], b"rebound", "rebound socket payload");
+    assert_eq!(from, helper_addr, "rebound socket source address");
+}
+
+/// Two independent socket pairs with interleaved traffic demux by destination
+/// port with no cross-delivery — a detector for cross-talk from the force-rebind
+/// hack that leaves the port the only demux key. One datagram per flow per round.
+pub fn udp_two_sockets_interleaved() {
+    let (tx1, tx1_addr) = bind_self();
+    let (mut rx1, rx1_addr) = bind_self();
+    let (tx2, tx2_addr) = bind_self();
+    let (mut rx2, rx2_addr) = bind_self();
+    for round in 0u8..3 {
+        let p1 = [0x10 | round; 12];
+        let p2 = [0x20 | round; 12];
+        assert_eq!(check!(tx1.send_to(&p1, rx1_addr)), 12, "pair-1 send length, round {}", round);
+        assert_eq!(check!(tx2.send_to(&p2, rx2_addr)), 12, "pair-2 send length, round {}", round);
+        let (r1, b1, rx1_back) = bounded("pair-1 recv_from", 10, move || {
+            let mut buf = [0u8; 32];
+            let r = rx1.recv_from(&mut buf);
+            (r, buf, rx1)
+        });
+        rx1 = rx1_back;
+        let (n, from) = check!(r1);
+        assert_eq!(&b1[..n], &p1[..], "pair-1 payload, round {} (cross-delivery?)", round);
+        assert_eq!(from, tx1_addr, "pair-1 source address, round {}", round);
+        let (r2, b2, rx2_back) = bounded("pair-2 recv_from", 10, move || {
+            let mut buf = [0u8; 32];
+            let r = rx2.recv_from(&mut buf);
+            (r, buf, rx2)
+        });
+        rx2 = rx2_back;
+        let (n, from) = check!(r2);
+        assert_eq!(&b2[..n], &p2[..], "pair-2 payload, round {} (cross-delivery?)", round);
+        assert_eq!(from, tx2_addr, "pair-2 source address, round {}", round);
+        log::info!("interleaved round {} complete", round);
+    }
+    // nothing may be left over anywhere: a stray datagram means cross-talk
+    for (name, sock) in [("tx1", &tx1), ("rx1", &rx1), ("tx2", &tx2), ("rx2", &rx2)] {
+        check!(sock.set_nonblocking(true));
+        let mut buf = [0u8; 32];
+        assert!(sock.recv_from(&mut buf).is_err(), "{} holds an unexpected leftover datagram", name);
+    }
+}
+
+/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// udp_send_to_oversize_payload_disabled is intentionally absent: DANGER, it
+/// panics the net service on the pinned toolchain.
+pub const TESTS: &[TestEntry] = &[
+    ("udp::udp_peek_from_does_not_consume", udp_peek_from_does_not_consume as fn()),
+    ("udp::udp_recv_buffer_smaller_than_datagram", udp_recv_buffer_smaller_than_datagram as fn()),
+    ("udp::udp_zero_len_datagram", udp_zero_len_datagram as fn()),
+    ("udp::udp_rx_queue_depth_two", udp_rx_queue_depth_two as fn()),
+    ("udp::udp_send_to_dead_port_ok", udp_send_to_dead_port_ok as fn()),
+    ("udp::udp_connect_does_not_filter_peer", udp_connect_does_not_filter_peer as fn()),
+    ("udp::udp_send_before_connect_notconnected", udp_send_before_connect_notconnected as fn()),
+    ("udp::udp_bind_port_zero_fails", udp_bind_port_zero_fails as fn()),
+    ("udp::udp_datagram_larger_than_mtu", udp_datagram_larger_than_mtu as fn()),
+    ("udp::udp_double_bind_same_port", udp_double_bind_same_port as fn()),
+    ("udp::udp_bind_foreign_addr_succeeds", udp_bind_foreign_addr_succeeds as fn()),
+    ("udp::udp_local_addr_is_bound_addr", udp_local_addr_is_bound_addr as fn()),
+    ("udp::udp_fast_rebind_after_drop", udp_fast_rebind_after_drop as fn()),
+    ("udp::udp_two_sockets_interleaved", udp_two_sockets_interleaved as fn()),
+];
+
+pub const XFAILS: &[XfailEntry] = &[("udp::udp_recv_buffer_smaller_than_datagram", "NTC-8")];

--- a/services/net/Cargo.toml
+++ b/services/net/Cargo.toml
@@ -64,4 +64,7 @@ precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
 renode = ["utralib/renode"]
 renode-minimal = []
+# Tier-2 test images: a real DHCP peer (emulation/linux-server.resc) is on the
+# switch, so skip the renode-minimal static-config seed and take a real lease.
+renode-peer = []
 default = []

--- a/services/net/src/main.rs
+++ b/services/net/src/main.rs
@@ -134,10 +134,91 @@ fn set_com_ints(com_int_list: &mut Vec<ComIntSources>) {
     com_int_list.push(ComIntSources::Invalid);
 }
 
+/// Install an IPv4 configuration on the interface. The production caller is the
+/// `WlanIpConfigUpdate` COM interrupt handler, which invokes this when the EC's
+/// DHCP client binds; test images (renode-minimal) also call it once at boot to
+/// seed a static config, because no DHCP peer exists on the emulated network.
+fn apply_ipv4_config(
+    config: Ipv4Conf,
+    net_config: &mut Option<Ipv4Conf>,
+    iface: &mut Interface,
+    dns_allclear_hook: &mut XousScalarEndpoint,
+    dns_ipv4_hook: &mut XousScalarEndpoint,
+) {
+    log::info!("Network config acquired: {:?}", config);
+    log::info!(
+        "{}NET.OK,{:?},{}",
+        precursor_hal::board::BOOKEND_START,
+        std::net::IpAddr::from(config.addr),
+        precursor_hal::board::BOOKEND_END
+    );
+    *net_config = Some(config);
+    // update a static variable that tracks this, useful for e.g. UDP bind
+    // address checking
+    IPV4_ADDRESS.store(u32::from_be_bytes(config.addr), Ordering::SeqCst);
+
+    if config.addr != [127, 0, 0, 1] {
+        // note: ARP cache is stale. Maybe that's ok?
+        iface.update_ip_addrs(|ip_addrs| {
+            ip_addrs.clear();
+            ip_addrs
+                .push(IpCidr::new(
+                    IpAddress::v4(config.addr[0], config.addr[1], config.addr[2], config.addr[3]),
+                    24,
+                ))
+                .unwrap();
+            // ...and the loopback interface
+            ip_addrs.push(IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8)).unwrap();
+        });
+    } else {
+        log::warn!("Attempt to update the loopback interface! Ignoring.");
+    }
+    // reset the default route, in case it has changed
+    iface.routes_mut().remove_default_ipv4_route();
+    iface
+        .routes_mut()
+        .add_default_ipv4_route(Ipv4Address::new(
+            config.gtwy[0],
+            config.gtwy[1],
+            config.gtwy[2],
+            config.gtwy[3],
+        ))
+        .unwrap();
+
+    dns_allclear_hook.notify();
+    dns_ipv4_hook.notify_custom_args([Some(u32::from_be_bytes(config.dns1)), None, None, None]);
+    // the current implementation always returns 0.0.0.0 as the second dns,
+    // ignore this if that's what we've got; otherwise, pass it on.
+    if config.dns2 != [0, 0, 0, 0] {
+        dns_ipv4_hook.notify_custom_args([Some(u32::from_be_bytes(config.dns2)), None, None, None]);
+    }
+}
+
 fn main() -> ! {
     log_server::init_wait().unwrap();
     log::set_max_level(log::LevelFilter::Info);
     log::info!("my PID is {}", xous::process::id());
+
+    // test images (renode-minimal): the on-target std::net suite deliberately
+    // leaks sockets while pinning close/timeout bugs (a leaked socket's rx/tx
+    // buffers stay allocated in this process, and a UDP socket alone costs
+    // ~128 KiB), which overruns the default heap ceiling partway through the
+    // run. Raise it the same way pddb does for its larger working set.
+    #[cfg(feature = "renode-minimal")]
+    {
+        const HEAP_LARGER_LIMIT: usize = 4096 * 1024;
+        if let Ok(xous::Result::Scalar2(1, current_limit)) = xous::rsyscall(
+            xous::SysCall::AdjustProcessLimit(xous::Limits::HeapMaximum as usize, 0, HEAP_LARGER_LIMIT),
+        ) {
+            xous::rsyscall(xous::SysCall::AdjustProcessLimit(
+                xous::Limits::HeapMaximum as usize,
+                current_limit,
+                HEAP_LARGER_LIMIT,
+            ))
+            .expect("couldn't adjust heap limit");
+            log::info!("heap limit increased to: {}", HEAP_LARGER_LIMIT);
+        }
+    }
 
     let xns = xous_names::XousNames::new().unwrap();
     let net_sid = xns.register_name(api::SERVER_NAME_NET, None).expect("can't register server");
@@ -369,6 +450,38 @@ fn main() -> ! {
                 }
             }
         }
+        // test images (renode-minimal): no DHCP peer exists on the emulated wifi
+        // switch, so a WlanIpConfigUpdate interrupt never fires and the interface
+        // would keep an empty address list forever. Seed a static config equivalent
+        // to a DHCP bind through the exact handler the production interrupt path
+        // uses. Deferred until config_valid: the bogus-MAC recovery above rebuilds
+        // `iface` from scratch, which would wipe an earlier injection.
+        // Tier-2 images (renode-peer) DO have a DHCP peer on the switch, so they
+        // skip the seed and take a real lease instead (a seed would fight the
+        // real Bound report and flap the address).
+        #[cfg(all(feature = "renode-minimal", not(feature = "renode-peer")))]
+        if config_valid && net_config.is_none() {
+            let msb = MAC_ADDRESS_MSB.load(Ordering::SeqCst).to_be_bytes();
+            let lsb = MAC_ADDRESS_LSB.load(Ordering::SeqCst).to_be_bytes();
+            apply_ipv4_config(
+                Ipv4Conf {
+                    dhcp: com_rs::DhcpState::Bound,
+                    mac: [msb[0], msb[1], lsb[0], lsb[1], lsb[2], lsb[3]],
+                    addr: [10, 0, 2, 15],
+                    gtwy: [10, 0, 2, 1],
+                    mask: [255, 255, 255, 0],
+                    // the resolver is the DUT itself: the test suite runs a fake
+                    // DNS server on its own address to exercise the dns service's
+                    // query/decode path hermetically
+                    dns1: [10, 0, 2, 15],
+                    dns2: [0, 0, 0, 0],
+                },
+                &mut net_config,
+                &mut iface,
+                &mut dns_allclear_hook,
+                &mut dns_ipv4_hook,
+            );
+        }
         let now = timer.elapsed_ms();
         let timestamp = Instant::from_millis(now as i64);
         let deadline = match iface.poll_at(timestamp, &sockets) {
@@ -562,6 +675,27 @@ fn main() -> ! {
                         hook.args,
                     );
                     buf.replace(NetMemResponse::Ok).unwrap();
+                    // test images (renode-minimal): the static config is seeded at
+                    // boot, before the dns service registers this hook, so the
+                    // notification that a production DHCP bind would deliver later
+                    // has already fired into the void. Replay it now.
+                    #[cfg(feature = "renode-minimal")]
+                    if let Some(config) = net_config {
+                        dns_ipv4_hook.notify_custom_args([
+                            Some(u32::from_be_bytes(config.dns1)),
+                            None,
+                            None,
+                            None,
+                        ]);
+                        if config.dns2 != [0, 0, 0, 0] {
+                            dns_ipv4_hook.notify_custom_args([
+                                Some(u32::from_be_bytes(config.dns2)),
+                                None,
+                                None,
+                                None,
+                            ]);
+                        }
+                    }
                 }
             }
             Some(Opcode::DnsHookAddIpv6) => {
@@ -1096,70 +1230,24 @@ fn main() -> ! {
                                             continue;
                                         }
                                     };
-                                    log::info!("Network config acquired: {:?}", config);
-                                    log::info!(
-                                        "{}NET.OK,{:?},{}",
-                                        precursor_hal::board::BOOKEND_START,
-                                        std::net::IpAddr::from(config.addr),
-                                        precursor_hal::board::BOOKEND_END
+                                    // test images (renode-minimal): the EC has no DHCP peer, so its
+                                    // config reports are never Bound (all-zero addresses); applying
+                                    // one would wipe the static config seeded at boot.
+                                    #[cfg(feature = "renode-minimal")]
+                                    if config.dhcp != com_rs::DhcpState::Bound {
+                                        log::info!(
+                                            "renode-minimal: ignoring non-Bound EC config report ({:?})",
+                                            config.dhcp
+                                        );
+                                        continue;
+                                    }
+                                    apply_ipv4_config(
+                                        config,
+                                        &mut net_config,
+                                        &mut iface,
+                                        &mut dns_allclear_hook,
+                                        &mut dns_ipv4_hook,
                                     );
-                                    net_config = Some(config);
-                                    // update a static variable that tracks this, useful for e.g. UDP bind
-                                    // address checking
-                                    IPV4_ADDRESS.store(u32::from_be_bytes(config.addr), Ordering::SeqCst);
-
-                                    if config.addr != [127, 0, 0, 1] {
-                                        // note: ARP cache is stale. Maybe that's ok?
-                                        iface.update_ip_addrs(|ip_addrs| {
-                                            ip_addrs.clear();
-                                            ip_addrs
-                                                .push(IpCidr::new(
-                                                    IpAddress::v4(
-                                                        config.addr[0],
-                                                        config.addr[1],
-                                                        config.addr[2],
-                                                        config.addr[3],
-                                                    ),
-                                                    24,
-                                                ))
-                                                .unwrap();
-                                            // ...and the loopback interface
-                                            ip_addrs
-                                                .push(IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8))
-                                                .unwrap();
-                                        });
-                                    } else {
-                                        log::warn!("Attempt to update the loopback interface! Ignoring.");
-                                    }
-                                    // reset the default route, in case it has changed
-                                    iface.routes_mut().remove_default_ipv4_route();
-                                    iface
-                                        .routes_mut()
-                                        .add_default_ipv4_route(Ipv4Address::new(
-                                            config.gtwy[0],
-                                            config.gtwy[1],
-                                            config.gtwy[2],
-                                            config.gtwy[3],
-                                        ))
-                                        .unwrap();
-
-                                    dns_allclear_hook.notify();
-                                    dns_ipv4_hook.notify_custom_args([
-                                        Some(u32::from_be_bytes(config.dns1)),
-                                        None,
-                                        None,
-                                        None,
-                                    ]);
-                                    // the current implementation always returns 0.0.0.0 as the second dns,
-                                    // ignore this if that's what we've got; otherwise, pass it on.
-                                    if config.dns2 != [0, 0, 0, 0] {
-                                        dns_ipv4_hook.notify_custom_args([
-                                            Some(u32::from_be_bytes(config.dns2)),
-                                            None,
-                                            None,
-                                            None,
-                                        ]);
-                                    }
                                 }
                                 ComIntSources::WlanRxReady => {
                                     activity_interval.store(0, Ordering::Relaxed); // reset the activity interval to 0

--- a/tools/README.md
+++ b/tools/README.md
@@ -176,3 +176,41 @@ watches the console for the boot banner and the net-ready marker, then the per-t
 result lines. It exits non-zero if any test fails. `--loglevel DEBUG` shows the
 milestone waits; `--help` lists the timeout flags.
 
+### Running `std-net-cross-host-ci.py` (cross-host `std::net` tests under Renode)
+
+The Cross-host counterpart: it boots the SoC + EC pair alongside a real Linux peer
+(`emulation/linux-server.resc`) on one Ethernet switch, so the DUT exchanges
+genuine packets with an independent stack instead of looping back inside itself.
+The DUT takes a real DHCP lease from the peer, and the cross-host theme exercises
+cross-host TCP/UDP echo, a real connect-refused RST, and DNS resolved by the
+peer's `dnsd`.
+
+```sh
+# From the repository root
+cargo xtask std-net-cross-host-ci --no-verify   # build the cross-host image
+python3 tools/std-net-cross-host-ci.py          # start all machines, provision the peer, run
+```
+
+Beyond the loopback driver's job, this one drives the peer's serial console (on a
+pty) to a passwordless root shell and starts its services — `dnsd`, a rewritten
+`udhcpd` advertising the peer as the resolver, and `nc` TCP/UDP echo servers —
+before the DUT boots far enough to take its lease. It copies the peer rootfs to
+a per-run scratch file (the peer's flash writes back). Exits non-zero on any
+failure.
+
+## Contribution Guidelines
+
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](../CODE_OF_CONDUCT.md)
+
+Please see [CONTRIBUTING](../CONTRIBUTING.md) for details on
+how to make a contribution.
+
+Please note that this project is released with a
+[Contributor Code of Conduct](../CODE_OF_CONDUCT.md).
+By participating in this project you agree to abide its terms.
+
+## License
+
+Copyright © 2020
+
+Licensed under the [Apache License 2.0](http://opensource.org/licenses/Apache-2.0) [LICENSE](LICENSE)

--- a/tools/README.md
+++ b/tools/README.md
@@ -157,19 +157,22 @@ image offline with `pddbdbg.py`. It exits non-zero if any test fails. A cold run
 ~15 minutes on a fast host. `--loglevel DEBUG` shows the boot choreography;
 `--help` lists the timeout flags. See `services/pddb-fs-tests/README.md`.
 
-## Contribution Guidelines
+### Running `std-net-ci.py` (on-target `std::net` tests under Renode)
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](../CODE_OF_CONDUCT.md)
+The sibling of `pddb-fs-ci.py`: `std-net-ci.py` runs the `services/net-tests` suite
+against the real riscv32 xous libstd inside Renode, exercising the actual
+`std::net`-over-`net`-service code path (smoltcp, over an emulated WF200 wifi link
+to the betrusted-ec). Requires Renode on the `PATH`; unlike the fs suite there is no
+`pddbdbg.py` analysis step and no PIN/format UX to drive.
 
-Please see [CONTRIBUTING](../CONTRIBUTING.md) for details on
-how to make a contribution.
+```sh
+# From the repository root
+cargo xtask std-net-ci --no-verify     # build the Renode test image (slow first time)
+python3 tools/std-net-ci.py            # boot, wait for net-ready, run the suite
+```
 
-Please note that this project is released with a
-[Contributor Code of Conduct](../CODE_OF_CONDUCT.md).
-By participating in this project you agree to abide its terms.
+The driver boots the emulator headless (no keyboard, no PDDB, fully unattended),
+watches the console for the boot banner and the net-ready marker, then the per-test
+result lines. It exits non-zero if any test fails. `--loglevel DEBUG` shows the
+milestone waits; `--help` lists the timeout flags.
 
-## License
-
-Copyright © 2020
-
-Licensed under the [Apache License 2.0](http://opensource.org/licenses/Apache-2.0) [LICENSE](LICENSE)

--- a/tools/std-net-ci.py
+++ b/tools/std-net-ci.py
@@ -1,0 +1,458 @@
+#! /usr/bin/env python3
+"""Fast local loop driver for the std::net suite under Renode.
+
+Per run: (re)creates a blank 0xFF flash backing file (the flash model needs a
+backing file even though this image has no persistent state), launches a
+headless Renode (emulation/tests/net-ci.resc, SoC + EC + wifi switch), tails
+the console UART log for the boot and net-ready milestones, then parses the
+net-tests sentinel stream. There is no first-boot UX to drive: the image has
+no PDDB, no keyboard, no graphics service, so boot runs unattended straight
+through to 'CI done'.
+
+Sentinel grammar (`TEST <name> PASS|FAIL|XFAIL|XPASS`, then `NET-TESTS DONE:
+pass=.. fail=.. xfail=.. xpass=.. total=..`, then `CI done`) and pass criteria
+mirror services/pddb-fs-tests, implemented in services/net-tests.
+
+Build the image first: cargo xtask std-net-ci
+Typical use: python3 tools/std-net-ci.py            (one run)
+             python3 tools/std-net-ci.py --runs 20   (flake hunting)
+"""
+import argparse
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+FLASH_SIZE = 134217728  # 128 MiB MX66UM1G45G NOR
+FLASH_CHUNK = 1024 * 1024
+
+# Console (log-server UART) markers.
+MARK_BOOT = 'Welcome to Xous'
+MARK_NET_OK = '_|TT|_NET.OK,'
+MARK_PANIC = 'PANIC in PID'
+
+RE_TEST = re.compile(r'TEST (\S+) (PASS|FAIL|XFAIL|XPASS)(?:\s+(.*))?$')
+RE_DONE = re.compile(
+    r'NET-TESTS DONE: pass=(\d+) fail=(\d+) xfail=(\d+) xpass=(\d+) total=(\d+)')
+
+
+class RunFailure(Exception):
+    pass
+
+
+class ConsoleTail:
+    """Incremental tail of the console UART CreateFileBackend log."""
+
+    def __init__(self, path):
+        self.path = path
+        self.f = None
+        self.partial = b''
+        self.panic_lines = []
+
+    def close(self):
+        if self.f is not None:
+            self.f.close()
+            self.f = None
+
+    def poll(self):
+        """Return a list of complete new lines (str) since the last poll."""
+        if self.f is None:
+            if not os.path.exists(self.path):
+                return []
+            self.f = open(self.path, 'rb')
+        data = self.f.read()
+        if not data:
+            return []
+        self.partial += data
+        raw_lines = self.partial.split(b'\n')
+        self.partial = raw_lines.pop()
+        lines = []
+        for raw in raw_lines:
+            line = raw.decode('utf-8', errors='replace').rstrip('\r')
+            if MARK_PANIC in line:
+                self.panic_lines.append(line)
+            lines.append(line)
+        return lines
+
+
+class RenodeRun:
+    """One Renode launch: monitor FIFO, console tail, milestone waits."""
+
+    def __init__(self, args, run_idx):
+        self.args = args
+        self.run_idx = run_idx
+        self.workdir = args.workdir
+        self.flash_file = os.path.join(args.workdir, 'flash.bin')
+        self.console_log = os.path.join(args.workdir, 'console.log')
+        self.kernel_log = os.path.join(args.workdir, 'kernel.log')
+        self.run_log = os.path.join(args.workdir, 'run.log')
+        self.fifo_path = os.path.join(args.workdir, 'monitor.fifo')
+        self.proc = None
+        self.mon_fd = None
+        self.run_log_f = None
+        self.tail = ConsoleTail(self.console_log)
+        # Console lines polled but not yet consumed by a wait. Without this
+        # buffer, a wait that matches mid-batch would silently drop the rest
+        # of the batch -- and consecutive markers routinely land in the same
+        # poll (e.g. the boot banner and NET.OK on a fast host).
+        self.pending = []
+        self.t0 = None
+
+    # ---------- infrastructure ----------
+
+    def milestone(self, msg):
+        elapsed = 0.0 if self.t0 is None else time.time() - self.t0
+        logging.info('[%8.1fs] %s', elapsed, msg)
+
+    def launch(self):
+        for stale in (self.console_log, self.kernel_log, self.run_log):
+            if os.path.exists(stale):
+                os.remove(stale)
+        if os.path.exists(self.fifo_path):
+            os.remove(self.fifo_path)
+        os.mkfifo(self.fifo_path)
+        # O_RDWR on a FIFO opens without blocking and keeps a writer alive, so
+        # Renode's stdin never sees EOF; monitor() writes to the same fd.
+        self.mon_fd = os.open(self.fifo_path, os.O_RDWR)
+        self.run_log_f = open(self.run_log, 'wb')
+        monitor_setup = '; '.join([
+            '$image_dir=@{}'.format(self.args.image_dir),
+            '$flash_file=@{}'.format(self.flash_file),
+            '$console_log=@{}'.format(self.console_log),
+            '$kernel_log=@{}'.format(self.kernel_log),
+            'i @{}'.format(self.args.resc),
+        ])
+        cmd = [self.args.renode, '--disable-gui', '--console',
+               '-e', monitor_setup]
+        self.t0 = time.time()
+        self.proc = subprocess.Popen(
+            cmd,
+            stdin=self.mon_fd,
+            stdout=self.run_log_f,
+            stderr=subprocess.STDOUT,
+            cwd=REPO_ROOT,
+        )
+        if self.args.pid_file:
+            with open(self.args.pid_file, 'w') as f:
+                f.write(str(self.proc.pid))
+        self.milestone('renode launched (pid {})'.format(self.proc.pid))
+
+    def monitor(self, command):
+        """Write one monitor command line to the FIFO."""
+        logging.debug('monitor <- %s', command)
+        os.write(self.mon_fd, (command + '\n').encode('utf-8'))
+
+    def check_alive(self):
+        if self.proc.poll() is not None:
+            raise RunFailure(
+                'renode exited prematurely (code {}); see {}'.format(
+                    self.proc.returncode, self.run_log))
+
+    def check_panic(self):
+        """The net-tests runner installs a panic hook, so a caught test
+        panic never prints this banner -- any occurrence is a real service
+        death. Fail immediately rather than waiting out the inactivity or
+        overall-cap timers."""
+        if self.tail.panic_lines:
+            raise RunFailure('PANIC in PID: {}'.format(
+                self.tail.panic_lines[-1].strip()))
+
+    def shutdown(self):
+        """Quit cleanly, then escalate."""
+        try:
+            if self.proc is not None and self.proc.poll() is None:
+                try:
+                    self.monitor('quit')
+                except OSError:
+                    pass
+                try:
+                    self.proc.wait(timeout=30)
+                    self.milestone('renode quit cleanly')
+                except subprocess.TimeoutExpired:
+                    logging.warning('renode did not quit within 30 s; killing')
+                    self.proc.kill()
+                    self.proc.wait()
+        finally:
+            # Belt and braces: never leave a renode behind.
+            if self.proc is not None and self.proc.poll() is None:
+                try:
+                    self.proc.kill()
+                    self.proc.wait()
+                except OSError:
+                    pass
+            if self.mon_fd is not None:
+                os.close(self.mon_fd)
+                self.mon_fd = None
+            if self.run_log_f is not None:
+                self.run_log_f.close()
+                self.run_log_f = None
+            self.tail.close()
+            if os.path.exists(self.fifo_path):
+                os.remove(self.fifo_path)
+            if self.args.pid_file and os.path.exists(self.args.pid_file):
+                os.remove(self.args.pid_file)
+
+    # ---------- console state machine primitives ----------
+
+    def poll_console(self):
+        """Poll the console tail into the pending-line buffer (logging each
+        new line once). All console consumption goes through self.pending so
+        a wait that stops mid-batch never drops the lines behind it."""
+        new_lines = self.tail.poll()
+        for line in new_lines:
+            logging.debug('console: %s', line)
+        self.pending.extend(new_lines)
+
+    def wait_for(self, markers, timeout):
+        """Consume console lines until one of `markers` appears; returns it."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            self.check_alive()
+            self.poll_console()
+            self.check_panic()
+            while self.pending:
+                line = self.pending.pop(0)
+                matched = None
+                for marker in markers:
+                    if marker in line:
+                        matched = marker
+                        break
+                if matched is not None:
+                    self.milestone('marker: {}'.format(matched))
+                    return matched
+            time.sleep(0.2)
+        raise RunFailure('timeout ({} s) waiting for {}'.format(
+            timeout, ' | '.join(markers)))
+
+    # ---------- boot ----------
+
+    def wait_for_ready(self):
+        """No first-boot UX to drive here: unattended straight through to
+        net-ready."""
+        self.wait_for([MARK_BOOT], self.args.timeout_boot)
+        self.wait_for([MARK_NET_OK], self.args.timeout_net_ready)
+
+    # ---------- sentinel stream ----------
+
+    def collect_results(self):
+        """After NET.OK: parse TEST/DONE sentinels; return failures.
+
+        Two timeouts govern the sentinel stream:
+        - INACTIVITY (--timeout-inactivity, default 180 s): no new console
+          output at all for that long. A wedged net service (e.g. a blocked
+          socket call that never wakes) manifests exactly this way -- every
+          later test blocks forever, so the console just goes quiet. On
+          expiry the run fails, reporting the last TEST sentinel seen and the
+          trailing console lines.
+        - OVERALL (--timeout-tests, default 1800 s): a generous whole-suite
+          cap so a pathological-but-chatty stream still terminates.
+        """
+        problems = []
+        counts = {'PASS': 0, 'FAIL': 0, 'XFAIL': 0, 'XPASS': 0}
+        done = None
+        last_sentinel = None
+        trailing = []  # last console lines, for the inactivity report
+        last_activity = time.time()
+        deadline = time.time() + self.args.timeout_tests
+        while done is None:
+            now = time.time()
+            if now >= deadline:
+                problems.append(
+                    'overall test cap hit: no NET-TESTS DONE within {} s '
+                    '(last sentinel: {})'.format(
+                        self.args.timeout_tests, last_sentinel or 'none'))
+                break
+            if now - last_activity >= self.args.timeout_inactivity:
+                problems.append(
+                    'console INACTIVE for {} s -- net service presumed dead. '
+                    'Last TEST sentinel: {}. Trailing console lines:\n  {}'
+                    .format(self.args.timeout_inactivity,
+                            last_sentinel or 'none (no test completed)',
+                            '\n  '.join(trailing[-12:]) or '(none)'))
+                break
+            self.check_alive()
+            before = len(self.pending)
+            self.poll_console()
+            self.check_panic()
+            if len(self.pending) > before:
+                last_activity = time.time()
+                trailing.extend(self.pending[before:])
+                del trailing[:-20]
+            while self.pending and done is None:
+                line = self.pending.pop(0)
+                m = RE_TEST.search(line)
+                if m:
+                    name, status, detail = m.group(1), m.group(2), m.group(3)
+                    counts[status] += 1
+                    last_sentinel = 'TEST {} {}'.format(name, status)
+                    self.milestone('TEST {} {}{}'.format(
+                        name, status, ' ' + detail if detail else ''))
+                    if status == 'FAIL':
+                        problems.append('test failed: {} ({})'.format(
+                            name, detail))
+                    elif status == 'XPASS':
+                        problems.append(
+                            'unexpected pass: {} ({}) -- update the XFAIL '
+                            'registry'.format(name, detail))
+                    continue
+                m = RE_DONE.search(line)
+                if m:
+                    done = tuple(int(x) for x in m.groups())
+                    self.milestone('NET-TESTS DONE: pass={} fail={} xfail={} '
+                                   'xpass={} total={}'.format(*done))
+                    break
+            time.sleep(0.2)
+        if done is not None:
+            _, n_fail, _, n_xpass, n_total = done
+            if n_fail != 0:
+                problems.append('DONE reports fail={}'.format(n_fail))
+            if n_xpass != 0:
+                problems.append('DONE reports xpass={}'.format(n_xpass))
+            if sum(counts.values()) != n_total:
+                logging.warning(
+                    'sentinel count mismatch: saw %d TEST lines, DONE says '
+                    'total=%d', sum(counts.values()), n_total)
+        # Drain any trailing output (panic banners race the DONE line).
+        settle = time.time() + 5
+        while time.time() < settle:
+            self.poll_console()
+            self.pending.clear()
+            if self.proc.poll() is not None:
+                break
+            time.sleep(0.5)
+        for line in self.tail.panic_lines:
+            problems.append('stray panic: {}'.format(line.strip()))
+        return problems
+
+
+def write_blank_flash(path):
+    """Fresh blank-NOR image: 0xFF-filled, written in 1 MiB chunks. Required
+    by the flash model even though this image never persists state."""
+    chunk = b'\xff' * FLASH_CHUNK
+    with open(path, 'wb') as f:
+        for _ in range(FLASH_SIZE // FLASH_CHUNK):
+            f.write(chunk)
+
+
+def preserve_failure_logs(args, run_idx):
+    dest = os.path.join(args.workdir, 'failed-run-{}'.format(run_idx))
+    os.makedirs(dest, exist_ok=True)
+    for name in ('console.log', 'kernel.log', 'run.log'):
+        src = os.path.join(args.workdir, name)
+        if os.path.exists(src):
+            shutil.copyfile(src, os.path.join(dest, name))
+    logging.info('failure logs preserved in %s', dest)
+
+
+def do_run(args, run_idx):
+    """One full run. Returns a list of problems (empty == PASS)."""
+    os.makedirs(args.workdir, exist_ok=True)
+    flash_file = os.path.join(args.workdir, 'flash.bin')
+    write_blank_flash(flash_file)
+    logging.info('fresh 0xFF flash file written: %s', flash_file)
+
+    run = RenodeRun(args, run_idx)
+    problems = []
+    try:
+        run.launch()
+        run.wait_for_ready()
+        problems.extend(run.collect_results())
+    except RunFailure as e:
+        problems.append(str(e))
+    finally:
+        # ALWAYS bring renode down, even on unexpected exceptions, so no
+        # orphan eats CPU.
+        run.shutdown()
+
+    if problems:
+        preserve_failure_logs(args, run_idx)
+    return problems
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Renode-based regression tester for std::net')
+    parser.add_argument(
+        '--workdir', required=False, type=str,
+        default=os.path.join(REPO_ROOT, 'target', 'std-net-ci'),
+        help='scratch directory for flash/logs/FIFO')
+    parser.add_argument(
+        '--resc', required=False, type=str,
+        default=os.path.join(REPO_ROOT, 'emulation', 'tests', 'net-ci.resc'),
+        help='machine-definition script to include')
+    parser.add_argument(
+        '--image-dir', required=False, type=str,
+        default=os.path.join(REPO_ROOT, 'target',
+                             'riscv32imac-unknown-xous-elf', 'release'),
+        help='directory holding loader.bin and xous.img')
+    parser.add_argument(
+        '--renode', required=False, type=str, default='renode',
+        help='renode executable')
+    parser.add_argument(
+        '--runs', required=False, type=int, default=1,
+        help='number of runs')
+    # Timeout defaults below are generous placeholders; tighten once real
+    # run timings are known.
+    parser.add_argument(
+        '--timeout-boot', required=False, type=int, default=300,
+        help='seconds allowed for the boot banner (wall clock)')
+    parser.add_argument(
+        '--timeout-net-ready', required=False, type=int, default=300,
+        help='seconds allowed for NET.OK after the boot banner (wall clock)')
+    parser.add_argument(
+        '--timeout-tests', required=False, type=int, default=1800,
+        help='overall cap (seconds) for the whole test sentinel stream')
+    parser.add_argument(
+        '--timeout-inactivity', required=False, type=int, default=180,
+        help='fail if the console emits NOTHING for this long after net-ready '
+             '(a wedged net service manifests as total console silence)')
+    parser.add_argument(
+        '--pid-file', required=False, type=str, default=None,
+        help='write the renode pid here while it runs')
+    parser.add_argument(
+        '--loglevel', required=False, type=str, default='INFO',
+        help='set logging level (INFO/DEBUG/WARNING/ERROR)')
+    args = parser.parse_args()
+
+    numeric_level = getattr(logging, args.loglevel.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError('Invalid log level: %s' % args.loglevel)
+    logging.basicConfig(level=numeric_level)
+
+    args.workdir = os.path.abspath(args.workdir)
+    args.resc = os.path.abspath(args.resc)
+    args.image_dir = os.path.abspath(args.image_dir)
+
+    pass_log = {}
+    for run_idx in range(int(args.runs)):
+        logging.info('===== run %d/%d =====', run_idx + 1, args.runs)
+        problems = do_run(args, run_idx)
+        if problems:
+            for p in problems:
+                logging.error('run %d: %s', run_idx, p)
+            pass_log[run_idx] = 'FAIL'
+        else:
+            pass_log[run_idx] = 'PASS'
+        logging.info('run %d %s', run_idx, pass_log[run_idx])
+
+    # summary report
+    passing = True
+    for items in pass_log.items():
+        logging.info(items)
+        if items[1] != 'PASS':
+            passing = False
+    if passing:
+        logging.info('Overall pass, exiting with 0')
+        exit(0)
+    else:
+        logging.info('A failure was detected, exiting with 1')
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/std-net-cross-host-ci.py
+++ b/tools/std-net-cross-host-ci.py
@@ -1,0 +1,553 @@
+#! /usr/bin/env python3
+"""Local loop driver for the std::net Cross-host (cross-host) suite under Renode.
+
+Cross-host boots the SoC + EC pair AND a real Linux peer (emulation/linux-server.resc)
+on one Ethernet switch. Per run this driver:
+  1. provisions a blank flash and a per-run scratch copy of the peer rootfs
+     (the peer's CFI flash writes back into its backing file);
+  2. launches headless Renode with emulation/tests/net-cross-host-ci.resc, which
+     starts all three machines and exposes the peer's serial console on a pty;
+  3. drives the peer console (press Enter for a passwordless root shell, then
+     start the test services -- a `nc` TCP echo server) before the DUT boots
+     far enough to run its tests;
+  4. tails the SoC console UART log for the boot and net-ready milestones (the
+     DUT takes a REAL DHCP lease from the peer's udhcpd -- the image is built
+     with net/renode-peer, no static seed), then parses the net-tests sentinel
+     stream exactly as tools/std-net-ci.py does.
+
+The peer contract (ports, addresses, service shapes) MUST match
+services/net-tests/src/tests/cross-host.rs -- keep the two in lockstep.
+
+Build the image first: cargo xtask std-net-cross-host-ci
+Typical use: python3 tools/std-net-cross-host-ci.py
+"""
+import argparse
+import logging
+import os
+import re
+import select
+import shutil
+import subprocess
+import sys
+import termios
+import time
+import tty
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+FLASH_SIZE = 134217728  # 128 MiB MX66UM1G45G NOR
+FLASH_CHUNK = 1024 * 1024
+
+PEER_ROOTFS_SRC = os.path.join(REPO_ROOT, 'emulation', 'linux-server-rootfs.jffs2')
+PEER_BIN = os.path.join(REPO_ROOT, 'emulation', 'versatile-vmlinux')
+
+# Peer service contract -- must match services/net-tests/src/tests/cross-host.rs.
+PEER_IP = '192.168.0.1'
+PEER_ECHO_TCP = 6001
+PEER_ECHO_UDP = 6002
+PEER_BULK_TCP = 6003
+PEER_BULK_LEN = 8192  # bytes of 'A' the bulk source serves
+# Static A records the peer's dnsd serves; the DUT's resolver (dns1, advertised
+# by the peer's udhcpd) points at PEER_IP so std lookups reach this dnsd.
+PEER_DNS_RECORDS = [
+    ('peer.test', '192.168.0.1'),
+    ('one.test', '10.11.12.13'),
+    ('two.test', '203.0.113.7'),
+]
+
+# Console (log-server UART) markers on the SoC.
+MARK_BOOT = 'Welcome to Xous'
+MARK_NET_OK = '_|TT|_NET.OK,'
+MARK_PANIC = 'PANIC in PID'
+
+# Peer console markers.
+PEER_BANNER = re.compile(rb'Please press Enter to activate this console')
+PEER_PROMPT = re.compile(rb'# ')
+PEER_MARK_RE = re.compile(rb'@@END@@:(\d+)')
+PEER_MARK_CMD = ' ; echo "@@EN""D@@:$?"'
+
+RE_TEST = re.compile(r'TEST (\S+) (PASS|FAIL|XFAIL|XPASS)(?:\s+(.*))?$')
+RE_DONE = re.compile(
+    r'NET-TESTS DONE: pass=(\d+) fail=(\d+) xfail=(\d+) xpass=(\d+) total=(\d+)')
+
+
+class RunFailure(Exception):
+    pass
+
+
+class PeerSetupError(RunFailure):
+    """A flake while provisioning the peer (pty/banner/console command). These
+    are harness issues, not DUT results, so do_run retries the whole run once
+    rather than counting a peer-console hiccup as a suite failure."""
+    pass
+
+
+class ConsoleTail:
+    """Incremental tail of the SoC console UART CreateFileBackend log."""
+
+    def __init__(self, path):
+        self.path = path
+        self.f = None
+        self.partial = b''
+        self.panic_lines = []
+
+    def close(self):
+        if self.f is not None:
+            self.f.close()
+            self.f = None
+
+    def poll(self):
+        if self.f is None:
+            if not os.path.exists(self.path):
+                return []
+            self.f = open(self.path, 'rb')
+        data = self.f.read()
+        if not data:
+            return []
+        self.partial += data
+        raw_lines = self.partial.split(b'\n')
+        self.partial = raw_lines.pop()
+        lines = []
+        for raw in raw_lines:
+            line = raw.decode('utf-8', errors='replace').rstrip('\r')
+            if MARK_PANIC in line:
+                self.panic_lines.append(line)
+            lines.append(line)
+        return lines
+
+
+class PeerConsole:
+    """Hardened pty reader/writer for the Linux peer's serial console.
+
+    The emulated 16550 occasionally drops the leading bytes of a written line,
+    so mitigations are: chunked writes, an end-marker per command, an
+    inactivity nudge (CR), and a ctrl-C + resend on a shell continuation prompt.
+    """
+
+    def __init__(self, pty_path, transcript_path):
+        self.fd = os.open(pty_path, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+        try:
+            tty.setraw(self.fd)
+        except termios.error:
+            pass
+        self.buf = b''
+        self.tf = open(transcript_path, 'ab', buffering=0)
+
+    def close(self):
+        try:
+            os.close(self.fd)
+        except OSError:
+            pass
+        self.tf.close()
+
+    def _pump(self, timeout):
+        r, _, _ = select.select([self.fd], [], [], timeout)
+        if self.fd in r:
+            try:
+                data = os.read(self.fd, 65536)
+            except OSError:
+                return
+            if data:
+                self.buf += data
+                self.tf.write(data)
+
+    def expect(self, pattern, timeout):
+        deadline = time.time() + timeout
+        while True:
+            m = pattern.search(self.buf)
+            if m:
+                self.buf = self.buf[m.end():]
+                return m
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                return None
+            self._pump(min(remaining, 1.0))
+
+    def send(self, s):
+        data = s.encode() if isinstance(s, str) else s
+        self.tf.write(b'\n>>> SEND: ' + data + b'\n')
+        off = 0
+        while off < len(data):
+            chunk = data[off:off + 16]
+            try:
+                n = os.write(self.fd, chunk)
+            except BlockingIOError:
+                select.select([], [self.fd], [], 1.0)
+                continue
+            off += n
+            time.sleep(0.01)
+
+    def run_cmd(self, label, cmd, timeout=90, _resends=0):
+        self.buf = b''
+        self.send(cmd + PEER_MARK_CMD + '\n')
+        deadline = time.time() + timeout
+        last_len, last_activity, nudges = 0, time.time(), 0
+        while True:
+            if re.search(rb'\r\n> $', self.buf) and _resends < 2:
+                logging.info('peer %s: continuation prompt, ctrl-c + resend', label)
+                self.send(b'\x03')
+                self.expect(PEER_PROMPT, 15)
+                time.sleep(1)
+                return self.run_cmd(label, cmd, timeout, _resends + 1)
+            m = PEER_MARK_RE.search(self.buf)
+            if m:
+                out = self.buf[:m.start()]
+                self.buf = self.buf[m.end():]
+                rc = int(m.group(1))
+                self.expect(PEER_PROMPT, 10)
+                text = out.decode('utf-8', 'replace')
+                logging.info('peer %s -> rc=%d', label, rc)
+                return rc, text
+            now = time.time()
+            if now >= deadline:
+                raise PeerSetupError('peer command {!r} timed out'.format(label))
+            if len(self.buf) != last_len:
+                last_len, last_activity = len(self.buf), now
+            elif now - last_activity > 10 and nudges < 3:
+                nudges += 1
+                logging.info('peer %s: no activity 10s, nudge %d', label, nudges)
+                self.send('\r')
+                last_activity = now
+            self._pump(1.0)
+
+
+class RenodeRun:
+    def __init__(self, args, run_idx):
+        self.args = args
+        self.run_idx = run_idx
+        self.workdir = args.workdir
+        self.flash_file = os.path.join(args.workdir, 'flash.bin')
+        self.peer_rootfs = os.path.join(args.workdir, 'peer-rootfs.jffs2')
+        self.peer_pty = os.path.join(args.workdir, 'peer.pty')
+        self.peer_transcript = os.path.join(args.workdir, 'peer-console.log')
+        self.console_log = os.path.join(args.workdir, 'console.log')
+        self.kernel_log = os.path.join(args.workdir, 'kernel.log')
+        self.run_log = os.path.join(args.workdir, 'run.log')
+        self.proc = None
+        self.stdin_r = None
+        self.run_log_f = None
+        self.peer = None
+        self.tail = ConsoleTail(self.console_log)
+        self.pending = []
+        self.t0 = None
+
+    def milestone(self, msg):
+        elapsed = 0.0 if self.t0 is None else time.time() - self.t0
+        logging.info('[%8.1fs] %s', elapsed, msg)
+
+    def launch(self):
+        for stale in (self.console_log, self.kernel_log, self.run_log,
+                      self.peer_transcript):
+            if os.path.exists(stale):
+                os.remove(stale)
+        if os.path.lexists(self.peer_pty):
+            os.remove(self.peer_pty)
+        # Per-run scratch rootfs: the peer's CFI flash writes back into it.
+        shutil.copyfile(PEER_ROOTFS_SRC, self.peer_rootfs)
+        self.run_log_f = open(self.run_log, 'wb')
+        monitor_setup = '; '.join([
+            '$image_dir=@{}'.format(self.args.image_dir),
+            '$flash_file=@{}'.format(self.flash_file),
+            '$console_log=@{}'.format(self.console_log),
+            '$kernel_log=@{}'.format(self.kernel_log),
+            '$peer_bin=@{}'.format(PEER_BIN),
+            '$peer_rootfs=@{}'.format(self.peer_rootfs),
+            '$peer_pty=@{}'.format(self.peer_pty),
+            'i @{}'.format(self.args.resc),
+        ])
+        cmd = [self.args.renode, '--disable-gui', '--console', '-e', monitor_setup]
+        self.t0 = time.time()
+        # Keep a stdin pipe open so Renode never sees EOF and exits.
+        self.stdin_r, _stdin_w = os.pipe()
+        self._stdin_w = _stdin_w
+        self.proc = subprocess.Popen(
+            cmd, stdin=self.stdin_r, stdout=self.run_log_f,
+            stderr=subprocess.STDOUT, cwd=REPO_ROOT)
+        if self.args.pid_file:
+            with open(self.args.pid_file, 'w') as f:
+                f.write(str(self.proc.pid))
+        self.milestone('renode launched (pid {})'.format(self.proc.pid))
+
+    def check_alive(self):
+        if self.proc.poll() is not None:
+            raise RunFailure('renode exited prematurely (code {}); see {}'.format(
+                self.proc.returncode, self.run_log))
+
+    def check_panic(self):
+        if self.tail.panic_lines:
+            raise RunFailure('PANIC in PID: {}'.format(
+                self.tail.panic_lines[-1].strip()))
+
+    def bring_up_peer(self):
+        """Log in to the peer and provision its test services and DHCP options.
+        All machines start together (the resc), but the peer boots and is
+        provisioned faster than the DUT reaches DHCP, and the udhcpd/DNS
+        reconfigure below runs first to widen that margin, so the DUT's lease
+        sees the resolver pointing at the peer's dnsd."""
+        for _ in range(int(self.args.timeout_peer / 0.5)):
+            if os.path.lexists(self.peer_pty):
+                break
+            self.check_alive()
+            time.sleep(0.5)
+        else:
+            raise PeerSetupError('peer pty never appeared')
+        self.peer = PeerConsole(self.peer_pty, self.peer_transcript)
+        if self.peer.expect(PEER_BANNER, self.args.timeout_peer) is None:
+            raise PeerSetupError('peer console banner never appeared')
+        self.milestone('peer console banner')
+        time.sleep(2)
+        self.peer.buf = b''
+        self.peer.send('\n')
+        if self.peer.expect(PEER_PROMPT, 60) is None:
+            raise PeerSetupError('peer shell prompt never appeared after Enter')
+        self.milestone('peer root shell active')
+        # Deterministic ordering without machine control: kill the bogus udhcpd
+        # rcS started FIRST so nothing answers while we provision; the DUT's
+        # DISCOVERs retry until the *reconfigured* udhcpd starts LAST, once every
+        # other service is up. Removes the bogus-DNS and services-not-ready races.
+        self.peer.run_cmd('stop_dhcp_and_remount',
+                          'pkill udhcpd 2>/dev/null; '
+                          'mount -o remount,rw /dev/root / && mkdir -p /tmp && echo RW_OK')
+        # dnsd: static A records bound to the peer's own address.
+        records = ''.join('{} {}\\n'.format(name, ip) for name, ip in PEER_DNS_RECORDS)
+        self.peer.run_cmd('start_dnsd',
+                          'printf "{}" > /tmp/dnsd.conf && '
+                          'dnsd -c /tmp/dnsd.conf -i {} -p 53 -d & sleep 1; echo DNS_UP'
+                          .format(records, PEER_IP))
+        # TCP echo (persistent) and UDP echo (one-shot -l: busybox `nc -u -lk`
+        # is unreliable; a single -l session handles the test's datagram burst).
+        self.peer.run_cmd('start_tcp_echo',
+                          'nc -lk -p {} -e /bin/cat </dev/null & sleep 1; echo TCP_UP'
+                          .format(PEER_ECHO_TCP))
+        self.peer.run_cmd('start_udp_echo',
+                          'nc -u -l -p {} -e /bin/cat </dev/null & sleep 1; echo UDP_UP'
+                          .format(PEER_ECHO_UDP))
+        # Bulk source: serve PEER_BULK_LEN bytes of 'A' (one-directional). Split
+        # into short commands -- long lines are what the uart occasionally drops.
+        self.peer.run_cmd('make_bulk_file',
+                          'head -c {} /dev/zero | tr "\\000" "A" > /tmp/bulk.bin; echo MK_OK'
+                          .format(PEER_BULK_LEN))
+        self.peer.run_cmd('start_bulk_source',
+                          'nc -lk -p {} < /tmp/bulk.bin & echo BULK_UP'.format(PEER_BULK_TCP))
+        # LAST: rewrite udhcpd's DNS option to advertise the peer as resolver and
+        # start it. This is now the only DHCP server on the switch, so the DUT
+        # binds this config (resolver -> the peer's dnsd) with every service up.
+        self.peer.run_cmd('start_udhcpd',
+                          'sed -i "s/^opt.*dns.*/opt dns {}/I" /etc/udhcpd.conf 2>/dev/null; '
+                          'grep -qi "opt dns" /etc/udhcpd.conf || '
+                          'echo "opt dns {}" >> /etc/udhcpd.conf; '
+                          'udhcpd /etc/udhcpd.conf & sleep 1; echo DHCP_UP'
+                          .format(PEER_IP, PEER_IP))
+        self.milestone('peer services up (dnsd, tcp {}, udp {}, bulk {}); udhcpd started last'
+                       .format(PEER_ECHO_TCP, PEER_ECHO_UDP, PEER_BULK_TCP))
+
+    def shutdown(self):
+        try:
+            if self.proc is not None and self.proc.poll() is None:
+                try:
+                    os.write(self._stdin_w, b'quit\n')
+                except OSError:
+                    pass
+                try:
+                    self.proc.wait(timeout=30)
+                    self.milestone('renode quit cleanly')
+                except subprocess.TimeoutExpired:
+                    logging.warning('renode did not quit within 30 s; killing')
+                    self.proc.kill()
+                    self.proc.wait()
+        finally:
+            if self.proc is not None and self.proc.poll() is None:
+                try:
+                    self.proc.kill()
+                    self.proc.wait()
+                except OSError:
+                    pass
+            if self.peer is not None:
+                self.peer.close()
+            for fd in (getattr(self, '_stdin_w', None), self.stdin_r):
+                if fd is not None:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+            if self.run_log_f is not None:
+                self.run_log_f.close()
+            self.tail.close()
+            if self.args.pid_file and os.path.exists(self.args.pid_file):
+                os.remove(self.args.pid_file)
+
+    def poll_console(self):
+        new_lines = self.tail.poll()
+        for line in new_lines:
+            logging.debug('console: %s', line)
+        self.pending.extend(new_lines)
+
+    def wait_for(self, markers, timeout):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            self.check_alive()
+            self.poll_console()
+            self.check_panic()
+            while self.pending:
+                line = self.pending.pop(0)
+                for marker in markers:
+                    if marker in line:
+                        self.milestone('marker: {}'.format(marker))
+                        return marker
+            time.sleep(0.2)
+        raise RunFailure('timeout ({} s) waiting for {}'.format(
+            timeout, ' | '.join(markers)))
+
+    def collect_results(self):
+        problems = []
+        counts = {'PASS': 0, 'FAIL': 0, 'XFAIL': 0, 'XPASS': 0}
+        done = None
+        last_sentinel = None
+        trailing = []
+        last_activity = time.time()
+        deadline = time.time() + self.args.timeout_tests
+        while done is None:
+            now = time.time()
+            if now >= deadline:
+                problems.append('overall test cap hit: no NET-TESTS DONE within '
+                                '{} s (last: {})'.format(self.args.timeout_tests,
+                                                         last_sentinel or 'none'))
+                break
+            if now - last_activity >= self.args.timeout_inactivity:
+                problems.append(
+                    'console INACTIVE for {} s -- net service presumed dead. '
+                    'Last TEST sentinel: {}. Trailing:\n  {}'.format(
+                        self.args.timeout_inactivity,
+                        last_sentinel or 'none',
+                        '\n  '.join(trailing[-12:]) or '(none)'))
+                break
+            self.check_alive()
+            before = len(self.pending)
+            self.poll_console()
+            self.check_panic()
+            if len(self.pending) > before:
+                last_activity = time.time()
+            while self.pending:
+                line = self.pending.pop(0)
+                trailing.append(line)
+                m = RE_TEST.search(line)
+                if m:
+                    name, verdict = m.group(1), m.group(2)
+                    counts[verdict] = counts.get(verdict, 0) + 1
+                    last_sentinel = '{} {}'.format(name, verdict)
+                    self.milestone('TEST {} {}{}'.format(
+                        name, verdict, (' ' + m.group(3)) if m.group(3) else ''))
+                    continue
+                m = RE_DONE.search(line)
+                if m:
+                    done = [int(x) for x in m.groups()]
+                    self.milestone('NET-TESTS DONE: pass={} fail={} xfail={} '
+                                   'xpass={} total={}'.format(*done))
+                    break
+            time.sleep(0.05)
+        if done is not None:
+            _, n_fail, _, n_xpass, n_total = done
+            if n_fail:
+                problems.append('DONE reports fail={}'.format(n_fail))
+            if n_xpass:
+                problems.append('DONE reports xpass={}'.format(n_xpass))
+            seen = sum(counts.values())
+            if seen != n_total:
+                problems.append('sentinel count mismatch: saw {} TEST lines, '
+                                'DONE says total={}'.format(seen, n_total))
+        self.poll_console()
+        self.check_panic()
+        return problems
+
+
+def write_blank_flash(path):
+    with open(path, 'wb') as f:
+        chunk = b'\xff' * FLASH_CHUNK
+        for _ in range(FLASH_SIZE // FLASH_CHUNK):
+            f.write(chunk)
+
+
+def preserve_failure_logs(args, run_idx):
+    dst = os.path.join(args.workdir, 'failed-run-{}'.format(run_idx))
+    os.makedirs(dst, exist_ok=True)
+    for name in ('console.log', 'kernel.log', 'run.log', 'peer-console.log'):
+        src = os.path.join(args.workdir, name)
+        if os.path.exists(src):
+            shutil.copyfile(src, os.path.join(dst, name))
+    logging.info('failure logs preserved in %s', dst)
+
+
+def do_run(args, run_idx):
+    logging.info('===== run %d/%d =====', run_idx + 1, args.runs)
+    # A peer-console flake during provisioning (a harness issue, not a DUT
+    # result) retries the whole run once; a real test failure does not.
+    for attempt in range(2):
+        write_blank_flash(os.path.join(args.workdir, 'flash.bin'))
+        run = RenodeRun(args, run_idx)
+        try:
+            run.launch()
+            run.bring_up_peer()
+            run.wait_for([MARK_BOOT], args.timeout_boot)
+            run.wait_for([MARK_NET_OK], args.timeout_net_ready)
+            problems = run.collect_results()
+            if problems:
+                for p in problems:
+                    logging.error('run %d: %s', run_idx, p)
+                preserve_failure_logs(args, run_idx)
+                return run_idx, 'FAIL'
+            logging.info('run %d PASS', run_idx)
+            return run_idx, 'PASS'
+        except PeerSetupError as e:
+            if attempt == 0:
+                logging.warning('run %d: peer setup flake (%s); retrying the run',
+                                run_idx, e)
+                continue
+            logging.error('run %d: peer setup flake on retry (%s)', run_idx, e)
+            preserve_failure_logs(args, run_idx)
+            return run_idx, 'FAIL'
+        except RunFailure as e:
+            logging.error('run %d: %s', run_idx, e)
+            preserve_failure_logs(args, run_idx)
+            return run_idx, 'FAIL'
+        finally:
+            run.shutdown()
+
+
+def main():
+    p = argparse.ArgumentParser(description='Renode Cross-host tester for std::net')
+    p.add_argument('--workdir',
+                   default=os.path.join(REPO_ROOT, 'target', 'std-net-cross-host-ci'))
+    p.add_argument('--resc',
+                   default=os.path.join(REPO_ROOT, 'emulation', 'tests',
+                                        'net-cross-host-ci.resc'))
+    p.add_argument('--image-dir',
+                   default=os.path.join(REPO_ROOT, 'target',
+                                        'riscv32imac-unknown-xous-elf', 'release'))
+    p.add_argument('--renode', default='renode')
+    p.add_argument('--runs', type=int, default=1)
+    p.add_argument('--timeout-peer', type=float, default=300.0,
+                   help='wall seconds for the peer pty + banner + shell')
+    p.add_argument('--timeout-boot', type=float, default=300.0)
+    p.add_argument('--timeout-net-ready', type=float, default=400.0,
+                   help='real DHCP can take longer than the loopback static seed')
+    p.add_argument('--timeout-tests', type=float, default=1800.0)
+    p.add_argument('--timeout-inactivity', type=float, default=180.0)
+    p.add_argument('--pid-file')
+    p.add_argument('--loglevel', default='INFO')
+    args = p.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.loglevel.upper()),
+                        format='%(levelname)s:%(name)s:%(message)s')
+    os.makedirs(args.workdir, exist_ok=True)
+
+    results = [do_run(args, i) for i in range(args.runs)]
+    failures = [i for i, verdict in results if verdict != 'PASS']
+    if failures:
+        logging.error('%d/%d runs FAILED: %s', len(failures), args.runs, failures)
+        sys.exit(1)
+    logging.info('all %d run(s) passed', args.runs)
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -267,12 +267,48 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Some("libstd-net") => {
             builder.target_renode().add_services(&base_pkgs).add_services(&get_cratespecs());
-            builder.add_loader_feature("renode-bypass").add_loader_feature("renode-minimal");
+            builder.add_loader_feature("renode-bypass");
             builder
                 .add_service("net", LoaderRegion::Ram)
                 .add_service("com", LoaderRegion::Ram)
                 .add_service("llio", LoaderRegion::Ram)
                 .add_service("dns", LoaderRegion::Ram);
+            // `net` and `dns` pull the UX client stack (pddb/gam/modals) as
+            // unconditional lib deps, and those only compile with a board
+            // feature selected; the full-image builds get this from feature
+            // unification across the whole package set, but this minimal set
+            // has to ask for it explicitly. `net/renode-minimal` (in place of
+            // the connection manager) and `dns/minimal-testing` (in place of
+            // pddb-backed prefs) keep the runtime paths pddb-free.
+            builder
+                .add_feature("net/renode-minimal")
+                .add_feature("dns/minimal-testing")
+                .add_feature("pddb/renode")
+                .add_feature("gam/renode")
+                .add_feature("modals/renode");
+        }
+        Some("std-net-ci") => {
+            // The libstd-net image plus the on-target std::net test runner;
+            // see the libstd-net arm above for why the feature list is what
+            // it is.
+            builder.target_renode().add_services(&base_pkgs).add_services(&get_cratespecs());
+            builder.add_loader_feature("renode-bypass");
+            builder
+                .add_service("net", LoaderRegion::Ram)
+                .add_service("com", LoaderRegion::Ram)
+                .add_service("llio", LoaderRegion::Ram)
+                // net blocks in setup on `trng::Trng::new` (ephemeral ports,
+                // MAC fallback), and dns needs it for query ids; the Renode
+                // TRNG peripheral models back it in emulation.
+                .add_service("trng", LoaderRegion::Ram)
+                .add_service("dns", LoaderRegion::Ram)
+                .add_service("net-tests", LoaderRegion::Ram);
+            builder
+                .add_feature("net/renode-minimal")
+                .add_feature("dns/minimal-testing")
+                .add_feature("pddb/renode")
+                .add_feature("gam/renode")
+                .add_feature("modals/renode");
         }
         Some("renode-aes-test") => {
             builder.target_renode().add_services(&aes_test_pkgs).add_services(&get_cratespecs());
@@ -1023,6 +1059,7 @@ Renode emulation:
  libstd-test             Renode test image that includes the minimum packages. [cratespecs] are services
                          Bypasses sig checks, keys locked out.
  libstd-net              Renode test image for testing network functions. Bypasses sig checks, keys locked out.
+ std-net-ci              libstd-net image plus the net-tests runner (on-target std::net CI suite).
  ffi-test                builds an image for testing C-FFI bindings and integration. [cratespecs] are services
  renode-aes-test         Renode image for AES emulation development. Extremely minimal.
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -310,6 +310,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .add_feature("gam/renode")
                 .add_feature("modals/renode");
         }
+        Some("std-net-cross-host-ci") => {
+            // Same image as std-net-ci, plus the cross-host test themes, built
+            // against a REAL DHCP peer (emulation/linux-server.resc) on the
+            // switch: `net/renode-peer` skips the renode-minimal static seed so
+            // the DUT takes a real lease, and `net-tests/cross-host` compiles in the
+            // cross-host themes that talk to the peer.
+            builder.target_renode().add_services(&base_pkgs).add_services(&get_cratespecs());
+            builder.add_loader_feature("renode-bypass");
+            builder
+                .add_service("net", LoaderRegion::Ram)
+                .add_service("com", LoaderRegion::Ram)
+                .add_service("llio", LoaderRegion::Ram)
+                .add_service("trng", LoaderRegion::Ram)
+                .add_service("dns", LoaderRegion::Ram)
+                .add_service("net-tests", LoaderRegion::Ram);
+            builder
+                .add_feature("net/renode-minimal")
+                .add_feature("net/renode-peer")
+                .add_feature("net-tests/cross-host")
+                .add_feature("dns/minimal-testing")
+                .add_feature("pddb/renode")
+                .add_feature("gam/renode")
+                .add_feature("modals/renode");
+        }
         Some("renode-aes-test") => {
             builder.target_renode().add_services(&aes_test_pkgs).add_services(&get_cratespecs());
         }
@@ -1060,6 +1084,7 @@ Renode emulation:
                          Bypasses sig checks, keys locked out.
  libstd-net              Renode test image for testing network functions. Bypasses sig checks, keys locked out.
  std-net-ci              libstd-net image plus the net-tests runner (on-target std::net CI suite).
+ std-net-cross-host-ci        std-net-ci plus the cross-host themes (real DHCP peer on the switch).
  ffi-test                builds an image for testing C-FFI bindings and integration. [cratespecs] are services
  renode-aes-test         Renode image for AES emulation development. Extremely minimal.
 


### PR DESCRIPTION
The std::net sibling of #909: on-target CI for the real xous network path
(riscv32 libstd → net server → smoltcp), which hosted mode never exercises.

Two suites: a loopback suite (`services/net-tests`, 99 tests, self-contained
in one image — TCP/UDP over the interface's own addresses, DNS against an
in-image fake resolver) and a cross-host suite (7 tests against a Linux peer
on an emulated Ethernet switch: DHCP lease, TCP/UDP echo, real RST, peer
DNS). Only product change is a `renode-minimal` feature so a test image can
boot without the UX stack.

Same contract as #909: green = every known-bad behavior pinned as an
expected failure; fixes flip tests to XPASS and go red until the registry
row is removed. This PR is harness plus findings only — about a dozen real
net-service bugs are pinned (quiet-socket timeouts never firing / the #880
family, CNAME parse rejection, UDP rebind demux, a v6 panic, FIN handling,
…), each documented in its test's doc comment. A validated fix series
follows as separate PRs.

Example runs: loopback gist, cross-host gist [keep the two links].
Run with `cargo xtask std-net-ci` / `std-net-cross-host-ci` + the tools/
drivers; workflows are manual-dispatch like the fs suite.

Developed with AI assistance, see commit trailers.