### PR TITLE
Fix REPL and UART

### DIFF
--- a/bao1x-boot/boot1/src/platform/bao1x/debug.rs
+++ b/bao1x-boot/boot1/src/platform/bao1x/debug.rs
@@ -72,14 +72,17 @@ impl SerialRead for Uart {
             udma::Uart::get_handle(utra::udma_uart_2::HW_UDMA_UART_2_BASE, uart_buf_addr, uart_buf_addr)
         };
         let mut c = 0u8;
-        udma_uart.read_async(&mut c);
+        let got = udma_uart.read_async(&mut c);
 
+        // Acknowledge the UART interrupt-controller pending latch so the IRQ can re-fire, but do
+        // NOT use it to decide whether a byte arrived. `pending != 0` only means "some UART event
+        // happened" (framing errors and non-data events included), which delivered phantom or
+        // duplicated bytes. `read_async` already reports whether a valid, error-free frame was
+        // latched, so gate on that instead.
         let mut irqarray5 = CSR::new(utra::irqarray5::HW_IRQARRAY5_BASE as *mut u32);
-        // read & clear the pending bits
         let pending = irqarray5.r(utra::irqarray5::EV_PENDING);
-        // crate::println!("pending {:x} {}", pending, unsafe { char::from_u32_unchecked(c as u32) });
         irqarray5.wo(utra::irqarray5::EV_PENDING, pending);
-        if pending != 0 { Some(c) } else { None }
+        if got != 0 { Some(c) } else { None }
     }
 }
 

--- a/bao1x-boot/boot1/src/repl.rs
+++ b/bao1x-boot/boot1/src/repl.rs
@@ -68,20 +68,17 @@ impl Repl {
             if self.cmdline.len() != 0 {
                 self.cmdline.pop();
             }
-        } else {
-            // everything else
-            match char::from_u32(c as u32) {
-                Some(c) => {
-                    if self.local_echo {
-                        crate::print!("{}", c);
-                    }
-                    self.cmdline.push(c);
-                }
-                None => {
-                    crate::println!("Warning: bad char received, ignoring")
-                }
+        } else if (0x20..=0x7e).contains(&c) {
+            // Printable ASCII only. Anything else (notably 0xFF framing noise that couples onto
+            // the idle UART RX line during USB enumeration) is dropped, so line noise can neither
+            // echo-storm the console nor grow `cmdline` without bound and exhaust the heap.
+            let c = c as char;
+            if self.local_echo {
+                crate::print!("{}", c);
             }
+            self.cmdline.push(c);
         }
+        // else: non-printable byte (control chars, 0x7f, 0x80..=0xff) — silently ignored
     }
 
     pub fn process(&mut self) -> Result<(), Error> {

--- a/libs/bao1x-hal/src/udma/uart.rs
+++ b/libs/bao1x-hal/src/udma/uart.rs
@@ -267,11 +267,24 @@ impl Uart {
                 as usize;
 
         if valid != 0 {
-            *c = unsafe {
+            // Sample the per-frame error status (framing/parity/overrun) *before* popping the byte.
+            // Coupling from USB signalling can forge a start bit on the Rx line; the hardware then
+            // frames a counterfeit byte, latches it Valid, and flags it in Error. Delivering it as
+            // data floods the console (and any Rx queue) with junk, so an errored frame is dropped.
+            let error = unsafe {
+                self.csr().base().add(Bank::Custom.into()).add(UartReg::Error.into()).read_volatile()
+            };
+            // Always pop the frame from the FIFO so the head advances and Valid clears.
+            let data = unsafe {
                 self.csr().base().add(Bank::Custom.into()).add(UartReg::Data.into()).read_volatile()
             } as u8;
 
-            1
+            if error == 0 {
+                *c = data;
+                1
+            } else {
+                0
+            }
         } else {
             0
         }


### PR DESCRIPTION
Under USB activity the boot1 serial console could be flooded with `0xFF` (`ÿ`) bytes and eventually panic with `memory allocation of 131072 bytes failed`, which showed up as intermittent ("hit and miss") USB enumeration on dabao/baosec.

This fixes the UART **receive path** so only validly-framed bytes are delivered, and hardens the REPL input — eliminating the flood and the OOM at the source.