### PR TITLE
PQ fixes

### DIFF
--- a/bao1x-boot/boot1/src/audit.rs
+++ b/bao1x-boot/boot1/src/audit.rs
@@ -94,6 +94,7 @@ pub fn audit() {
         owc.get(PARANOID_MODE).unwrap(),
         owc.get(PARANOID_MODE_DUPE).unwrap()
     );
+    crate::println!("PQ required: {}/{}", owc.get(REQUIRE_PQ).unwrap(), owc.get(REQUIRE_PQ_DUPE).unwrap());
     // this number may be non-zero because some of the sensors are on a hair-trigger
     crate::println!("Possible attack attempts: {}", owc.get(POSSIBLE_ATTACKS).unwrap());
     crate::println!("Revocations:");

--- a/bao1x-boot/boot1/src/repl.rs
+++ b/bao1x-boot/boot1/src/repl.rs
@@ -1126,7 +1126,7 @@ impl Repl {
             _ => {
                 crate::println!("Command not recognized: {}", cmd);
                 crate::print!(
-                    "Commands include: altboot, audit, boot, boardtype, bootwait, echo, idmode, ifr, localecho, lockdown, paranoid, reset, self_destruct, skipping, uf2, usb_speed"
+                    "Commands include: altboot, audit, boot, boardtype, bootwait, echo, idmode, ifr, localecho, lockdown, paranoid, require-pq, reset, self_destruct, skipping, uf2, usb_speed"
                 );
                 #[cfg(feature = "test-boot0-keys")]
                 crate::print!(", publock");

--- a/bao1x-boot/boot1/src/repl.rs
+++ b/bao1x-boot/boot1/src/repl.rs
@@ -102,12 +102,20 @@ impl Repl {
                     ("loader", LOADER_REVOCATION_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
                     ("boot0", BOOT0_REVOCATION_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
                     ("boot1", BOOT1_REVOCATION_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
-                    ("loader", LOADER_REVOCATION_DUPE_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
-                    ("boot0", BOOT0_REVOCATION_DUPE_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
-                    ("boot1", BOOT1_REVOCATION_DUPE_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
+                    ("loader+", LOADER_REVOCATION_DUPE_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
+                    ("boot0+", BOOT0_REVOCATION_DUPE_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
+                    ("boot1+", BOOT1_REVOCATION_DUPE_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
+                    ("loader-pq", PQ_LOADER_REVOCATION_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
+                    ("boot0-pq", PQ_BOOT0_REVOCATION_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
+                    ("boot1-pq", PQ_BOOT1_REVOCATION_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
+                    ("loader-pq+", PQ_LOADER_REVOCATION_DUPE_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
+                    ("boot0-pq+", PQ_BOOT0_REVOCATION_DUPE_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
+                    ("boot1-pq+", PQ_BOOT1_REVOCATION_DUPE_OFFSET + bao1x_api::pubkeys::DEVELOPER_KEY_SLOT),
                     ("paranoid1", PARANOID_MODE), /* let's try CI testing with this active, and see how
                                                    * bad it is... */
                     ("paranoid2", PARANOID_MODE_DUPE),
+                    ("pq", REQUIRE_PQ),
+                    ("pq+", REQUIRE_PQ_DUPE),
                 ];
                 for &(desc, devkey) in devkey_offsets.iter() {
                     match unsafe { owc.inc(devkey) } {
@@ -712,6 +720,20 @@ impl Repl {
                 let mut rram = bao1x_hal::rram::Reram::new();
                 unsafe { rram.self_destruct() }
                 // ... and all was null and void!
+            }
+            "require-pq" => {
+                match args.as_slice() {
+                    [s] if s == "confirm" => false,
+                    _ => {
+                        return Err(Error::help("Usage: 'require-pq confirm'. WARNING: cannot be undone!"));
+                    }
+                };
+                let one_way = OneWayCounter::new();
+                // safety: the offsets come from the API and are guaranteed to be valid
+                unsafe {
+                    one_way.inc(bao1x_api::REQUIRE_PQ).unwrap();
+                    one_way.inc(bao1x_api::REQUIRE_PQ_DUPE).unwrap();
+                }
             }
             "baosec-init" => {
                 let full = match args.as_slice() {

--- a/bao1x-boot/boot1/src/repl.rs
+++ b/bao1x-boot/boot1/src/repl.rs
@@ -725,7 +725,9 @@ impl Repl {
                 match args.as_slice() {
                     [s] if s == "confirm" => false,
                     _ => {
-                        return Err(Error::help("Usage: 'require-pq confirm'. WARNING: cannot be undone!"));
+                        return Err(Error::help(
+                            "Usage: 'require-pq confirm'. This command disallows firmwares without a valid PQ signature. WARNING: cannot be undone!",
+                        ));
                     }
                 };
                 let one_way = OneWayCounter::new();

--- a/tools/src/sign_image.rs
+++ b/tools/src/sign_image.rs
@@ -279,7 +279,6 @@ pub fn sign_image<P: AsRef<Path>>(
             // Now we can use the private key data.
             let signing_key = SigningKey::from_bytes(&secbytes);
             let testing_pem = pem::parse(TEST_KEY_PEM)?;
-            let testing_pem_data = testing_pem.contents[16..].to_owned();
             let testing_key = SigningKey::from_bytes(testing_pem.contents[16..].try_into().unwrap());
 
             let anti_rollback = if let Some(code) = anti_rollback_manual {
@@ -355,7 +354,7 @@ pub fn sign_image<P: AsRef<Path>>(
                 }
 
                 // derive the public key for use in "fake keys" routines
-                let sk = Ed25519KeyPair::from_pkcs8_maybe_unchecked(&testing_pem_data)
+                let sk = Ed25519KeyPair::from_pkcs8_maybe_unchecked(&testing_pem.contents)
                     .map_err(|e| format!("{}", e))?;
                 let derived_public_key = sk.public_key();
 


### PR DESCRIPTION
- add PQ revocations to lockdown
- add require pq to lockdown
- add a command to allow a user to require PQ signing

By default the system only regards the PQ signature as advisory.
