### PR TITLE
bio-bdma: fix I2C read corruption - drive ACK/NACK only after SCL falls

### DIFF
--- a/libs/xous-bio-bdma/src/i2c.rs
+++ b/libs/xous-bio-bdma/src/i2c.rs
@@ -290,7 +290,11 @@ bio_code!(
     "bne x6, x0, 23b",   // loop back if we haven't shifted all the bits
     "mv x17, x11",       // x17 <- read data
 
-    // outgoing ACK or NACK
+    // outgoing ACK or NACK. SCL must be low before SDA changes direction:
+    // an SDA edge while SCL is still high reads as a START/STOP condition.
+    "mv x20, x0", // SCL L0
+    "mv x24, x5",        // SCL <- 0
+    "mv x20, x0", // SCL L1
     "beq x10, x0, 28f",  // if last iteration, do NACK
     "mv x24, x4",        //    otherwise ACK by SDA as output
     "addi x7, x7, 1",    //   ACK += 1
@@ -299,9 +303,6 @@ bio_code!(
     "mv x25, x4",        // SDA is input (SDA goes high; NACK)
     "addi x8, x8, 1",    //   NACK += 1
   "29:",
-    "mv x20, x0", // SCL L0
-    "mv x24, x5",        // SCL <- 0
-    "mv x20, x0", // SCL L1
     "mv x20, x0", // SCL H0
     "mv x25, x5",        // SCL <- 1
     "j 25f",


### PR DESCRIPTION
## Bug

In the `i2c_driver` bio_code! program, the master's outgoing ACK/NACK after each
read byte changes the SDA direction while SCL is still high from the 8th data bit:

    "beq x10, x0, 28f",  // if last iteration, do NACK
    "mv x24, x4",        // ACK by SDA as output   <-- SCL is still high here
    ...
    "mv x20, x0", // SCL L0
    "mv x24, x5", // SCL <- 0                      <-- SCL falls only afterwards

Whenever the slave's last data bit is 1 (SDA high), driving SDA low at that point
is a START condition on the wire. A spec-compliant slave aborts the read and stops
driving, so every byte after the first one ending in binary 1 reads back as
pulled-up 0xFF. The transaction status still "passes" because the master's own
ACKs are counted blindly, which makes the corruption easy to miss.

Observed against a Hynitron CST9220 touch controller on bao1x silicon:

- expected `55 B0` (boot ACK) -> read `55 FF`   (0x55 ends in 1)
- expected `80 07 xx xx`      -> read `80 07 FF FF` (0x80 ends in 0, 0x07 ends in 1)

The failure pattern tracks the LSB of each data byte exactly. A wire-level capture
(sampling the pads plus the BIO DBG_PADOE ownership bits from the host CPU during a
live transaction) confirmed the spurious START: SDA falls while SCL is high right
after a data byte whose LSB is 1. This presumably passes the LiteX testbench
because its I2C model does not treat the mid-high SDA edge as a restart.

## Fix

Reorder the outgoing ACK/NACK: pull SCL low first, change SDA during the low
phase, then release SCL. Textbook I2C data-hold timing; same instruction count.

## Validation

- Verified on bao1x silicon via a C port of this exact program driving a CST9220
  (ARM host, same BIO block): multi-byte reads now return correct data and the
  device is fully functional. The validated configuration also included a
  wait-for-SCL-high after each SCL release (clock-stretch tolerance); that
  enhancement is left out of this PR to keep it minimal, happy to send it as a
  follow-up if there's interest.
- `python3 libs/bio-lib/erratum_check.py libs/xous-bio-bdma/src/i2c.rs` passes.
- The block assembles clean as rv32i with binutils.

Note: `libs/xous-bio/src/i2c.rs` contains a stale copy of the same program with
the same bug (that crate no longer builds against current utralib); left untouched.