### PR TITLE
update xous-semver to handle augmented/testing tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8221,9 +8221,9 @@ dependencies = [
 
 [[package]]
 name = "xous-semver"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906500be0c4ed13afc3c8743e4d40337bfbe08e7dadfa216c39907aaa06cc8c2"
+checksum = "40505168527c6a6aa9ebb8487657e983748f0c1e86cd701ff0046f08dcea3761"
 
 [[package]]
 name = "xous-susres"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4.14"
 pem = "0.8.3"
 svd2utra = "0.1.25"
 xmas-elf = "0.9.0"
-xous-semver = "0.1.5"
+xous-semver = "0.1.6"
 ed25519-dalek = { version = "2.1.0", features = ["digest", "rand_core"] }
 sha2 = { version = "0.10.8" }
 pkcs8 = { version = "0.8.0", features = ["pem"] }


### PR DESCRIPTION
requires a bump of the xous-semver crate