### PR TITLE
usb: defer RUN_STOP pullup until the core is armed and SE0 released

### DIFF
--- a/bao1x-boot/boot1/src/main.rs
+++ b/bao1x-boot/boot1/src/main.rs
@@ -235,16 +235,20 @@ pub unsafe extern "C" fn rust_entry() -> ! {
     }
 
     delay(250);
-    // setup the USB port
-    let (mut last_usb_state, mut portsc) = match one_way.get_decoded::<UsbDefaultSpeed>() {
+    // Arm the USB core while the port is still held in SE0 (RUN_STOP stays de-asserted here).
+    let _ = match one_way.get_decoded::<UsbDefaultSpeed>() {
         Ok(UsbDefaultSpeed::Full) => glue::setup(Some(PortSpeed::Fs)),
         _ => glue::setup(Some(PortSpeed::Hs)),
     };
-    delay(150);
 
-    // release SE0
+    // release SE0 so the bus returns to a clean idle before we assert the pullup
     iox.set_gpio_pin(se0_baosec.0, se0_baosec.1, bao1x_api::IoxValue::High);
     iox.set_gpio_pin(se0_dabao.0, se0_dabao.1, bao1x_api::IoxValue::High);
+    delay(150); // let the bus settle to disconnected-idle before presenting the device
+
+    // Assert the pullup (RUN_STOP) as the final bring-up step. The running core's first observed
+    // bus reset is now the host's genuine reset, so high-speed chirp can complete.
+    let (mut last_usb_state, mut portsc) = glue::connect();
     // return the pin to an input
     match board_type {
         BoardTypeCoding::Dabao | BoardTypeCoding::Oem => {

--- a/bao1x-boot/boot1/src/platform/bao1x/usb/glue.rs
+++ b/bao1x-boot/boot1/src/platform/bao1x/usb/glue.rs
@@ -128,15 +128,40 @@ pub fn setup(speed: Option<bao1x_hal::usb::driver::PortSpeed>) -> (UsbDeviceStat
             let usb = &mut *core::ptr::addr_of_mut!(*usb_ref);
             usb.reset();
             usb.init(speed);
+            // Arm the event ring, interrupter and EP0, but do NOT assert the pullup (RUN_STOP)
+            // here: it is deferred to `connect()`, which the caller invokes only after the
+            // external SE0 port mask has been released.
             usb.start();
-            usb.update_current_speed();
-            // IRQ enable must happen without dependency on the hardware lock
+            // IRQ enable must happen without dependency on the hardware lock, and must be armed
+            // before the pullup is asserted.
             usb.irq_csr.wo(utralib::utra::irqarray1::EV_PENDING, 0xffff_ffff); // blanket clear
             usb.irq_csr.wfo(utralib::utra::irqarray1::EV_ENABLE_USBC_DUPE, 1);
 
             let last_usb_state = usb.get_device_state();
             let portsc = usb.portsc_val();
-            crate::println_d!("USB state: {:?}, {:x}", last_usb_state, portsc);
+            crate::println_d!("USB armed (pullup deferred): {:?}, {:x}", last_usb_state, portsc);
+            (last_usb_state, portsc)
+        } else {
+            panic!("USB core not allocated, can't proceed!");
+        }
+    }
+}
+
+/// Assert the upstream pullup (RUN_STOP) — the final USB bring-up step.
+///
+/// Must be called *after* [`setup`] and after the external SE0 port mask has been released (and
+/// the bus given a moment to settle). Deferring RUN_STOP to this point lets the first bus reset
+/// the running core observes be the host's genuine reset, so high-speed chirp can complete
+/// instead of collapsing to full-speed.
+pub fn connect() -> (UsbDeviceState, u32) {
+    unsafe {
+        if let Some(ref mut usb_ref) = crate::platform::bao1x::usb::USB {
+            let usb = &mut *core::ptr::addr_of_mut!(*usb_ref);
+            usb.pullup(true);
+            usb.update_current_speed();
+            let last_usb_state = usb.get_device_state();
+            let portsc = usb.portsc_val();
+            crate::println_d!("USB pullup asserted: {:?}, {:x}", last_usb_state, portsc);
             (last_usb_state, portsc)
         } else {
             panic!("USB core not allocated, can't proceed!");

--- a/bao1x-boot/boot1/src/repl.rs
+++ b/bao1x-boot/boot1/src/repl.rs
@@ -1073,6 +1073,8 @@ impl Repl {
                 iox.set_gpio_pin_value(bao1x_api::IoxPort::PF, 5, bao1x_api::IoxValue::Low);
                 // force USB speed to full speed
                 crate::glue::setup(Some(bao1x_hal::usb::driver::PortSpeed::Fs));
+                // SE0 is already released at this point, so assert the pullup immediately.
+                crate::glue::connect();
 
                 let slot_mgr = bao1x_hal::acram::SlotManager::new();
                 let mut rram = bao1x_hal::rram::Reram::new();

--- a/baremetal/src/platform/bao1x/usb/glue.rs
+++ b/baremetal/src/platform/bao1x/usb/glue.rs
@@ -23,15 +23,35 @@ pub fn setup() -> (UsbDeviceState, u32) {
             let usb = &mut *core::ptr::addr_of_mut!(*usb_ref);
             usb.reset();
             usb.init(None);
+            // Arm the event ring, interrupter and EP0, but defer the pullup (RUN_STOP) to
+            // `connect()`, which is called only after the external SE0 mask has been released.
             usb.start();
-            usb.update_current_speed();
-            // IRQ enable must happen without dependency on the hardware lock
+            // IRQ enable must happen without dependency on the hardware lock, and before the pullup.
             usb.irq_csr.wo(utralib::utra::irqarray1::EV_PENDING, 0xffff_ffff); // blanket clear
             usb.irq_csr.wfo(utralib::utra::irqarray1::EV_ENABLE_USBC_DUPE, 1);
 
             let last_usb_state = usb.get_device_state();
             let portsc = usb.portsc_val();
-            crate::println_d!("USB state: {:?}, {:x}", last_usb_state, portsc);
+            crate::println_d!("USB armed (pullup deferred): {:?}, {:x}", last_usb_state, portsc);
+            (last_usb_state, portsc)
+        } else {
+            panic!("USB core not allocated, can't proceed!");
+        }
+    }
+}
+
+/// Assert the upstream pullup (RUN_STOP) — the final USB bring-up step. Call after [`setup`] and
+/// after the external SE0 port mask has been released, so the running core's first observed bus
+/// reset is the host's genuine reset and high-speed chirp can complete.
+pub fn connect() -> (UsbDeviceState, u32) {
+    unsafe {
+        if let Some(ref mut usb_ref) = crate::platform::bao1x::usb::USB {
+            let usb = &mut *core::ptr::addr_of_mut!(*usb_ref);
+            usb.pullup(true);
+            usb.update_current_speed();
+            let last_usb_state = usb.get_device_state();
+            let portsc = usb.portsc_val();
+            crate::println_d!("USB pullup asserted: {:?}, {:x}", last_usb_state, portsc);
             (last_usb_state, portsc)
         } else {
             panic!("USB core not allocated, can't proceed!");
@@ -65,11 +85,14 @@ pub fn hotplug_usb<T: IoSetup + IoGpio>(iox: &T) -> (UsbDeviceState, u32) {
     let (se0_port, se0_pin) = bao1x_hal::board::setup_usb_pins(iox);
     iox.set_gpio_pin_value(se0_port, se0_pin, bao1x_api::IoxValue::Low); // put the USB port into SE0
     crate::delay(500);
-    // setup the USB port
-    let (last_usb_state, portsc) = glue::setup();
+    // Arm the USB core while the port is still masked by SE0 (RUN_STOP deferred).
+    let _ = glue::setup();
     crate::delay(500);
-    // release SE0
+    // release SE0 so the bus returns to a clean idle before we assert the pullup
     iox.set_gpio_pin_value(se0_port, se0_pin, bao1x_api::IoxValue::High);
+    crate::delay(50); // let the bus settle to disconnected-idle
+    // assert the pullup (RUN_STOP) as the final bring-up step
+    let (last_usb_state, portsc) = glue::connect();
     // USB should have a solid shot of connecting now.
     crate::println!("USB device ready");
     (last_usb_state, portsc)

--- a/libs/bao1x-hal/src/usb/driver.rs
+++ b/libs/bao1x-hal/src/usb/driver.rs
@@ -1469,12 +1469,26 @@ impl CorigineUsb {
                 | self.csr.ms(EVENTCONFIG_USB2_RESUME_NO_PLC_ENABLE, 1),
         );
 
+        // NOTE: RUN_STOP (the upstream pullup / "connect") is deliberately NOT
+        // asserted here.
+        //
+        // The pullup must be the *last* bring-up step. Asserting it here races
+        // the host: the core becomes visible before it can service SETUP
+        // packets, and if the port is still held in SE0 the running core
+        // mistakes the masked bus for host reset signalling, fails high-speed
+        // chirp sequence, and drops to full-speed.
+        //
+        // `start()` only arms the event ring, interrupter and EP0; assert the
+        // pullup via `pullup(true)` once the SoC interrupt is unmasked and any
+        // external SE0 port mask has been released.
+        //
+        // It's important to note that the resulting behavior is
+        // non-deterministic. That is, sometimes the link recovers and manages
+        // to negotiate HS, sometimes is drops to FS, sometimes it confuses xHCI
+        // (the host) enough to force it to disable the port.
         self.csr.wo(
             USBCMD,
-            self.csr.r(USBCMD)
-                | self.csr.ms(USBCMD_SYS_ERR_ENABLE, 1)
-                | self.csr.ms(USBCMD_INT_ENABLE, 1)
-                | self.csr.ms(USBCMD_RUN_STOP, 1),
+            self.csr.r(USBCMD) | self.csr.ms(USBCMD_SYS_ERR_ENABLE, 1) | self.csr.ms(USBCMD_INT_ENABLE, 1),
         );
 
         /*
@@ -1502,6 +1516,23 @@ impl CorigineUsb {
 
         self.set_addr(0, CRG_INT_TARGET);
     }
+
+    /// Assert (`connect = true`) or de-assert the upstream pullup by toggling
+    /// `USBCMD.RUN_STOP`.
+    ///
+    /// It makes the device visible on the bus and therefore MUST be the final
+    /// bring-up step. `start()` no longer touches RUN_STOP, so the required
+    /// order is:
+    ///
+    /// ```text
+    /// reset -> init -> start -> (unmask SoC IRQ) -> (release external SE0) -> pullup(true)
+    /// ```
+    ///
+    /// Asserting the pullup any earlier races the host into enumerating a core
+    /// that cannot yet answer to SETUP packets, and - while an external SE0
+    /// line still masks the port - makes the running core misread the held bus
+    /// as host reset signalling, botching high-speed chirp.
+    pub fn pullup(&mut self, connect: bool) { self.csr.rmwf(USBCMD_RUN_STOP, if connect { 1 } else { 0 }); }
 
     pub fn issue_command(&mut self, cmd: CmdType, p0: u32, p1: u32) -> core::result::Result<(), Error> {
         // don't allow overlapping commands. This can hang the system if the USB core is wedged.
@@ -2503,6 +2534,8 @@ impl UsbBus for CorigineWrapper {
             hw.reset();
             hw.init(None); // default to high speed
             hw.start();
+            // cable-driven (VBUS) connect: nothing gates the port, so assert the pullup now.
+            hw.pullup(true);
             hw.update_current_speed();
             // IRQ enable must happen without dependency on the hardware lock
             hw.irq_csr.clone()
@@ -2879,6 +2912,8 @@ impl UsbBus for CorigineWrapper {
             hw.reset();
             hw.init(None);
             hw.start();
+            // cable-driven (VBUS) connect: nothing gates the port, so assert the pullup now.
+            hw.pullup(true);
             hw.update_current_speed();
             // IRQ enable must happen without dependency on the hardware lock
             hw.irq_csr.clone()

--- a/services/usb-bao1x/src/hw.rs
+++ b/services/usb-bao1x/src/hw.rs
@@ -150,6 +150,8 @@ impl<'a> Bao1xUsb<'a> {
 
         self.wrapper.core().init(None);
         self.wrapper.core().start();
+        // cable-driven (VBUS) connect: assert the pullup as the final step.
+        self.wrapper.core().pullup(true);
         self.wrapper.core().update_current_speed();
 
         // irq must me enabled without dependency on the hw lock
@@ -172,6 +174,8 @@ impl<'a> Bao1xUsb<'a> {
         self.wrapper.core().reset();
         self.wrapper.core().init(None);
         self.wrapper.core().start();
+        // cable-driven (VBUS) connect: assert the pullup as the final step.
+        self.wrapper.core().pullup(true);
         self.wrapper.core().update_current_speed();
 
         // reset all shared data structures


### PR DESCRIPTION
RUN_STOP was asserted inside start(), before the interrupter/EP0 were ready and ~150ms before the external SE0 mask was released. With the host present, the running core read the masked bus as reset signalling and botched HS chirp, yielding retried enumerations and full-speed fallback.

Split RUN_STOP out of start() into pullup() and assert it as the final bring-up step (after IRQ arm + SE0 release) in boot1 and baremetal. std service paths keep pullup() right after start() (cable/VBUS driven).