### PR TITLE
Encrypt swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ version = "0.1.0"
 dependencies = [
  "aes 0.8.4",
  "arbitrary-int",
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-emu",
  "bao1x-hal",
  "bao1x-hal-service",
@@ -402,7 +402,7 @@ dependencies = [
 name = "bao-video"
 version = "0.1.0"
 dependencies = [
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-emu",
  "bao1x-hal",
  "bao1x-hal-service",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "bao1x-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arbitrary-int",
  "bitbybit",
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "bao1x-api"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4edc5137cb217d351fe061bbb39e97a31cffe012d10806b0b35f342cb0e4495"
+checksum = "bcda37a833ae6d23551c1e6340b7b2b53803d8e447ad10a4e6b71bd522149b4f"
 dependencies = [
  "arbitrary-int",
  "bitbybit",
@@ -465,7 +465,7 @@ dependencies = [
 name = "bao1x-boot0"
 version = "0.1.0"
 dependencies = [
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-hal",
  "critical-section",
  "digest 0.10.7",
@@ -484,7 +484,7 @@ dependencies = [
 name = "bao1x-boot1"
 version = "0.1.0"
 dependencies = [
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-hal",
  "base64 0.22.1",
  "critical-section",
@@ -509,7 +509,7 @@ dependencies = [
 name = "bao1x-emu"
 version = "0.1.0"
 dependencies = [
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "log",
  "minifb",
  "num-derive 0.4.2",
@@ -531,7 +531,7 @@ name = "bao1x-hal"
 version = "0.1.0"
 dependencies = [
  "arbitrary-int",
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bitbybit",
  "bitfield",
  "bitflags 1.3.2",
@@ -563,7 +563,7 @@ name = "bao1x-hal-service"
 version = "0.1.0"
 dependencies = [
  "arbitrary-int",
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-hal",
  "bio-lib",
  "bitbybit",
@@ -630,7 +630,7 @@ dependencies = [
 name = "baremetal"
 version = "0.1.0"
 dependencies = [
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-hal",
  "base64 0.22.1",
  "critical-section",
@@ -745,7 +745,7 @@ name = "bio-lib"
 version = "0.1.0"
 dependencies = [
  "arbitrary-int",
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-hal",
  "bitbybit",
  "log",
@@ -762,7 +762,7 @@ dependencies = [
 name = "bio-stream"
 version = "0.1.0"
 dependencies = [
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-hal",
  "bao1x-hal-service",
  "log",
@@ -1908,7 +1908,7 @@ version = "0.1.0"
 dependencies = [
  "aes 0.8.4",
  "arbitrary-int",
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-emu",
  "bao1x-hal",
  "bao1x-hal-service",
@@ -3689,7 +3689,7 @@ dependencies = [
  "aes 0.8.4",
  "aes-gcm-siv",
  "aes-kw",
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-emu",
  "bao1x-hal",
  "bao1x-hal-service",
@@ -3716,6 +3716,7 @@ dependencies = [
  "xous-api-names",
  "xous-api-ticktimer",
  "xous-ipc 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xous-swapper",
  "zeroize",
 ]
 
@@ -3887,7 +3888,7 @@ dependencies = [
  "aes-gcm-siv",
  "armv7",
  "atsama5d27",
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-hal",
  "com_rs 0.1.0 (git+https://github.com/betrusted-io/com_rs?branch=main)",
  "crc 1.8.1",
@@ -4084,7 +4085,7 @@ dependencies = [
 name = "modals"
 version = "0.1.0"
 dependencies = [
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-emu",
  "bao1x-hal-service",
  "bit_field",
@@ -6027,7 +6028,7 @@ dependencies = [
 name = "sha2-bao1x"
 version = "0.10.9"
 dependencies = [
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "digest 0.10.7",
  "utralib 0.1.27",
 ]
@@ -6036,7 +6037,7 @@ dependencies = [
 name = "sha2-bao1x-pq"
 version = "0.11.0"
 dependencies = [
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "digest 0.11.3",
  "utralib 0.1.27",
 ]
@@ -7076,7 +7077,7 @@ dependencies = [
 name = "usb-bao1x"
 version = "0.1.0"
 dependencies = [
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-emu",
  "bao1x-hal",
  "bao1x-hal-service",
@@ -7406,7 +7407,7 @@ version = "0.1.0"
 dependencies = [
  "arrayref",
  "backup-vault2",
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-emu",
  "bao1x-hal",
  "bao1x-hal-service",
@@ -8167,7 +8168,7 @@ name = "xous-kernel"
 version = "0.9.38"
 dependencies = [
  "armv7",
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-hal",
  "bitflags 1.3.2",
  "critical-section",
@@ -8268,7 +8269,7 @@ version = "0.1.0"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm-siv",
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "bao1x-hal",
  "loader",
  "log",
@@ -8286,7 +8287,7 @@ dependencies = [
 name = "xous-ticktimer"
 version = "0.1.32"
 dependencies = [
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "loader",
  "log",
  "num-derive 0.4.2",
@@ -8308,7 +8309,7 @@ name = "xous-tools"
 version = "0.1.3"
 dependencies = [
  "aes-gcm-siv",
- "bao1x-api 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bao1x-api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.20.0",
  "bitflags 1.3.2",
  "byteorder",
@@ -8366,7 +8367,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "atty",
- "bao1x-api 0.1.2",
+ "bao1x-api 0.1.3",
  "chrono",
  "filetime",
  "lazy_static",

--- a/apps-baosec/vault2/src/main.rs
+++ b/apps-baosec/vault2/src/main.rs
@@ -349,6 +349,48 @@ fn main() -> ! {
     .ok();
     vault_ui.refresh_draw_list();
 
+    {
+        // check/trigger swap encryption before starting the main loop
+        let xns = xous_names::XousNames::new().unwrap();
+        let keystore = keystore::Keystore::new(&xns);
+        const THROW_AWAY_SERVER: &'static str = "_use once server_";
+        const THROW_AWAY_OP: usize = 42;
+        // idle forever, maybe turn this into a full blocking server that just parks and ends
+        let status_server = xns.register_name(THROW_AWAY_SERVER, None).unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(200)); // settle the system a little bit out of sheer paranoia
+
+        let rand = xous::create_server_id().unwrap().to_array();
+        let token = [rand[0], rand[1], rand[2]];
+        keystore.ensure_swap_encryption(THROW_AWAY_SERVER, THROW_AWAY_OP, token).unwrap();
+        let modals = modals::Modals::new(&xns).unwrap();
+        let mut in_progress = false;
+        let mut msg_opt = None;
+        loop {
+            xous::reply_and_receive_next(status_server, &mut msg_opt).unwrap();
+            let msg = msg_opt.as_mut().unwrap();
+            if msg.body.id() == THROW_AWAY_OP {
+                if let Some(scalar) = msg.body.scalar_message() {
+                    if token == [scalar.arg2 as u32, scalar.arg3 as u32, scalar.arg4 as u32] {
+                        let progress = scalar.arg1 as u32;
+                        if progress == 100 {
+                            break;
+                        }
+                        if !in_progress {
+                            modals.start_progress("Encrypting apps...", progress, 100, 0).ok();
+                            in_progress = true;
+                        } else {
+                            modals.update_progress(progress).ok();
+                        }
+                    }
+                }
+            }
+        }
+        if in_progress {
+            modals.finish_progress().ok();
+        }
+    }
+
     // kickstart the pumper
     xous::send_message(pump_conn, xous::Message::new_scalar(PumpOp::Pump.to_usize().unwrap(), 0, 0, 0, 0))
         .expect("couldn't start the pumper");

--- a/apps-baosec/vault2/src/main.rs
+++ b/apps-baosec/vault2/src/main.rs
@@ -349,6 +349,7 @@ fn main() -> ! {
     .ok();
     vault_ui.refresh_draw_list();
 
+    #[cfg(not(feature = "hosted-baosec"))]
     {
         // check/trigger swap encryption before starting the main loop
         let xns = xous_names::XousNames::new().unwrap();

--- a/bao1x-boot/boot1/src/repl.rs
+++ b/bao1x-boot/boot1/src/repl.rs
@@ -859,7 +859,11 @@ impl Repl {
                 // and should report as all 0's.
                 let ifr = unsafe { core::slice::from_raw_parts(0x6040_0000 as *const u8, 0x400) };
                 for (i, chunk) in ifr.chunks(32).enumerate() {
+                    // these "redundant" asserts make it harder to abuse this print as a memory dumping
+                    // primitive, e.g. by glitching or other similar attack
+                    assert!(ifr.as_ptr() as usize == 0x6040_0000);
                     crate::println!("  {:03x}: {:02x?}", i * 32, chunk);
+                    assert!(i < 32);
                 }
             }
             #[cfg(feature = "test-boot0-keys")]

--- a/baosign.ps1
+++ b/baosign.ps1
@@ -193,6 +193,7 @@ foreach ($imageSpec in $selectedConfig) {
         # Build the cargo run command
         $cargoCmd = @(
             "cargo", "run", "--",
+            "--strip-pq",
             "--credential-file", "..\credentials\$CredentialFile",
             "--file", "..\..\$imagePath",
             "--function-code", $functionCode
@@ -203,7 +204,7 @@ foreach ($imageSpec in $selectedConfig) {
         Write-Status "Target SSH: $(if ($Local) { '(skipped, --Local mode)' } else { $TARGET })"
 
         # Execute the signing command
-        & cargo run -- --credential-file "..\credentials\$CredentialFile" --file "..\..\$imagePath" --function-code $functionCode 2>&1 | Tee-Object -Variable result
+        & cargo run -- --strip-pq --credential-file "..\credentials\$CredentialFile" --file "..\..\$imagePath" --function-code $functionCode 2>&1 | Tee-Object -Variable result
         # $result = cargo run -- --credential-file "..\credentials\$CredentialFile" --file "..\..\$imagePath" --function-code $functionCode | Tee-Object -Variable result
 
         if ($LASTEXITCODE -eq 0) {

--- a/libs/bao1x-api/Cargo.toml
+++ b/libs/bao1x-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bao1x-api"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Baochip-1x API Crate"
 license = "Apache-2.0"

--- a/libs/bao1x-api/src/offsets/baosec.rs
+++ b/libs/bao1x-api/src/offsets/baosec.rs
@@ -122,16 +122,32 @@ pub const RMA_KEY: SlotIndex = SlotIndex::Data(257, PartitionAccess::Fw0, RwPerm
 /// to developer mode.
 pub const CP_COOKIE: SlotIndex = SlotIndex::Data(258, PartitionAccess::Fw0, RwPerms::ReadWrite);
 
-/// The swap encryption key. Used to protect swap images beyond the signing key, if we so desire.
-pub const SWAP_KEY: SlotIndex = SlotIndex::Data(259, PartitionAccess::Fw0, RwPerms::ReadWrite);
+/// This used to be the swap key, but it is deprecated. It is now marked as simply a reserved
+/// key which can be used for future purposes. Note the PartionAccess::Fw0 permissions on this -
+/// this means it's not accessible outside of the bootloader or key manager, in particular, it
+/// is not accessible in the loader, where the swap key would be needed.
+pub const RESERVED_1: SlotIndex = SlotIndex::Data(259, PartitionAccess::Fw0, RwPerms::ReadWrite);
 
 /// A test value placed by FT into the memory array. If you can read the original value, you've captured a
 /// flag!
 /// There is a second flag stored somewhere else. Can you find it?
 pub const THE_FLAG_1: SlotIndex = SlotIndex::Data(260, PartitionAccess::Fw0, RwPerms::ReadWrite);
 
-// [261..=383] reserved for Baochip data slot usage, see the "common" page for more details
-// NOTE: COLLATERAL is from 261..265, but it is in the "common" page
+// [261..=264] are the COLLATERAL keys (on the common page)
+// [265..=268] are the PK receipt slots
+
+/// The `SWAP` key gets more permissive access on it because it needs to be accessible outside
+/// of the bootloader and keystore - in particular, the loader, which is not trusted to
+/// access the master keys, needs access to this to decrypt the swap partition. This removes
+/// one of the belt and suspenders that protects the swap key - still, in user run mode, the
+/// key is not accessible by virtue of the memory page being mapped exclusively into the
+/// keystore process, so there is still *some* protection on the key.
+pub const SWAP_KEY: SlotIndex = SlotIndex::Data(271, PartitionAccess::Open, RwPerms::ReadWrite);
+
+// 272 are the clock scramble params
+// 273 are the ATE reserved location
+//
+// [274..=383] reserved for Baochip data slot usage, see the "common" page for more details
 
 pub const NUISANCE_KEYS_1: SlotIndex =
     SlotIndex::DataRange(1920..2048, PartitionAccess::Fw0, RwPerms::ReadWrite);

--- a/libs/bao1x-api/src/offsets/common.rs
+++ b/libs/bao1x-api/src/offsets/common.rs
@@ -348,7 +348,9 @@ pub const BOOT1_PK_RECEIPT_SLOT3: SlotIndex = SlotIndex::Data(268, PartitionAcce
 pub const BOOT1_RECEIPT_SLOTS: [SlotIndex; 4] =
     [BOOT1_PK_RECEIPT_SLOT0, BOOT1_PK_RECEIPT_SLOT1, BOOT1_PK_RECEIPT_SLOT2, BOOT1_PK_RECEIPT_SLOT3];
 
-// [269..=271] reserved for future use
+// [269..=270] reserved for future use
+
+// 271 is the loader swap key for devices that have swap
 
 // 32 bytes reserved to configure/set up clock scrambling
 pub const CLOCK_SCRAMBLE_PARAMS: SlotIndex = SlotIndex::Data(272, PartitionAccess::Open, RwPerms::ReadWrite);

--- a/libs/bao1x-api/src/signatures.rs
+++ b/libs/bao1x-api/src/signatures.rs
@@ -325,9 +325,13 @@ pub struct SwapDescriptor {
     pub ram_offset: u32,
     pub ram_size: u32,
     pub name: u32,
+    /// This field is deprecated. It is ignored but retained so that the record shape
+    /// remains backward compatible
     pub key: [u8; 32],
     pub flash_offset: u32,
 }
 impl AsRef<[u8]> for SwapDescriptor {
     fn as_ref(&self) -> &[u8] { bytemuck::bytes_of(self) }
 }
+
+pub const SWAP_VERSION: u32 = 0x01_01_0000;

--- a/libs/keystore-api/Cargo.toml
+++ b/libs/keystore-api/Cargo.toml
@@ -31,6 +31,7 @@ policy-menu = []
 gen2 = []
 owc-inc = []
 app-keys = []
+swap = []
 
 std = ["derive-rkyv", "xous-names", "xous-ipc", "locales"]
 derive-rkyv = ["rkyv"]

--- a/libs/keystore-api/src/common.rs
+++ b/libs/keystore-api/src/common.rs
@@ -188,3 +188,10 @@ impl Into<(usize, usize, usize)> for PasswordState {
         }
     }
 }
+
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct SwapEncryptCall {
+    pub status_server: String,
+    pub status_opcode: u32,
+    pub token: [u32; 3],
+}

--- a/libs/keystore-api/src/gen2_api.rs
+++ b/libs/keystore-api/src/gen2_api.rs
@@ -33,6 +33,10 @@ pub enum Opcode {
     #[cfg(feature = "app-keys")]
     AppKeyOp = 1024,
 
+    /// Call to trigger that swap is encrypted
+    #[cfg(feature = "swap")]
+    EnsureSwapEncryption = 1536,
+
     // ----- below are non-cryptographic opcodes but used to manipulate sensitive state -----
     /// Set bootwait parameters
     Bootwait = 4096,

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -142,7 +142,8 @@ userspace-swap-debug = []     # sets up app UART mapping.
 
 # general flags
 debug-print = []
+unsafe-debug-print = []
 early-printk = []
-resume = []       # suspend/resume pathway code
+resume = []             # suspend/resume pathway code
 
 default = []

--- a/loader/src/platform/bao1x/swap.rs
+++ b/loader/src/platform/bao1x/swap.rs
@@ -22,6 +22,9 @@ use crate::swap::*;
 use crate::*;
 
 /// hard coded at offset 0 of SPI FLASH for now, until we figure out if and how to move this around.
+/// UPDATE: i think this is basically fixed here, if we have to move it, we need to change it in
+/// a lot of locations and I don't see much need to move it. Keeping the constant for now but
+/// maybe eventually we can just eliminate it since it's 0.
 const SWAP_IMG_START: usize = 0;
 
 pub struct SwapHal {
@@ -203,7 +206,7 @@ impl SwapHal {
             // safety: buf.data is aligned to 4096-byte boundary and filled with initialized data
             let ssh: &SwapSourceHeader =
                 unsafe { (buf.data.as_ptr() as *const SwapSourceHeader).as_ref().unwrap() };
-            #[cfg(feature = "debug-print")]
+            #[cfg(feature = "unsafe-debug-print")]
             {
                 println!("SwapSourceHeader: {:x?}", ssh);
                 println!("Swap key: {:x?}", &swap.key);
@@ -215,7 +218,8 @@ impl SwapHal {
                 partial_nonce: [0u8; 8],
                 aad_storage: [0u8; 64],
                 aad_len: 0,
-                src_cipher: Aes256GcmSiv::new((&swap.key).into()),
+                // start with the "0-key" guess
+                src_cipher: Aes256GcmSiv::new((&[0u8; 32]).into()),
                 flash_spim,
                 ram_spim,
                 swap_mac_start: ram_size_actual,
@@ -229,7 +233,8 @@ impl SwapHal {
             hal.aad_len = ssh.aad_len as usize;
             hal.partial_nonce.copy_from_slice(&ssh.partial_nonce);
 
-            // trial decryption with swap key to see if it's valid
+            // trial decryption with 0 key - if it's valid, then we have been presented a new swap image, and
+            // we TOFU it assuming its signature passes
             match hal.decrypt_src_page_at(0) {
                 Ok(_) => {
                     // check signature only if the swap key is all 0's
@@ -239,97 +244,94 @@ impl SwapHal {
                     // In practice for full security, the swap shall be encrypted to a custom symmetric
                     // key unique to each device, which takes the place of the signature check. This
                     // check is thus assumed to be performed only upon the first presentation of
-                    // a signed update.
-                    if swap.key == [0u8; 32] {
-                        crate::println!("Fresh swap image found - checking signature before proceeding");
-                        match bao1x_hal::sigcheck::validate_image(
-                            LOADER_TO_SWAP,
-                            Some(&mut hal.flash_spim),
-                            None,
-                        ) {
-                            Ok((k, k2, tag, _target, pq_tag)) => {
-                                let tag_owned;
-                                println!(
-                                    "*** Swap signature check by key @ {}/{}({}) pq {} OK ***",
-                                    k,
-                                    !k2,
-                                    core::str::from_utf8(&tag).unwrap_or("invalid tag"),
-                                    if let Some(tag) = pq_tag {
-                                        tag_owned = tag;
-                                        core::str::from_utf8(&tag_owned).unwrap_or("invalid tag")
-                                    } else {
-                                        "No PQ sig"
-                                    }
-                                );
-                                bollard!(bao1x_hal::sigcheck::die_no_std, 4);
-                                if k != !k2 {
-                                    bao1x_hal::sigcheck::die_no_std();
+                    // a signed update, and done in the defender's controlled environment.
+                    //
+                    // It is the keystore's responsibility to coordinate with the swap layer after
+                    // boot to encrypt the swap memory to the local key. Once this is done, the TOCTOU is
+                    // gone.
+                    crate::println!("Fresh swap image found - checking signature before proceeding");
+                    match bao1x_hal::sigcheck::validate_image(LOADER_TO_SWAP, Some(&mut hal.flash_spim), None)
+                    {
+                        Ok((k, k2, tag, _target, pq_tag)) => {
+                            let tag_owned;
+                            println!(
+                                "*** Swap signature check by key @ {}/{}({}) pq {} OK ***",
+                                k,
+                                !k2,
+                                core::str::from_utf8(&tag).unwrap_or("invalid tag"),
+                                if let Some(tag) = pq_tag {
+                                    tag_owned = tag;
+                                    core::str::from_utf8(&tag_owned).unwrap_or("invalid tag")
+                                } else {
+                                    "No PQ sig"
                                 }
-                                bollard!(bao1x_hal::sigcheck::die_no_std, 4);
-                                // k is just a nominal slot number. If either match, assume we are dealing
-                                // with a developer image.
-                                if tag
-                                    == *bao1x_api::pubkeys::KEYSLOT_INITIAL_TAGS
-                                        [bao1x_api::pubkeys::DEVELOPER_KEY_SLOT]
-                                    || k == bao1x_api::pubkeys::DEVELOPER_KEY_SLOT
-                                    || !k2 == bao1x_api::pubkeys::DEVELOPER_KEY_SLOT
-                                    || pq_tag
-                                        == Some(
-                                            *bao1x_api::pubkeys::KEYSLOT_INITIAL_TAGS
-                                                [bao1x_api::pubkeys::DEVELOPER_KEY_SLOT],
-                                        )
-                                {
-                                    // we can't erase keys in the loader, because the keys have already been
-                                    // locked out at this point. Thus,
-                                    // ensure that the system is already in developer mode.
-                                    let owc = bao1x_hal::acram::OneWayCounter::new();
-                                    bollard!(bao1x_hal::sigcheck::die_no_std, 4);
-                                    if owc.get(bao1x_api::DEVELOPER_MODE).unwrap() == 0 {
-                                        println!("{}LOADER.SWAPDIE,{}", BOOKEND_START, BOOKEND_END);
-                                        println!(
-                                            "Swap is devkey signed, but system is not in developer mode. Dying!"
-                                        );
-                                        bao1x_hal::sigcheck::die_no_std();
-                                    } else {
-                                        bollard!(bao1x_hal::sigcheck::die_no_std, 4);
-                                        // check if it's still 0 - force a double-glitch
-                                        if owc.get(bao1x_api::DEVELOPER_MODE).unwrap() == 0 {
-                                            bao1x_hal::sigcheck::die_no_std();
-                                        }
-                                        bollard!(bao1x_hal::sigcheck::die_no_std, 4);
-                                        println!("{}LOADER.SWAPDEV,{}", BOOKEND_START, BOOKEND_END);
-                                        println!(
-                                            "Developer key detected on swap. Proceeding in developer mode!"
-                                        );
-                                    }
-                                    let backup = bao1x_hal::buram::BackupManager::new();
-                                    bollard!(bao1x_hal::sigcheck::die_no_std, 4);
-                                    let owc = bao1x_hal::acram::OneWayCounter::new();
-                                    if owc.get(bao1x_api::IN_SYSTEM_BOOT_SETUP_DONE).unwrap() != 0 {
-                                        let erase_proof: &[u8; 32] = backup
-                                            .get_slice(bao1x_hal::buram::ERASURE_PROOF_RANGE_BYTES)
-                                            .try_into()
-                                            .unwrap();
-                                        if erase_proof != &[ERASE_VALUE; 32] {
-                                            bao1x_hal::sigcheck::die_no_std();
-                                        }
-                                    }
-                                    bollard!(bao1x_hal::sigcheck::die_no_std, 4);
-                                }
-                            }
-                            Err(e) => {
-                                println!("{}LOADER.SWAPSIGFAIL,{}", BOOKEND_START, BOOKEND_END);
-                                println!("Fresh swap image did not pass public key validation: {:?}", e);
+                            );
+                            bollard!(bao1x_hal::sigcheck::die_no_std, 4);
+                            if k != !k2 {
                                 bao1x_hal::sigcheck::die_no_std();
                             }
+                            bollard!(bao1x_hal::sigcheck::die_no_std, 4);
+                            // k is just a nominal slot number. If either match, assume we are dealing
+                            // with a developer image.
+                            if tag
+                                == *bao1x_api::pubkeys::KEYSLOT_INITIAL_TAGS
+                                    [bao1x_api::pubkeys::DEVELOPER_KEY_SLOT]
+                                || k == bao1x_api::pubkeys::DEVELOPER_KEY_SLOT
+                                || !k2 == bao1x_api::pubkeys::DEVELOPER_KEY_SLOT
+                                || pq_tag
+                                    == Some(
+                                        *bao1x_api::pubkeys::KEYSLOT_INITIAL_TAGS
+                                            [bao1x_api::pubkeys::DEVELOPER_KEY_SLOT],
+                                    )
+                            {
+                                // we can't erase keys in the loader, because the keys have already been
+                                // locked out at this point. Thus,
+                                // ensure that the system is already in developer mode.
+                                let owc = bao1x_hal::acram::OneWayCounter::new();
+                                bollard!(bao1x_hal::sigcheck::die_no_std, 4);
+                                if owc.get(bao1x_api::DEVELOPER_MODE).unwrap() == 0 {
+                                    println!("{}LOADER.SWAPDIE,{}", BOOKEND_START, BOOKEND_END);
+                                    println!(
+                                        "Swap is devkey signed, but system is not in developer mode. Dying!"
+                                    );
+                                    bao1x_hal::sigcheck::die_no_std();
+                                } else {
+                                    bollard!(bao1x_hal::sigcheck::die_no_std, 4);
+                                    // check if it's still 0 - force a double-glitch
+                                    if owc.get(bao1x_api::DEVELOPER_MODE).unwrap() == 0 {
+                                        bao1x_hal::sigcheck::die_no_std();
+                                    }
+                                    bollard!(bao1x_hal::sigcheck::die_no_std, 4);
+                                    println!("{}LOADER.SWAPDEV,{}", BOOKEND_START, BOOKEND_END);
+                                    println!("Developer key detected on swap. Proceeding in developer mode!");
+                                }
+                                let backup = bao1x_hal::buram::BackupManager::new();
+                                bollard!(bao1x_hal::sigcheck::die_no_std, 4);
+                                let owc = bao1x_hal::acram::OneWayCounter::new();
+                                if owc.get(bao1x_api::IN_SYSTEM_BOOT_SETUP_DONE).unwrap() != 0 {
+                                    let erase_proof: &[u8; 32] = backup
+                                        .get_slice(bao1x_hal::buram::ERASURE_PROOF_RANGE_BYTES)
+                                        .try_into()
+                                        .unwrap();
+                                    if erase_proof != &[ERASE_VALUE; 32] {
+                                        bao1x_hal::sigcheck::die_no_std();
+                                    }
+                                }
+                                bollard!(bao1x_hal::sigcheck::die_no_std, 4);
+                            }
                         }
-                        // TODO: encrypt the swap image to SWAP_KEY if PARANOID_MODE is set.
+                        Err(e) => {
+                            println!("{}LOADER.SWAPSIGFAIL,{}", BOOKEND_START, BOOKEND_END);
+                            println!("Fresh swap image did not pass public key validation: {:?}", e);
+                            bao1x_hal::sigcheck::die_no_std();
+                        }
                     }
                 }
                 Err(_) => {
                     // The fully-hardened system should be using a swap that is hardened to the swap key.
                     // The premise is that the blue team has control of the system when the swap is loaded,
                     // and thus the encryption step does not need to be hardened.
+
                     let slot_mgr = SlotManager::new();
                     let swap_key = slot_mgr.read(&SWAP_KEY).unwrap();
                     // replace the cipher with the new key
@@ -338,6 +340,10 @@ impl SwapHal {
                         println!("{}LOADER.SWAPDECFAIL,{}", BOOKEND_START, BOOKEND_END);
                         println!("Swap image failed cryptographic integrity checks!");
                         bao1x_hal::sigcheck::die_no_std();
+                    } else {
+                        println!(
+                            "*** Swap encrypted with AEAD by device key, signature check not required ***"
+                        );
                     }
                 }
             }

--- a/services/keystore/Cargo.toml
+++ b/services/keystore/Cargo.toml
@@ -62,6 +62,8 @@ byteorder = "1.4.3" # used by keywrap
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hkdf = "0.12.4"
 
+xous-swapper = { path = "../xous-swapper", optional = true } # contains spinor
+
 #[dependencies.curve25519-dalek]
 #version = "=4.1.2"                           # note this is patched to our fork in ./Cargo.toml
 #default-features = false
@@ -88,11 +90,20 @@ owc-inc = ["keystore-api/owc-inc"]
 # potential attack surface exposed by the keystore server.
 app-keys = ["keystore-api/app-keys"]
 
+# feature to enable backward compatibility with older units, before the swap slot switch happened
+# in like a year this flag could be deprecated, but also, it's coded with fairly safe assumptions
+# so it's...probably OK to just leave there?
+legacy-swap-key = []
+# used to track which targets have swap
+swap = ["xous-swapper/bao1x", "keystore-api/swap", "legacy-swap-key"]
+
 board-baosec = [
     "utralib/bao1x",
     "keystore-api/gen2",
     "bao1x-hal",
     "bao1x-hal-service/board-baosec",
+    "swap",
+    "xous-swapper/board-baosec",
     # "bao1x-hal/security",
 ] # USB form factor token
 loader-baosec = []
@@ -107,6 +118,8 @@ board-baosor = [
     "keystore-api/gen2",
     "modals/bao1x",
     "bao1x-hal-service/board-baosor",
+    "swap",
+    "xous-swapper/board-baosor",
 ] # Precursor form factor
 loader-baosor = []
 board-dabao = [

--- a/services/keystore/src/lib.rs
+++ b/services/keystore/src/lib.rs
@@ -407,6 +407,21 @@ impl Keystore {
             _ => Err(xous::Error::InternalError),
         }
     }
+
+    #[cfg(feature = "swap")]
+    pub fn ensure_swap_encryption(
+        &self,
+        status_server: &str,
+        op: usize,
+        token: [u32; 3],
+    ) -> Result<(), xous::Error> {
+        let call =
+            SwapEncryptCall { status_server: status_server.to_owned(), status_opcode: op as u32, token };
+        let buf = Buffer::into_buf(call).or(Err(xous::Error::InternalError))?;
+        buf.send(self.conn, Opcode::EnsureSwapEncryption.to_u32().unwrap())
+            .or(Err(xous::Error::InternalError))?;
+        Ok(())
+    }
 }
 
 use core::sync::atomic::{AtomicU32, Ordering};

--- a/services/keystore/src/platform/baosec/server.rs
+++ b/services/keystore/src/platform/baosec/server.rs
@@ -26,6 +26,9 @@ pub fn keystore(sid: SID) -> ! {
         log::info!("{}COLLATERAL.FAIL,{}", BOOKEND_START, BOOKEND_END);
     }
 
+    #[cfg(feature = "swap")]
+    let xns = xous_names::XousNames::new().unwrap();
+
     let mut msg_opt = None;
 
     // allow preemption once the keystore has claimed locks on all its critical resources
@@ -190,6 +193,41 @@ pub fn keystore(sid: SID) -> ! {
                         _ => app_key = AppKey::InternalError,
                     }
                     buffer.replace(app_key).unwrap();
+                }
+            }
+            #[cfg(feature = "swap")]
+            Opcode::EnsureSwapEncryption => {
+                if let Some(mem) = msg.body.memory_message() {
+                    let buffer = unsafe { Buffer::from_memory_message(mem) };
+                    let swap_call = buffer.to_original::<SwapEncryptCall, _>().unwrap();
+                    if let Ok(cid) = xns.request_connection_blocking(&swap_call.status_server) {
+                        #[cfg(feature = "legacy-swap-key")]
+                        let key = store.get_swap_key(&mut rram);
+                        #[cfg(not(feature = "legacy-swap-key"))]
+                        let key = store.get_swap_key();
+                        if !store.is_developer() {
+                            let _ = store
+                                .ensure_swap_encryption(cid, swap_call.status_opcode, swap_call.token, key)
+                                .inspect_err(|e| log::info!("Couldn't ensure swap encryption: {:?}", e));
+                        }
+                        // set completion to 100%
+                        xous::try_send_message(
+                            cid,
+                            xous::Message::new_scalar(
+                                swap_call.status_opcode as usize,
+                                100,
+                                swap_call.token[0] as usize,
+                                swap_call.token[1] as usize,
+                                swap_call.token[2] as usize,
+                            ),
+                        )
+                        .ok();
+                        log::info!("{}SWAP.ENCRYPTED,{}", BOOKEND_START, BOOKEND_END);
+                    } else {
+                        log::warn!(
+                            "Swap encryption check skipped because the caller provided an invalid server name for status feedback"
+                        );
+                    }
                 }
             }
             Opcode::InvalidCall => {

--- a/services/keystore/src/platform/baosec/store.rs
+++ b/services/keystore/src/platform/baosec/store.rs
@@ -1,10 +1,12 @@
 use aes::Aes256;
 use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit, generic_array::GenericArray};
+use aes_gcm_siv::{AeadInPlace, Aes256GcmSiv, Nonce, Tag};
 use bao1x_api::{
     BOOT0_PUBKEY_FAIL, BoardTypeCoding, BootWaitCoding, CP_ID, DEVELOPER_MODE, OEM_MODE,
-    SLOT_ELEMENT_LEN_BYTES, UUID,
+    SLOT_ELEMENT_LEN_BYTES, UUID, signatures::SWAP_VERSION, signatures::SwapSourceHeader,
 };
-use bao1x_hal::board::{BOOKEND_END, BOOKEND_START};
+use bao1x_hal::board::{BOOKEND_END, BOOKEND_START, SWAP_KEY};
+use bao1x_hal::udma::FLASH_SECTOR_LEN;
 use bao1x_hal::{
     acram::{OneWayCounter, SlotManager},
     board::{CHAFF_KEYS, COLLATERAL, NUISANCE_KEYS_0, NUISANCE_KEYS_1, ROOT_SEED, THE_FLAG_1},
@@ -14,6 +16,7 @@ use hkdf::Hkdf;
 use keystore_api::KeyWrapper;
 use rand::prelude::*;
 use sha2::Sha256;
+use xous::MemoryRange;
 
 use crate::*;
 
@@ -23,6 +26,7 @@ pub struct KeyStore {
     slot_mgr: SlotManager,
     pub owc: OneWayCounter,
     master_key: Option<[u8; KEY_LEN]>,
+    swap_range: MemoryRange,
 }
 
 impl KeyStore {
@@ -32,7 +36,24 @@ impl KeyStore {
         let owc = OneWayCounter::new();
         owc.register_mapping(rram);
 
-        Self { slot_mgr, owc, master_key: None }
+        let swap_range = xous::syscall::map_memory(
+            None,
+            // by requesting the offset into MMAP_VIRT_BASE, we (a) ensure the offset of the virtual
+            // pages maintain a 1:1 correspondence with the offsets in SPI flash and (b)
+            // by simply dereferencing any slices derived from virtual area we get a correct pointer
+            // that we can pass directly into the swapper to update the correct sector of memory.
+            xous::MemoryAddress::new(xous::arch::MMAP_VIRT_BASE),
+            bao1x_hal::board::SWAP_FLASH_RESERVED_LEN as usize,
+            xous::MemoryFlags::R | xous::MemoryFlags::VIRT,
+        )
+        .expect("Couldn't map the swap memory range");
+
+        Self { slot_mgr, owc, master_key: None, swap_range }
+    }
+
+    fn swap_slice(&self) -> &[u8] {
+        // safety: all values are representable in a u8
+        unsafe { self.swap_range.as_slice() }
     }
 
     fn system_init_inner(&mut self, rram: &mut Reram) {
@@ -387,6 +408,34 @@ impl KeyStore {
 
     pub fn is_developer(&self) -> bool { self.owc.get(bao1x_api::DEVELOPER_MODE).unwrap() != 0 }
 
+    #[cfg(not(feature = "legacy-swap-key"))]
+    pub(crate) fn get_swap_key(&self) -> [u8; 32] {
+        self.slot_mgr.read(&SWAP_KEY).expect("couldn't access swap key").try_into().unwrap()
+    }
+
+    #[cfg(feature = "legacy-swap-key")]
+    /// For legacy systems, the key isn't initialized on boot. If it's all 0, assume this is the case
+    /// and generate a fresh key.
+    pub(crate) fn get_swap_key(&self, rram: &mut Reram) -> [u8; 32] {
+        let key_slice = self.slot_mgr.read(&SWAP_KEY).expect("couldn't access swap key");
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&key_slice);
+        if key == [0u8; 32] {
+            let xns = xous_names::XousNames::new().unwrap();
+            let mut trng = bao1x_hal_service::trng::Trng::new(&xns).unwrap();
+            trng.fill_bytes(&mut key);
+            match self.slot_mgr.write(rram, &SWAP_KEY, &key) {
+                Err(e) => {
+                    log::warn!("{:?}: Couldn't initialize the swap key - swap will be insecure!", e);
+                }
+                _ => {}
+            };
+            key
+        } else {
+            key
+        }
+    }
+
     #[cfg(feature = "app-keys")]
     pub fn read_app_key(&self, index: usize) -> Result<[u8; 32], xous::Error> {
         use bao1x_api::common::APPLICATION;
@@ -434,5 +483,134 @@ impl KeyStore {
                 }
             }
         }
+    }
+
+    #[cfg(feature = "swap")]
+    fn get_swap_header(&self) -> Result<SwapSourceHeader, xous::Error> {
+        // safety: swap_range is aligned to 4096-byte boundary and filled with initialized data
+        // ... or so we hope! we have to validate these fields, as they are attacker-controlled.
+        // the alignment is at least true as we control that
+        let ssh: &SwapSourceHeader =
+            unsafe { (self.swap_range.as_ptr() as *const SwapSourceHeader).as_ref().unwrap() };
+
+        if ssh.version != SWAP_VERSION {
+            return Err(xous::Error::VerificationError);
+        }
+        Ok(ssh.clone())
+    }
+
+    /// Implements the encryption check & call. Requires a connection, opcode and token
+    /// so that it can provide regular status updates to a UI layer that is outside of
+    /// this crate.
+    #[cfg(feature = "swap")]
+    pub fn ensure_swap_encryption(
+        &mut self,
+        cid: xous::CID,
+        opcode: u32,
+        token: [u32; 3],
+        key: [u8; 32],
+    ) -> Result<(), xous::Error> {
+        use xous_swapper::FlashPage;
+        use zeroize::Zeroize;
+
+        const REPORT_INTERVAL: usize = 8;
+
+        let ssh = self.get_swap_header()?;
+        assert!(ssh.mac_offset & 0xFFF == 0, "MAC offset has improper alignment");
+        let image_mac_start = ssh.mac_offset as usize + 0x1000;
+        let mut current_mac_offset = image_mac_start;
+
+        let zero_cipher = Aes256GcmSiv::new((&[0u8; 32]).into());
+        let dest_cipher = Aes256GcmSiv::new(&key.into());
+
+        let mut page_buf = FlashPage::new();
+        let mut tags = Vec::<Tag>::new();
+        const MAX_TAGS: usize = FLASH_SECTOR_LEN as usize / size_of::<Tag>();
+
+        let swapper = xous_swapper::Swapper::new().unwrap();
+
+        // swap image starts at 0x1000 and continues until mac_offset.
+        // The offset of 0x1000 is currently a hard-coded constant. It's used in
+        // loader/src/platform/bao1x/swap.rs and also in tools/src/swap_writer.rs
+        for (i, offset) in (0x1000..ssh.mac_offset as usize + 0x1000).step_by(FLASH_SECTOR_LEN).enumerate() {
+            let ciphertext = &self.swap_slice()[offset..offset + FLASH_SECTOR_LEN];
+            page_buf.data.copy_from_slice(ciphertext);
+            let mut nonce = [0u8; size_of::<Nonce>()];
+            nonce[..4].copy_from_slice(&(offset as u32 - 0x1000).to_be_bytes());
+            nonce[4..].copy_from_slice(&ssh.partial_nonce);
+            let mut aad_buf = [0u8; 64];
+            aad_buf[..ssh.aad_len as usize].copy_from_slice(&ssh.aad[..ssh.aad_len as usize]);
+            let aad = &aad_buf[..ssh.aad_len as usize];
+            let tag_loc = image_mac_start + ((offset - 0x1000) / 0x1000) * size_of::<Tag>();
+            let tag = &self.swap_slice()[tag_loc..tag_loc + size_of::<Tag>()];
+            let nonce = Nonce::from_slice(&nonce);
+            // log::info!("aad: {:x?}", &aad);
+            // log::info!("nonce: {:x?}", &nonce);
+            // log::info!("tag: {:x?}", &tag);
+            // log::info!("data: {:x?}...{:x?}", &page_buf.data[..16], &page_buf.data[4080..]);
+            if zero_cipher.decrypt_in_place_detached(nonce, &aad, &mut page_buf.data, tag.into()).is_err() {
+                log::debug!("zero cipher fail");
+                if offset == 0x1000 {
+                    // if we have an error on the first block, it might be that we're already encrypted
+                    if dest_cipher
+                        .decrypt_in_place_detached(nonce, &aad, &mut page_buf.data, tag.into())
+                        .is_ok()
+                    {
+                        // we're already encrypted - nothing to do
+                        return Ok(());
+                    }
+                }
+                log::debug!("didn't succeed fallback verification");
+                // just bail if we can't get the data - even if we're halfway through...
+                return Err(xous::Error::VerificationError);
+            }
+            // now page_buf has our data - let's encrypt to the new key
+            let new_tag = dest_cipher
+                .encrypt_in_place_detached(nonce, &aad, &mut page_buf.data)
+                .expect("couldn't encrypt to new key");
+            tags.push(new_tag);
+
+            // commit the page buf
+            swapper.write_page(offset, &page_buf)?;
+
+            // check and see if we need to commit tags
+            if tags.len() == MAX_TAGS {
+                // we have enough tags to write over a full page of tags - since we are going in linear
+                // order through memory, it's safe to replace a page of tags after we've read and encrypted
+                // the last page of tags.
+                page_buf.data.zeroize();
+                for (tag, chunk) in tags.iter().zip(page_buf.data.chunks_exact_mut(size_of::<Tag>())) {
+                    chunk.copy_from_slice(&tag[..]);
+                }
+                swapper.write_page(current_mac_offset, &page_buf)?;
+                current_mac_offset += FLASH_SECTOR_LEN;
+                tags.clear();
+            }
+
+            // report status to the caller - %age completion. This is a slow operation and users
+            // are impatient.
+            if i % REPORT_INTERVAL == 0 {
+                let percentage = (100 * i) / (ssh.mac_offset as usize / FLASH_SECTOR_LEN);
+                xous::try_send_message(
+                    cid,
+                    xous::Message::new_scalar(
+                        opcode as usize,
+                        percentage,
+                        token[0] as usize,
+                        token[1] as usize,
+                        token[2] as usize,
+                    ),
+                )
+                .ok();
+            }
+        }
+        // the final page may not have filled up the whole tag buffer. clear the remaining tags
+        page_buf.data.zeroize();
+        for (tag, chunk) in tags.iter().zip(page_buf.data.chunks_exact_mut(size_of::<Tag>())) {
+            chunk.copy_from_slice(&tag[..]);
+        }
+        swapper.write_page(current_mac_offset, &page_buf)?;
+
+        Ok(())
     }
 }

--- a/services/keystore/src/platform/baosec/store.rs
+++ b/services/keystore/src/platform/baosec/store.rs
@@ -1,11 +1,17 @@
 use aes::Aes256;
 use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit, generic_array::GenericArray};
+#[cfg(feature = "swap")]
 use aes_gcm_siv::{AeadInPlace, Aes256GcmSiv, Nonce, Tag};
 use bao1x_api::{
     BOOT0_PUBKEY_FAIL, BoardTypeCoding, BootWaitCoding, CP_ID, DEVELOPER_MODE, OEM_MODE,
-    SLOT_ELEMENT_LEN_BYTES, UUID, signatures::SWAP_VERSION, signatures::SwapSourceHeader,
+    SLOT_ELEMENT_LEN_BYTES, UUID,
 };
-use bao1x_hal::board::{BOOKEND_END, BOOKEND_START, SWAP_KEY};
+#[cfg(feature = "swap")]
+use bao1x_api::{signatures::SWAP_VERSION, signatures::SwapSourceHeader};
+#[cfg(feature = "swap")]
+use bao1x_hal::board::SWAP_KEY;
+use bao1x_hal::board::{BOOKEND_END, BOOKEND_START};
+#[cfg(feature = "swap")]
 use bao1x_hal::udma::FLASH_SECTOR_LEN;
 use bao1x_hal::{
     acram::{OneWayCounter, SlotManager},
@@ -16,6 +22,7 @@ use hkdf::Hkdf;
 use keystore_api::KeyWrapper;
 use rand::prelude::*;
 use sha2::Sha256;
+#[cfg(feature = "swap")]
 use xous::MemoryRange;
 
 use crate::*;
@@ -26,6 +33,7 @@ pub struct KeyStore {
     slot_mgr: SlotManager,
     pub owc: OneWayCounter,
     master_key: Option<[u8; KEY_LEN]>,
+    #[cfg(feature = "swap")]
     swap_range: MemoryRange,
 }
 
@@ -36,6 +44,7 @@ impl KeyStore {
         let owc = OneWayCounter::new();
         owc.register_mapping(rram);
 
+        #[cfg(feature = "swap")]
         let swap_range = xous::syscall::map_memory(
             None,
             // by requesting the offset into MMAP_VIRT_BASE, we (a) ensure the offset of the virtual
@@ -48,9 +57,15 @@ impl KeyStore {
         )
         .expect("Couldn't map the swap memory range");
 
-        Self { slot_mgr, owc, master_key: None, swap_range }
+        #[cfg(not(feature = "swap"))]
+        let ret = Self { slot_mgr, owc, master_key: None };
+        #[cfg(feature = "swap")]
+        let ret = Self { slot_mgr, owc, master_key: None, swap_range };
+
+        ret
     }
 
+    #[cfg(feature = "swap")]
     fn swap_slice(&self) -> &[u8] {
         // safety: all values are representable in a u8
         unsafe { self.swap_range.as_slice() }
@@ -408,7 +423,7 @@ impl KeyStore {
 
     pub fn is_developer(&self) -> bool { self.owc.get(bao1x_api::DEVELOPER_MODE).unwrap() != 0 }
 
-    #[cfg(not(feature = "legacy-swap-key"))]
+    #[cfg(all(not(feature = "legacy-swap-key"), feature = "swap"))]
     pub(crate) fn get_swap_key(&self) -> [u8; 32] {
         self.slot_mgr.read(&SWAP_KEY).expect("couldn't access swap key").try_into().unwrap()
     }

--- a/signing/fido-signer/Cargo.lock
+++ b/signing/fido-signer/Cargo.lock
@@ -122,7 +122,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bao1x-api"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "arbitrary-int",
  "bitbybit",

--- a/signing/fido-signer/src/main.rs
+++ b/signing/fido-signer/src/main.rs
@@ -6,7 +6,8 @@
 //! tool replaces those signatures in place with production ones. It never
 //! changes the size or layout of the image, so the input and output are
 //! byte-for-byte identical apart from the signature fields (plus the toolchain
-//! hash, if `--baobit-hash` is given).
+//! hash, if `--baobit-hash` is given) - the one exception being `--strip-pq`,
+//! which deliberately reverts an image to the smaller legacy layout.
 //!
 //! The two signatures are independent. Supply `-c` to replace the ed25519
 //! signature, `--pq-key` to replace the SLH-DSA signature, or both to do the
@@ -14,7 +15,8 @@
 //! an air-gapped signing host never has to shuttle intermediate files around.
 //! The ed25519 private key stays on the FIDO2 token; the SLH-DSA private key
 //! lives on the signing host itself (it has to - the tree build is far too slow
-//! to push through a token). At least one of the two must be given.
+//! to push through a token). At least one of `-c`, `--pq-key`, or `--strip-pq`
+//! must be given.
 //!
 //! # Usage
 //!
@@ -32,15 +34,22 @@
 //!       signature is left untouched, so this is a half-signed image until the
 //!       `-c` pass runs.
 //!
+//!   fido-signer -c <cred.json> -f <image.bin> --strip-pq
+//!       Turn a PQ image back into a legacy (pre-PQ) image and re-sign it with
+//!       ed25519. Clears the PQ fields, drops the SLH-DSA tail, and produces a
+//!       smaller file that exercises the pre-PQ verify path on an old bootloader
+//!       and is treated as a plain ed25519 image by a new one.
+//!
 //!   fido-signer -c <cred.json> -m <base64>
 //!       Sign a raw base64 message with the token. Testing aid; requires `-c`,
-//!       and `--pq-key` is not accepted, since there is no image header to patch.
+//!       and `--pq-key` / `--strip-pq` are not accepted, since there is no image
+//!       header to patch.
 //!
 //! Splitting the work across two invocations is safe in either order: the
 //! ed25519 pass writes only the unsigned prefix of the record, and the SLH-DSA
 //! pass writes only the tail past `sealed_data_end()`. Neither is inside the
-//! region the other one signs. `--baobit-hash`, however, is not order-free - see
-//! below.
+//! region the other one signs. `--baobit-hash` and `--strip-pq`, however, both
+//! edit the signed `sealed_data` and so are not order-free - see below.
 //!
 //! Useful flags:
 //!   -b/--baobit-hash <hex20>  Inject the toolchain hash into `sealed_data`
@@ -48,12 +57,35 @@
 //!                             any signature applied before the injection is
 //!                             invalidated by it. Use it on the first pass, or
 //!                             on a single combined pass.
+//!   --strip-pq                Remove the PQ signature fields entirely and drop
+//!                             the SLH-DSA tail, producing a legacy image. Edits
+//!                             the signed region, so it requires a following (or
+//!                             same-run) `-c` pass. Mutually exclusive with
+//!                             `--pq-key`.
 //!   -p/--function-code <code> Override the function code read out of the image.
 //!                             Rarely needed; see below.
 //!   --no-uf2                  Suppress the .uf2 output.
 //!   --pq-force                Sign even if the PQ public key is not listed in
 //!                             the image's own `pubkeys_pq` slots. Only useful
 //!                             for bring-up; such an image will not boot.
+//!
+//! # What --strip-pq clears
+//!
+//! A genuine pre-PQ image ends its meaningful `sealed_data` at `toolchain`;
+//! everything after it is zero-padding from the old generator. `--strip-pq`
+//! reproduces that by zeroing all three of the PQ-era fields:
+//!
+//!   - `pq_enabled`        what makes a modern verifier attempt a PQ check at all;
+//!   - `pubkeys_pq`        the committed PQ public keys;
+//!   - `corrected_version` the marker a modern verifier reads as "legacy record" (a value of 0 selects the
+//!     legacy compatibility path).
+//!
+//! and then truncates the trailing `SignaturePqInFlash`. Clearing
+//! `corrected_version` is what makes this a *legacy* image rather than a
+//! *modern non-PQ* image; drop that one field from the strip if you want the
+//! latter. A pre-PQ bootloader reads none of these three, so it accepts the
+//! result on the strength of the ed25519 signature alone; a modern bootloader
+//! sees a legacy record with no PQ signature and verifies ed25519 only.
 //!
 //! # Function code and the .uf2
 //!
@@ -77,18 +109,20 @@
 //! 1. Locate the signature record and recover the function code from it.
 //! 2. Patch the toolchain hash, if given. It lives inside `sealed_data`, so it must be final before anything
 //!    is hashed.
-//! 3. Run every PQ preflight check - key loads, cache matches the key, the image has `pq_enabled` set, the
+//! 3. Strip the PQ fields, if `--strip-pq`. Also edits `sealed_data` and drops the tail, so it too must
+//!    happen before hashing.
+//! 4. Run every PQ preflight check - key loads, cache matches the key, the image has `pq_enabled` set, the
 //!    image reserves a signature slot of the right size, and the key's public key is one of the four
 //!    committed in the header. All of this happens *before* the token is touched, so a mismatched key never
 //!    costs an operator a wasted user-presence gesture.
-//! 4. ed25519, if `-c`: hash the sealed region, get the assertion (touch the token), patch `signature` /
+//! 5. ed25519, if `-c`: hash the sealed region, get the assertion (touch the token), patch `signature` /
 //!    `aad` / `aad_len`.
-//! 5. SLH-DSA, if `--pq-key`: hash the same region with SHA-256, sign the digest, write the signature at
+//! 6. SLH-DSA, if `--pq-key`: hash the same region with SHA-256, sign the digest, write the signature at
 //!    `sealed_data_end()`. This is the long, unattended step, so it deliberately runs after the operator's
 //!    touch rather than before it.
-//! 6. Read the file back and verify the PQ signature against the public key committed in the image's own
+//! 7. Read the file back and verify the PQ signature against the public key committed in the image's own
 //!    header - the same computation the boot verifier performs.
-//! 7. Emit the .uf2 for the function code from step 1.
+//! 8. Emit the .uf2 for the function code from step 1.
 //!
 //! # What is covered by what
 //!
@@ -96,7 +130,7 @@
 //! for `swap`, whose metadata header precedes the signature block):
 //!
 //!   [0, sealed_data_offset())          jal || ed25519 sig || aad_len || aad.
-//!                                      Unsigned; this is what step 4 patches.
+//!                                      Unsigned; this is what step 5 patches.
 //!   [sealed_data_offset(),             `protected` = sealed_data || zero pad
 //!    sealed_data_end())                || payload. Covered by BOTH signatures.
 //!                                      `sealed_data_end()` is
@@ -193,6 +227,14 @@ struct Args {
     #[arg(short = 'b', long = "baobit-hash", value_name = "HASH")]
     baobit_hash: Option<String>,
 
+    /// Remove the PQ signature fields entirely, producing a legacy (pre-PQ)
+    /// image: clears `corrected_version`, `pq_enabled`, and `pubkeys_pq` in
+    /// `sealed_data` and drops the trailing SLH-DSA signature. Edits the signed
+    /// region, so an ed25519 re-sign (`-c`) must follow (ideally in the same
+    /// run). Mutually exclusive with `--pq-key`.
+    #[arg(long = "strip-pq", conflicts_with_all = ["message", "pq_key"])]
+    strip_pq: bool,
+
     /// SLH-DSA (post-quantum) secret key, raw 4*n bytes as emitted by
     /// `xous-pq-sign-image keygen`. When present, the image's PQ signature is
     /// replaced. May be used with or without `-c`.
@@ -286,17 +328,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse command line arguments
     let args = Args::parse();
 
-    // The two signature passes are independent, but doing neither is always a
+    // Each of the three passes is optional, but doing none of them is always a
     // mistake rather than a no-op worth honouring silently.
-    if args.credential_file.is_none() && args.pq_key.is_none() {
+    if args.credential_file.is_none() && args.pq_key.is_none() && !args.strip_pq {
         return Err(String::from(
             "Nothing to do: supply -c <cred.json> to replace the ed25519 signature, \
-             --pq-key <key> to replace the SLH-DSA signature, or both.",
+             --pq-key <key> to replace the SLH-DSA signature, --strip-pq to make a legacy image, \
+             or a combination.",
         )
         .into());
     }
-    // There is no PQ path for a raw message: the PQ signature only exists as a
-    // field inside an image header.
+    // There is no PQ path (add or strip) for a raw message: the PQ fields only
+    // exist inside an image header. clap already excludes --pq-key/--strip-pq
+    // from --message; this covers the remaining -c-less message case.
     if args.message.is_some() && args.credential_file.is_none() {
         return Err(String::from("--message requires -c <cred.json>").into());
     }
@@ -317,12 +361,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    // Injecting the toolchain hash mutates `sealed_data`, which both signatures
-    // cover. Doing that without re-applying ed25519 in the same run leaves the
-    // ed25519 signature stale until a later `-c` pass fixes it.
+    // Both --baobit-hash and --strip-pq mutate `sealed_data`, which the ed25519
+    // signature covers. Doing either without re-applying ed25519 in the same run
+    // leaves that signature stale until a later `-c` pass fixes it.
     if baobit_hash.is_some() && credential.is_none() {
         println!(
             "WARNING: --baobit-hash without -c invalidates the image's existing ed25519 \
+             signature.\n         An ed25519 pass must follow before this image will boot."
+        );
+    }
+    if args.strip_pq && credential.is_none() {
+        println!(
+            "WARNING: --strip-pq without -c invalidates the image's existing ed25519 \
              signature.\n         An ed25519 pass must follow before this image will boot."
         );
     }
@@ -361,11 +411,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             if let Some(toolchain) = baobit_hash {
                 patch_hash_in_file(&file_path, &toolchain, offset)?;
             }
+
+            // strip the PQ fields here, if requested. Like the baobit patch this
+            // edits `sealed_data`, and it also truncates the tail, so it must
+            // land before the sealed region is hashed below.
+            if args.strip_pq {
+                println!("\nStripping PQ fields to produce a legacy image...");
+                strip_pq_from_file(&file_path, offset)?;
+            }
+
             // Re-read the file so we hash the patched contents
             let file = fs::read(&file_path)
                 .map_err(|e| format!("Failed to re-read file '{}': {}", file_path.display(), e))?;
 
-            // Re-parse the header: the toolchain patch above changed `sealed_data`.
+            // Re-parse the header: the patches above changed `sealed_data`.
             let mut sig = SignatureInFlash::default();
             sig.as_mut().copy_from_slice(&file[offset..offset + size_of::<SignatureInFlash>()]);
 
@@ -403,7 +462,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 sealed_end - sealed_start
             );
             println!("  file is {} bytes ({} bytes of tail)", file.len(), file.len() - sealed_end);
-            println!("  pq_enabled: {:#010x}", sig.sealed_data.pq_enabled);
+            println!(
+                "  corrected_version: {:#010x}  pq_enabled: {:#010x}",
+                sig.sealed_data.corrected_version, sig.sealed_data.pq_enabled
+            );
 
             // A `swap` image is the only one whose record is displaced. If the
             // embedded code and the offset the record was found at disagree,
@@ -462,7 +524,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
 
             // Everything that can fail about the PQ side is checked here, before
-            // the operator is asked to touch the token.
+            // the operator is asked to touch the token. (--strip-pq and --pq-key
+            // are mutually exclusive, so this never runs on a stripped image.)
             if let Some(ref pq_key_path) = args.pq_key {
                 pq_ctx = Some(pq_preflight(
                     pq_key_path,
@@ -482,12 +545,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 data_to_sign = Some(h.finalize().as_slice().to_vec());
             }
         } else {
-            // Not a bao1x image: there is no header, so no PQ slot to patch and
-            // nothing to do but sign the raw bytes with the token.
+            // Not a bao1x image: there is no header, so no PQ slot to patch, no
+            // PQ fields to strip, and nothing to do but sign the raw bytes.
             if args.pq_key.is_some() {
                 return Err(format!(
                     "'{}' is not a signed bao1x image (no magic number at offset 0 or {}); \
                      there is no PQ signature slot to patch",
+                    file_path.display(),
+                    SWAP_SIG_OFFSET
+                )
+                .into());
+            }
+            if args.strip_pq {
+                return Err(format!(
+                    "'{}' is not a signed bao1x image (no magic number at offset 0 or {}); \
+                     there are no PQ fields to strip",
                     file_path.display(),
                     SWAP_SIG_OFFSET
                 )
@@ -556,7 +628,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             // The function code came from the image unless `-p` overrode it, so
             // the .uf2 is emitted without the operator having to name the
-            // partition.
+            // partition. If --strip-pq truncated the tail, the file is already
+            // shorter here, so the .uf2 excludes the removed signature too.
             if !args.no_uf2 {
                 if let Some(ref function_code) = uf2_function_code {
                     let output = file_path.with_extension("uf2");
@@ -597,6 +670,69 @@ fn sign_ed25519_hash(
         }
         Err(e) => Err(e.try_into().unwrap()),
     }
+}
+
+// ----- legacy conversion (--strip-pq) ---------------------------------------
+
+/// Zero the PQ-era fields inside `sealed_data` and drop the trailing SLH-DSA
+/// signature, turning a PQ image back into a faithful legacy (pre-PQ) image.
+///
+/// Clears `corrected_version`, `pq_enabled`, and `pubkeys_pq` - exactly the
+/// region the pre-PQ generator left as zero-padding - and truncates the
+/// `SignaturePqInFlash` tail. Everything touched is inside the ed25519-signed
+/// region (or changes the file length), so the caller MUST re-apply the ed25519
+/// signature afterwards or the image will not boot.
+///
+/// Returns the number of tail bytes removed.
+fn strip_pq_from_file(file_path: &PathBuf, offset: usize) -> Result<usize, Box<dyn std::error::Error>> {
+    let mut file = OpenOptions::new().read(true).write(true).open(file_path)?;
+    let mut header = read_header_from_file(&mut file, offset)?;
+
+    let was_corrected = header.sealed_data.corrected_version;
+    let was_enabled = header.sealed_data.pq_enabled;
+
+    header.sealed_data.corrected_version = 0;
+    header.sealed_data.pq_enabled = 0;
+    for pk in header.sealed_data.pubkeys_pq.iter_mut() {
+        *pk = Default::default();
+    }
+
+    write_header_to_file(&mut file, &header, offset)?;
+
+    // Drop the PQ signature tail, if present. `sealed_data_end()` is where the
+    // signed region ends and the tail begins; only a lone, correctly-sized PQ
+    // signature is removed - anything else is left alone and flagged, since we
+    // can't tell what it is.
+    let sealed_end = (offset + header.sealed_data_end()) as u64;
+    let file_len = file.seek(SeekFrom::End(0))?;
+    let tail = file_len.saturating_sub(sealed_end);
+
+    let removed = if tail == 0 {
+        0
+    } else if tail as usize == SIGNATURE_PQ_LENGTH {
+        file.set_len(sealed_end)?;
+        SIGNATURE_PQ_LENGTH
+    } else {
+        println!(
+            "  WARNING: {} trailing bytes after the signed region is not a {}-byte PQ signature; \
+             leaving the tail in place",
+            tail, SIGNATURE_PQ_LENGTH
+        );
+        0
+    };
+    file.flush()?;
+
+    println!(
+        "  cleared corrected_version ({:#010x} -> 0), pq_enabled ({:#010x} -> 0), pubkeys_pq",
+        was_corrected, was_enabled
+    );
+    if removed > 0 {
+        println!("  removed {}-byte PQ signature tail (file now {} bytes)", removed, sealed_end);
+    } else {
+        println!("  no PQ signature tail to remove");
+    }
+
+    Ok(removed)
 }
 
 // ----- post-quantum (SLH-DSA) signing ---------------------------------------

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = "1.0"
 # size of the signature block or offsets in RRAM are changed, so that it can be
 # absorbed into this package.
 # bao1x-api = { path = "../libs/bao1x-api" }
-bao1x-api = "0.1.2" # use crates.io to refer to this
+bao1x-api = "0.1.3" # use crates.io to refer to this
 
 slh-dsa = { path = "../bao1x-boot/slh-dsa-bao1x", features = [
     "parallel",

--- a/tools/src/swap_writer.rs
+++ b/tools/src/swap_writer.rs
@@ -8,11 +8,9 @@ use aes_gcm_siv::{
     Aes256GcmSiv, Nonce,
     aead::{Aead, KeyInit, Payload},
 };
-use bao1x_api::signatures::SwapSourceHeader;
+use bao1x_api::signatures::{SWAP_VERSION, SwapSourceHeader};
 
 use crate::sign_image::{Version, sign_image};
-
-const SWAP_VERSION: u32 = 0x01_01_0000;
 
 pub fn git_rev(override_rev: Option<&str>) -> u64 {
     let hash = if let Some(rev) = override_rev {
@@ -143,13 +141,14 @@ impl SwapWriter {
             nonce_vec.extend_from_slice(&((offset as u32) * 0x1000).to_be_bytes());
             nonce_vec.extend_from_slice(&header.partial_nonce.to_be_bytes());
             let nonce = Nonce::from_slice(&nonce_vec);
+            // println!("pt: {:x?}", &padded_block[..32]);
             // println!("nonce: {:x?}", nonce);
             // println!("aad: {:x?}", header.aad);
             let enc = cipher
                 .encrypt(nonce, Payload { aad: &header.aad, msg: &padded_block })
                 .expect("couldn't encrypt block");
             assert!(enc.len() == 0x1010);
-            // println!("data: {:x?}", &enc[..32]);
+            // println!("ct: {:x?}", &enc[..32]);
             // println!("tag: {:x?}", &enc[0x1000..]);
             image.write(&enc[..0x1000])?;
             macs.extend_from_slice(&enc[0x1000..]);


### PR DESCRIPTION
This resolves a very, very long standing to-do that created a significant TOCTOU window on devices with swap.

After this patch, after the first boot of the device into run mode, swap is encrypted to a per-device-unique swap key which is slightly less hardened than your typical key but still protected. The "less hardening" is necessary because the swap key needs to be readable in the loader, which exists in this no-man's land between the hardened boot and the safety of the virtual memory environment of the kernel. An attacker with an ability to coerce the loader into running arbitrary code could compromise the swap key (whereas all the other keys are not coerceable). 
