### PR TITLE
Prevent hardening being optimised away

### DIFF
--- a/bao1x-boot/boot1/src/repl.rs
+++ b/bao1x-boot/boot1/src/repl.rs
@@ -861,7 +861,7 @@ impl Repl {
                 for (i, chunk) in ifr.chunks(32).enumerate() {
                     // these "redundant" asserts make it harder to abuse this print as a memory dumping
                     // primitive, e.g. by glitching or other similar attack
-                    assert!(ifr.as_ptr() as usize == 0x6040_0000);
+                    assert!(core::hint::black_box(ifr.as_ptr()) as usize == 0x6040_0000);
                     crate::println!("  {:03x}: {:02x?}", i * 32, chunk);
                     assert!(i < 32);
                 }


### PR DESCRIPTION
The optimiser is too clever, so the assert statement hardening added in 0f5d22c1510a ("harden a print statement")
gets optimised away in release builds. Adding black_box() prevents that.

black_box is documented as "best effort" with no guarantees, but this is an improvement.

Original disassembly :
(objdump -dSl with debug=true in Cargo.toml profile.release) 
```
; /xous-core/bao1x-boot/boot1/src/repl.rs:861
;                 for (i, chunk) in ifr.chunks(32).enumerate() {
6002a1fe: 017c2023     	sw	s7, 0x0(s8)
6002a202: 009c2223     	sw	s1, 0x4(s8)
; /xous-core/bao1x-boot/boot1/src/repl.rs:865
;                     crate::println!("  {:03x}: {:02x?}", i * 32, chunk);
6002a206: 208c2423     	sw	s0, 0x208(s8)
; /xous-core/bao1x-boot/boot1/src/platform/bao1x/debug.rs:93
;                 let _ = write!(crate::debug::Uart {}, $($args)+);
6002a20a: 6505         	lui	a0, 0x1
```

After this change:
```
;                 for (i, chunk) in ifr.chunks(32).enumerate() {
6002a202: 019c2023     	sw	s9, 0x0(s8)
6002a206: 00ac2223     	sw	a0, 0x4(s8)
; src/rust/library/core/src/hint.rs:491
;     crate::intrinsics::black_box(dummy)
6002a20a: c2a6         	sw	s1, 0x44(sp)
6002a20c: 00cc         	addi	a1, sp, 0x44
6002a20e: 4596         	lw	a1, 0x44(sp)
; [Branch to panic]
6002a210: 6c9593e3     	bne	a1, s1, 0x6002b0d6 <<bao1x_boot1[75dd45bcca5ca846]::repl::Repl>::process+0x1bfc>
; src/rust/library/core/src/slice/mod.rs:2054
;         unsafe { (from_raw_parts(ptr, mid), from_raw_parts(ptr.add(mid), unchecked_sub(len, mid))) }
6002a214: 40ab8bb3     	sub	s7, s7, a0
; src/rust/library/core/src/ptr/const_ptr.rs:863
;         unsafe { intrinsics::offset(self, count) }
6002a218: 9caa         	add	s9, s9, a0
; /xous-core/bao1x-boot/boot1/src/repl.rs:865
;                     crate::println!("  {:03x}: {:02x?}", i * 32, chunk);
6002a21a: 208c2423     	sw	s0, 0x208(s8)
; /xous-core/bao1x-boot/boot1/src/platform/bao1x/debug.rs:93
;                 let _ = write!(crate::debug::Uart {}, $($args)+);
6002a21e: 6505         	lui	a0, 0x1
```