### PR TITLE
bao1x-api: DmaWindow base/bounds are page numbers, not bytes.

### DIFF
--- a/libs/bao1x-api/src/bio.rs
+++ b/libs/bao1x-api/src/bio.rs
@@ -533,7 +533,7 @@ pub struct IrqConfig {
 }
 
 /// Defines an accessible window by DMA from BIO cores. It's a slice starting from `base` going for `bounds`
-/// bytes.
+/// **pages**.
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "std", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
 pub struct DmaWindow {

--- a/libs/bao1x-api/src/bio.rs
+++ b/libs/bao1x-api/src/bio.rs
@@ -533,7 +533,7 @@ pub struct IrqConfig {
 }
 
 /// Defines an accessible window by DMA from BIO cores. It's a slice starting from `base` going for `bounds`
-/// **pages**.
+/// pages.
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "std", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
 pub struct DmaWindow {


### PR DESCRIPTION
Ran into this when I was trying to write some strange bio code.. 😅  
Clarifies that DmaWindow base/bounds are in pages, not bytes.
