### PR TITLE
fix the unsigned boot header vulnerability

### DIFF
--- a/libs/bao1x-hal/src/sigcheck.rs
+++ b/libs/bao1x-hal/src/sigcheck.rs
@@ -6,6 +6,7 @@ use bao1x_api::PQ_REVOCATION_DUPE_DISTANCE;
 use bao1x_api::REQUIRE_PQ;
 use bao1x_api::REQUIRE_PQ_DUPE;
 use bao1x_api::REVOCATION_DUPE_DISTANCE;
+use bao1x_api::StaticsInRom;
 use bao1x_api::bollard;
 use bao1x_api::classic_to_pq_revocation;
 use bao1x_api::pubkeys::DEVELOPER_KEY_SLOT;
@@ -428,11 +429,27 @@ pub fn validate_image(
             // continue on to return classical signature
             bollard!(die_no_std, 4);
             assert!(valid_key != valid_key2);
+            // boot0 has to skip past both the signature block and the statics structure. The
+            // statics structure is needed because there is no loader in the boot0 context, and
+            // thus a region is reserved to initialize static data (which is required to make things
+            // like static-atomics work in the boot0 stage). The actual offset is in practice defined
+            // by code structure sizes but de facto fixed to 0x400. This computation ensures these
+            // two are consistent, so if in the future I tweak one value I should hit the assert and
+            // remind myself to fix the others.
+            let header_len = SIGBLOCK_LEN + size_of::<StaticsInRom>();
+            assert!(header_len == 0x400, "header size is inconsistent");
             Ok((
                 valid_key,
                 valid_key2,
                 pk_src.sealed_data.pubkeys[valid_key].tag,
-                (img_offset as u32) ^ u32::from_le_bytes(pk_src.sealed_data.pubkeys[valid_key].tag),
+                // add header_len to the jump offset - so that the jump target is inside the signed
+                // region. This addition does not affect boot0 because the jump target is fixed to always
+                // be at the unsigned trampoline instruction. Boot0's first instruction is OK to be
+                // unsigned because it is assumed that boot0 is trusted code. Mutability of boot0 is
+                // fatal to the security assumptions of the chip. `img_offset` is a compile-time constant
+                // and therefore not attacker controlled.
+                ((img_offset as usize + header_len) as u32)
+                    ^ u32::from_le_bytes(pk_src.sealed_data.pubkeys[valid_key].tag),
                 if verdict == PQ_MATCH { Some(pq_tag) } else { None },
             ))
         } else {


### PR DESCRIPTION
this changes the target address computation to skip past the two header trampolines.

In the case of boot0, the address computation is never run - this is because the CPU always boots to the first address in RRAM (and this is why the trampolines are necessary - the idea was to make the signature and static data headers code-driven so as requirements changed we could be future-proof; this was especially important in the early days of code development when we didn't know how big the structures would be).

In the case of boot1/loader/baremetal regions - the target address is always after the headers. I would say now these headers are fixed, so the patch includes an assert to check that the values equal the hard-defined constant. It's not that the values can't be changed, but changing them is a big deal and therefore it's made somewhat difficult to do it accidentally.

In the case of xous/swap/app regions - these are handled by the loader to do the signature checking, and I believe that the loaded code is always in the signed region. The trampoline is not used in these sequences.

Thus I think this patch completely solves the vulnerability, under the strong assumption that boot0/boot1 is rewritten with code that uses this.

The strong caveat is that boot0 is not (currently) updateable on the dc34 badges, so even with a boot1 update, one could downgrade boot1, and perform the attack. This might be fixable because, through an ironic twist, the dc34 badges use A0 silicon which also contains another bug that would allow boot0 malleability.

That being said, the same bug that allows boot0 malleability also makes the net solution more fragile. A patch flow involving boot0 malleability on A0 silicon/dc34 badges is contemplated but currently not a priority because I'm not sure there is a strong request for it, and the focus at the moment is looking forward and making sure that the boot0/boot1 flows are iron-clad for tattoing into the parts for the upcoming production deadline in early September.