### PR TITLE
ATE

### DIFF
--- a/bao1x-boot/boot1/src/main.rs
+++ b/bao1x-boot/boot1/src/main.rs
@@ -17,8 +17,12 @@ use core::{
     sync::atomic::{AtomicBool, AtomicU32, Ordering},
 };
 
-use bao1x_api::{BoardTypeCoding, BootWaitCoding, bollard};
-use bao1x_hal::{board::KeyPress, iox::Iox, usb::driver::UsbDeviceState};
+use bao1x_api::{BoardTypeCoding, BootWaitCoding, UsbDefaultSpeed, bollard};
+use bao1x_hal::{
+    board::KeyPress,
+    iox::Iox,
+    usb::driver::{PortSpeed, UsbDeviceState},
+};
 use bao1x_hal::{buram::BackupManager, hardening::*};
 use bao1x_hal::{sh1107::Oled128x128, udma::GlobalConfig};
 use critical_section::Mutex;
@@ -232,7 +236,10 @@ pub unsafe extern "C" fn rust_entry() -> ! {
 
     delay(250);
     // setup the USB port
-    let (mut last_usb_state, mut portsc) = glue::setup();
+    let (mut last_usb_state, mut portsc) = match one_way.get_decoded::<UsbDefaultSpeed>() {
+        Ok(UsbDefaultSpeed::Full) => glue::setup(Some(PortSpeed::Fs)),
+        _ => glue::setup(Some(PortSpeed::Hs)),
+    };
     delay(150);
 
     // release SE0
@@ -261,7 +268,7 @@ pub unsafe extern "C" fn rust_entry() -> ! {
     crate::glue::setup_spim(perclk);
 
     // it's in this loop that the board type would be set after initial boot
-    let mut repl = crate::repl::Repl::new();
+    let mut repl = crate::repl::Repl::new(perclk);
     let mut new_key: Option<KeyPress>;
     loop {
         let (new_usb_state, new_portsc) = glue::usb_status();

--- a/bao1x-boot/boot1/src/main.rs
+++ b/bao1x-boot/boot1/src/main.rs
@@ -39,7 +39,7 @@ use crate::secboot::try_boot;
 // - "Towards" - not a release yet, but working towards the stated milestone
 // - Eliminating "Towards" is done at the tag-out point.
 // - The "base" name is the name of the signing key used in the release.
-const RELEASE_DESCRIPTION: &'static str = "0.10.1 bao1";
+const RELEASE_DESCRIPTION: &'static str = "0.10.2 bao1";
 
 static UART_RX: Mutex<RefCell<VecDeque<u8>>> = Mutex::new(RefCell::new(VecDeque::new()));
 #[allow(dead_code)]

--- a/bao1x-boot/boot1/src/main.rs
+++ b/bao1x-boot/boot1/src/main.rs
@@ -39,7 +39,7 @@ use crate::secboot::try_boot;
 // - "Towards" - not a release yet, but working towards the stated milestone
 // - Eliminating "Towards" is done at the tag-out point.
 // - The "base" name is the name of the signing key used in the release.
-const RELEASE_DESCRIPTION: &'static str = "Towards 0.10.1 beta-1";
+const RELEASE_DESCRIPTION: &'static str = "0.10.1 bao1";
 
 static UART_RX: Mutex<RefCell<VecDeque<u8>>> = Mutex::new(RefCell::new(VecDeque::new()));
 #[allow(dead_code)]

--- a/bao1x-boot/boot1/src/platform/bao1x.rs
+++ b/bao1x-boot/boot1/src/platform/bao1x.rs
@@ -1,5 +1,6 @@
 pub mod bao1x;
 pub use bao1x::*;
+pub mod ate;
 pub mod debug;
 pub mod gfx;
 pub mod irq;

--- a/bao1x-boot/boot1/src/platform/bao1x/ate.rs
+++ b/bao1x-boot/boot1/src/platform/bao1x/ate.rs
@@ -1,0 +1,92 @@
+use bao1x_hal::udma::{AdcExtChannel, AdcSource, GlobalConfig};
+
+#[repr(C)]
+pub struct Ate {
+    adc: [[u16; 5]; 3],
+}
+impl Ate {
+    pub fn new(perclk: u32) -> Ate {
+        use bao1x_api::{IoGpio, IoSetup};
+        use bao1x_hal::iox::Iox;
+        let iox = Iox::new(utralib::utra::iox::HW_IOX_BASE as *mut u32);
+        let udma_global = GlobalConfig::new();
+        udma_global.clock_on(bao1x_api::PeriphId::Adc);
+        // safety: clocks have been turned on. The ADC buffer is located at the base of IFRAM0 which should
+        // be empty, as IFRAM reserved addresses allocate from top-down.
+        let mut adc = unsafe { bao1x_hal::udma::Adc::new_baremetal(perclk, utralib::HW_IFRAM0_MEM) };
+        // setup PF1 as an "index" pin
+        iox.setup_pin(
+            bao1x_api::IoxPort::PF,
+            1,
+            Some(bao1x_api::IoxDir::Output),
+            Some(bao1x_api::IoxFunction::Gpio),
+            None,
+            Some(bao1x_api::IoxEnable::Disable),
+            None,
+            None,
+        );
+        // bring the pin low to indicate that we're starting the test
+        iox.set_gpio_pin_value(bao1x_api::IoxPort::PF, 1, bao1x_api::IoxValue::Low);
+        // setup PA4..=PA7 as inputs - just to make sure we aren't accidentally driving them.
+        // disable the pull-up, too.
+        for pin in 4..=7 {
+            iox.setup_pin(
+                bao1x_api::IoxPort::PA,
+                pin,
+                Some(bao1x_api::IoxDir::Input),
+                Some(bao1x_api::IoxFunction::Gpio),
+                Some(bao1x_api::IoxEnable::Disable),
+                Some(bao1x_api::IoxEnable::Disable),
+                None,
+                None,
+            );
+        }
+        // pipe-clear any stale ADC values
+        let _dummy = adc.read_raw_averaged(AdcSource::Ext(AdcExtChannel::Adc0), 8);
+
+        let sources = [
+            AdcSource::Temperature,
+            AdcSource::Ext(AdcExtChannel::Adc0),
+            AdcSource::Ext(AdcExtChannel::Adc1),
+            AdcSource::Ext(AdcExtChannel::Adc2),
+            AdcSource::Ext(AdcExtChannel::Adc3),
+        ];
+        let mut ate: Ate = Ate { adc: [[0xDEADu16; 5]; 3] };
+        for sample in 0..3 {
+            // 0->1 on PF1 indicates zone for updating analog values within 5ms
+            iox.set_gpio_pin_value(bao1x_api::IoxPort::PF, 1, bao1x_api::IoxValue::High);
+            crate::platform::delay(5);
+            iox.set_gpio_pin_value(bao1x_api::IoxPort::PF, 1, bao1x_api::IoxValue::Low);
+            // 1->0 on PF1 indicates sampling values
+            for (channel, source) in sources.iter().enumerate() {
+                let _dummy = adc.read_raw_averaged(*source, 8); // dummy reading still required every source change, some bug in ADC driver?
+                let raw = adc.read_raw_averaged(*source, 8);
+                ate.adc[sample][channel] = raw;
+                /* // don't include this in production code, it adds a lot of overhead & time!
+                crate::println!(
+                    "sample {} source {:?}: {} {} {}",
+                    sample,
+                    source,
+                    raw,
+                    bao1x_hal::udma::Adc::raw_to_temp_celsius(raw),
+                    bao1x_hal::udma::Adc::raw_to_voltage(raw)
+                );
+                */
+            }
+            crate::platform::delay(5);
+        }
+        ate
+    }
+
+    pub fn serialize_into(&self, buf: &mut [u8; 32]) {
+        let mut idx = 0usize;
+        for sample_set in self.adc.iter() {
+            for &adc_data in sample_set.iter() {
+                let b = adc_data.to_le_bytes();
+                buf[idx] = b[0];
+                buf[idx + 1] = b[1];
+                idx += 2;
+            }
+        }
+    }
+}

--- a/bao1x-boot/boot1/src/platform/bao1x/usb/glue.rs
+++ b/bao1x-boot/boot1/src/platform/bao1x/usb/glue.rs
@@ -104,7 +104,7 @@ pub fn write_spim_page(addr: usize, data: Box<[u8; SPINOR_ERASE_SIZE as usize]>)
     }
 }
 
-pub fn setup() -> (UsbDeviceState, u32) {
+pub fn setup(speed: Option<bao1x_hal::usb::driver::PortSpeed>) -> (UsbDeviceState, u32) {
     /*
     use crate::usb;
 
@@ -127,7 +127,7 @@ pub fn setup() -> (UsbDeviceState, u32) {
         if let Some(ref mut usb_ref) = crate::platform::bao1x::usb::USB {
             let usb = &mut *core::ptr::addr_of_mut!(*usb_ref);
             usb.reset();
-            usb.init();
+            usb.init(speed);
             usb.start();
             usb.update_current_speed();
             // IRQ enable must happen without dependency on the hardware lock

--- a/bao1x-boot/boot1/src/repl.rs
+++ b/bao1x-boot/boot1/src/repl.rs
@@ -32,12 +32,13 @@ pub struct Repl {
     do_cmd: bool,
     local_echo: bool,
     lockdown_armed: bool,
+    perclk: u32,
     #[cfg(feature = "uf2-spim")]
     serial_assembler: PageAssembler<PageCallback>,
 }
 
 impl Repl {
-    pub fn new() -> Self {
+    pub fn new(perclk: u32) -> Self {
         Self {
             cmdline: String::new(),
             do_cmd: false,
@@ -45,6 +46,7 @@ impl Repl {
             lockdown_armed: false,
             #[cfg(feature = "uf2-spim")]
             serial_assembler: PageAssembler::new(write_spim_page),
+            perclk,
         }
     }
 
@@ -1024,6 +1026,75 @@ impl Repl {
                 }
                 run_kat_verify::<Sha2_128_24>(SHA2_128_24_PK, SHA2_128_24_SIG);
             }
+            "ate" => {
+                use bao1x_api::{IoGpio, IoSetup};
+                use bao1x_hal::iox::Iox;
+                let iox = Iox::new(utralib::utra::iox::HW_IOX_BASE as *mut u32);
+                // setup PF1 as an "index" pin
+                iox.setup_pin(
+                    bao1x_api::IoxPort::PF,
+                    5,
+                    Some(bao1x_api::IoxDir::Output),
+                    Some(bao1x_api::IoxFunction::Gpio),
+                    None,
+                    Some(bao1x_api::IoxEnable::Disable),
+                    None,
+                    None,
+                );
+                // indicates test running
+                iox.set_gpio_pin_value(bao1x_api::IoxPort::PF, 5, bao1x_api::IoxValue::Low);
+                // force USB speed to full speed
+                crate::glue::setup(Some(bao1x_hal::usb::driver::PortSpeed::Fs));
+
+                let slot_mgr = bao1x_hal::acram::SlotManager::new();
+                let mut rram = bao1x_hal::rram::Reram::new();
+                let slot = &bao1x_api::offsets::ATE_RESERVED;
+                let ate = crate::platform::ate::Ate::new(self.perclk);
+                let mut data = [0u8; 32];
+                ate.serialize_into(&mut data);
+                slot_mgr.write(&mut rram, slot, &data).ok();
+
+                // indicates test finish
+                iox.set_gpio_pin_value(bao1x_api::IoxPort::PF, 5, bao1x_api::IoxValue::High);
+            }
+            "atecheck" => {
+                let slot_mgr = bao1x_hal::acram::SlotManager::new();
+                let slot = &bao1x_api::offsets::ATE_RESERVED;
+                match slot_mgr.read(slot) {
+                    Ok(d) => crate::println!("{:02x?}", d),
+                    Err(e) => crate::println!("{:?}", e),
+                }
+            }
+            "usb_speed" => {
+                let one_way = OneWayCounter::new();
+                if args.len() == 0 {
+                    crate::println!(
+                        "USB speed: {:?}",
+                        one_way.get_decoded::<bao1x_api::UsbDefaultSpeed>().expect("owc coding error")
+                    );
+                    self.abort_cmd();
+                    return Ok(());
+                } else if args.len() != 1 {
+                    return Err(Error::help("usb_speed [full | high]"));
+                }
+                let new_type = match args[0].as_str() {
+                    "full" => bao1x_api::UsbDefaultSpeed::Full,
+                    "high" => bao1x_api::UsbDefaultSpeed::High,
+                    _ => return Err(Error::help("usb_speed [full | high]")),
+                };
+                let mut count = 0;
+                while one_way.get_decoded::<bao1x_api::UsbDefaultSpeed>().expect("owc coding error")
+                    != new_type
+                {
+                    one_way.inc_coded::<bao1x_api::UsbDefaultSpeed>().expect("increment error");
+                    count += 1;
+                }
+                crate::println!(
+                    "USB default speed is {:?} after {} increments. Takes effect after a reboot.",
+                    new_type,
+                    count
+                );
+            }
             "echo" => {
                 for word in args {
                     crate::print!("{} ", word);
@@ -1033,7 +1104,7 @@ impl Repl {
             _ => {
                 crate::println!("Command not recognized: {}", cmd);
                 crate::print!(
-                    "Commands include: altboot, audit, boot, boardtype, bootwait, echo, idmode, ifr, localecho, lockdown, paranoid, reset, self_destruct, skipping, uf2"
+                    "Commands include: altboot, audit, boot, boardtype, bootwait, echo, idmode, ifr, localecho, lockdown, paranoid, reset, self_destruct, skipping, uf2, usb_speed"
                 );
                 #[cfg(feature = "test-boot0-keys")]
                 crate::print!(", publock");

--- a/baremetal/src/platform/bao1x/usb/glue.rs
+++ b/baremetal/src/platform/bao1x/usb/glue.rs
@@ -22,7 +22,7 @@ pub fn setup() -> (UsbDeviceState, u32) {
         if let Some(ref mut usb_ref) = crate::platform::bao1x::usb::USB {
             let usb = &mut *core::ptr::addr_of_mut!(*usb_ref);
             usb.reset();
-            usb.init();
+            usb.init(None);
             usb.start();
             usb.update_current_speed();
             // IRQ enable must happen without dependency on the hardware lock

--- a/libs/bao1x-api/src/offsets/baosec.rs
+++ b/libs/bao1x-api/src/offsets/baosec.rs
@@ -133,9 +133,6 @@ pub const THE_FLAG_1: SlotIndex = SlotIndex::Data(260, PartitionAccess::Fw0, RwP
 // [261..=383] reserved for Baochip data slot usage, see the "common" page for more details
 // NOTE: COLLATERAL is from 261..265, but it is in the "common" page
 
-// [384..=1919] are unused and available for third party use
-pub const APPLICATION: SlotIndex = crate::offsets::APPLICATION;
-
 pub const NUISANCE_KEYS_1: SlotIndex =
     SlotIndex::DataRange(1920..2048, PartitionAccess::Fw0, RwPerms::ReadWrite);
 pub const NUISANCE_KEYS: [SlotIndex; 2] = [NUISANCE_KEYS_0, NUISANCE_KEYS_1];

--- a/libs/bao1x-api/src/offsets/common.rs
+++ b/libs/bao1x-api/src/offsets/common.rs
@@ -93,7 +93,15 @@ pub const fn classic_to_pq_revocation(classic: usize) -> Option<usize> {
 // slots 0-127 are for bootloader/xous use
 // slots 128-255 are for user applications
 
-// slots 0-20 are currently unallocated
+// slots 0-19 are currently unallocated
+
+encode_oneway! {
+    #[offset = 20]
+    pub enum UsbDefaultSpeed {
+        High,
+        Full,
+    }
+}
 
 /// When this or REQUIRE_PQ_DUPE is set, the next stage *must* have a valid PQ signature
 /// By default, PQ signatures are optional.
@@ -327,7 +335,10 @@ pub const BOOT1_RECEIPT_SLOTS: [SlotIndex; 4] =
 // 32 bytes reserved to configure/set up clock scrambling
 pub const CLOCK_SCRAMBLE_PARAMS: SlotIndex = SlotIndex::Data(272, PartitionAccess::Open, RwPerms::ReadWrite);
 
-// [273..=383] available for future data slot usage - in particular opentitan provisioning block (2k of data)
+// 32 bytes reserved for ATE test operations. Data is read back by the ATE at this location via JTAG.
+pub const ATE_RESERVED: SlotIndex = SlotIndex::Data(273, PartitionAccess::Open, RwPerms::ReadWrite);
+
+// [274..=383] available for future data slot usage - in particular opentitan provisioning block (2k of data)
 // can fit in this with some margin.
 
 // Notes on defining the boot0 IFR region.

--- a/libs/bao1x-api/src/offsets/dabao.rs
+++ b/libs/bao1x-api/src/offsets/dabao.rs
@@ -55,9 +55,6 @@ pub use crate::baosec::{
 pub const KEY_SLOTS: [SlotIndex; 6] =
     [THE_FLAG_1, ROOT_SEED, RMA_KEY, NUISANCE_KEYS_0, NUISANCE_KEYS_1, CHAFF_KEYS];
 
-// [384..=1919] are unused and available for third party use
-pub const APPLICATION: SlotIndex = crate::offsets::APPLICATION;
-
 // offsets into the application slot range for storing BIO config
 pub const APP_BIO_CLK_INDEX: usize = 0;
 pub const APP_BIO_PINS_INDEX: usize = 1;

--- a/libs/bao1x-hal/src/udma/adc.rs
+++ b/libs/bao1x-hal/src/udma/adc.rs
@@ -292,7 +292,7 @@ impl Adc {
     fn delay_us(us: u64) {
         // abuse the d11ctime timer to create some time-out like thing
         let mut d11c = CSR::new(utra::d11ctime::HW_D11CTIME_BASE as *mut u32);
-        d11c.wfo(utra::d11ctime::CONTROL_COUNT, 333); // 1.0us per interval
+        d11c.wfo(utra::d11ctime::CONTROL_COUNT, 12000); // empirically tested; if values seem too low adjust higher
         let mut polarity = d11c.rf(utra::d11ctime::HEARTBEAT_BEAT);
         for _ in 0..us {
             while polarity == d11c.rf(utra::d11ctime::HEARTBEAT_BEAT) {}

--- a/libs/bao1x-hal/src/usb/driver.rs
+++ b/libs/bao1x-hal/src/usb/driver.rs
@@ -334,13 +334,6 @@ pub struct Uicr {
 }
 
 const CRG_UDC_CFG0_MAXSPEED_FS: u32 = 1;
-// surprisingly, just swapping this constant in "sort of works"
-// some to-do around figuring out why the protocol breaks, could
-// just be signal integrity because too many connectors, but very
-// likely this is also an inability to handle the longer packet
-// sizes mandated by the HS protocol.
-//
-// leave as a warning so we have this as a TODO.
 const CRG_UDC_CFG0_MAXSPEED_HS: u32 = 3;
 
 pub const CRG_UDC_ERDPLO_EHB: u32 = 1 << 3;
@@ -1272,7 +1265,7 @@ impl CorigineUsb {
         println!("USB reset done: {:x}", dummy);
     }
 
-    pub fn init(&mut self) {
+    pub fn init(&mut self, speed: Option<PortSpeed>) {
         crate::println!("~~~~~~~~~~~~~~~~INIT~~~~~~~~~~~~~~~");
         let ifram_slice = unsafe {
             core::slice::from_raw_parts_mut(
@@ -1291,7 +1284,12 @@ impl CorigineUsb {
             // wait for reset to finish
         }
 
-        self.csr.wo(DEVCONFIG, 0x80 | CRG_UDC_CFG0_MAXSPEED_FS | CRG_UDC_CFG0_MAXSPEED_HS);
+        match speed {
+            // note: LS option is not well tested
+            Some(PortSpeed::Ls) => self.csr.wo(DEVCONFIG, 0x80),
+            Some(PortSpeed::Fs) => self.csr.wo(DEVCONFIG, 0x80 | CRG_UDC_CFG0_MAXSPEED_FS),
+            _ => self.csr.wo(DEVCONFIG, 0x80 | CRG_UDC_CFG0_MAXSPEED_FS | CRG_UDC_CFG0_MAXSPEED_HS),
+        };
 
         self.csr.wo(
             EVENTCONFIG,
@@ -2260,7 +2258,7 @@ impl CorigineUsb {
      we uh...decide to implement a third target, or something like that.
     */
     /// Force and hold the reset pin according to the state selected
-    pub fn ll_reset(&mut self, state: bool) {
+    pub fn ll_reset(&mut self, state: bool, speed: Option<PortSpeed>) {
         #[cfg(feature = "std")]
         crate::println!("ll_reset is UNSURE");
         // There is a PHY control, it looks like 0x1C bit 1 set to 1 will cause the device to hi-Z
@@ -2270,7 +2268,7 @@ impl CorigineUsb {
         if state {
             self.reset();
         } else {
-            self.init();
+            self.init(speed);
         }
     }
 
@@ -2503,7 +2501,7 @@ impl UsbBus for CorigineWrapper {
             // disable IRQs
             hw.irq_csr.wo(utralib::utra::irqarray1::EV_ENABLE, 0);
             hw.reset();
-            hw.init();
+            hw.init(None); // default to high speed
             hw.start();
             hw.update_current_speed();
             // IRQ enable must happen without dependency on the hardware lock

--- a/libs/bao1x-hal/src/usb/driver.rs
+++ b/libs/bao1x-hal/src/usb/driver.rs
@@ -2873,7 +2873,7 @@ impl UsbBus for CorigineWrapper {
             // disable IRQs
             hw.irq_csr.wo(utralib::utra::irqarray1::EV_ENABLE, 0);
             hw.reset();
-            hw.init();
+            hw.init(None);
             hw.start();
             hw.update_current_speed();
             // IRQ enable must happen without dependency on the hardware lock

--- a/services/usb-bao1x/src/hw.rs
+++ b/services/usb-bao1x/src/hw.rs
@@ -148,7 +148,7 @@ impl<'a> Bao1xUsb<'a> {
         self.irq_csr.wo(utra::irqarray1::EV_EDGE_TRIGGERED, 0);
         self.irq_csr.wo(utra::irqarray1::EV_POLARITY, 0);
 
-        self.wrapper.core().init();
+        self.wrapper.core().init(None);
         self.wrapper.core().start();
         self.wrapper.core().update_current_speed();
 

--- a/services/usb-bao1x/src/hw.rs
+++ b/services/usb-bao1x/src/hw.rs
@@ -170,7 +170,7 @@ impl<'a> Bao1xUsb<'a> {
         self.irq_csr.wo(utra::irqarray1::EV_ENABLE, 0);
 
         self.wrapper.core().reset();
-        self.wrapper.core().init();
+        self.wrapper.core().init(None);
         self.wrapper.core().start();
         self.wrapper.core().update_current_speed();
 


### PR DESCRIPTION
ATE enhancement to boot1

- `ate` command samples the ADC and stores it in RRAM for retrieval by the ATE environment. It also forces USB speed to full speed so the tester can keep up
- `usb_speed` is a new command added to the boot1 repl environment that allows users to force the boot speed down to full speed (or revert back to high speed).

The full speed forcing is useful for users who just want a working USB but don't want to deal with the signal integrity issues of high speed, and/or don't have the experience to deal with it.
