### PR TITLE
IFR patch

### DIFF
--- a/bao1x-boot/boot-updater/src/main.rs
+++ b/bao1x-boot/boot-updater/src/main.rs
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn rust_entry() -> ! {
         IS_BAOSEC.store(true, Ordering::SeqCst);
     }
     #[cfg(feature = "oem-baosec-lite")]
-    {
+    if board_type == BoardTypeCoding::Oem {
         IS_BAOSEC.store(true, Ordering::SeqCst);
     }
 
@@ -109,12 +109,16 @@ pub unsafe extern "C" fn rust_entry() -> ! {
     let mut udma_global = GlobalConfig::new();
     let mut oled_iox = iox.clone();
     #[cfg(feature = "oem-baosec-lite")]
-    let mut oled = Some(bao1x_hal::sh1107::Oled128x128::new(
-        bao1x_hal::sh1107::MainThreadToken::new(),
-        perclk,
-        &mut oled_iox,
-        &mut udma_global,
-    ));
+    let mut oled = if board_type == BoardTypeCoding::Oem {
+        Some(bao1x_hal::sh1107::Oled128x128::new(
+            bao1x_hal::sh1107::MainThreadToken::new(),
+            perclk,
+            &mut oled_iox,
+            &mut udma_global,
+        ))
+    } else {
+        None
+    };
     #[cfg(not(feature = "oem-baosec-lite"))]
     let mut oled = if board_type == BoardTypeCoding::Baosec {
         Some(bao1x_hal::sh1107::Oled128x128::new(

--- a/bao1x-boot/boot1/Cargo.toml
+++ b/bao1x-boot/boot1/Cargo.toml
@@ -61,6 +61,8 @@ qe-debug = ["verbose-debug", "bao1x-hal/debug-print-duart"]
 
 # various pocs for security issues
 pocs = []
+# check and fix IFR values - requires an unsafe setting from bao1x-hal
+fix-ifr = ["bao1x-hal/redteam"]
 
 verilator-only = []
 default = ["oem-baosec-lite"]

--- a/bao1x-boot/boot1/src/main.rs
+++ b/bao1x-boot/boot1/src/main.rs
@@ -85,16 +85,6 @@ pub unsafe extern "C" fn rust_entry() -> ! {
     let one_way = bao1x_hal::acram::OneWayCounter::new();
     let mut board_type =
         one_way.get_decoded::<bao1x_api::BoardTypeCoding>().expect("Board type coding error");
-    #[cfg(feature = "oem-baosec-lite")]
-    {
-        // this this flag was explicitly passed, this firmware image is only useful for OEM boards.
-        // set the board type as thus.
-        while board_type != bao1x_api::BoardTypeCoding::Oem {
-            one_way.inc_coded::<bao1x_api::BoardTypeCoding>().ok();
-            board_type =
-                one_way.get_decoded::<bao1x_api::BoardTypeCoding>().expect("Board type coding error");
-        }
-    }
 
     // crate::println_d!("TX_IDLE: {:?}", crate::platform::usb::TX_IDLE.load(Ordering::SeqCst));
     let perclk: u32;
@@ -124,7 +114,7 @@ pub unsafe extern "C" fn rust_entry() -> ! {
         IS_BAOSEC.store(true, Ordering::SeqCst);
     }
     #[cfg(feature = "oem-baosec-lite")]
-    {
+    if board_type == BoardTypeCoding::Oem {
         IS_BAOSEC.store(true, Ordering::SeqCst);
     }
 
@@ -197,12 +187,16 @@ pub unsafe extern "C" fn rust_entry() -> ! {
     let mut udma_global = GlobalConfig::new();
     let mut oled_iox = iox.clone();
     #[cfg(feature = "oem-baosec-lite")]
-    let mut oled = Some(bao1x_hal::sh1107::Oled128x128::new(
-        bao1x_hal::sh1107::MainThreadToken::new(),
-        perclk,
-        &mut oled_iox,
-        &mut udma_global,
-    ));
+    let mut oled = if board_type == BoardTypeCoding::Oem {
+        Some(bao1x_hal::sh1107::Oled128x128::new(
+            bao1x_hal::sh1107::MainThreadToken::new(),
+            perclk,
+            &mut oled_iox,
+            &mut udma_global,
+        ))
+    } else {
+        None
+    };
     #[cfg(not(feature = "oem-baosec-lite"))]
     let mut oled = if board_type == BoardTypeCoding::Baosec {
         Some(bao1x_hal::sh1107::Oled128x128::new(
@@ -265,7 +259,9 @@ pub unsafe extern "C" fn rust_entry() -> ! {
         crate::glue::setup_spim(perclk);
     }
     #[cfg(feature = "oem-baosec-lite")]
-    crate::glue::setup_spim(perclk);
+    if board_type == BoardTypeCoding::Oem {
+        crate::glue::setup_spim(perclk);
+    }
 
     // it's in this loop that the board type would be set after initial boot
     let mut repl = crate::repl::Repl::new(perclk);
@@ -369,15 +365,14 @@ pub unsafe extern "C" fn rust_entry() -> ! {
             iox.set_gpio_dir(se0_dabao.0, se0_dabao.1, bao1x_api::IoxDir::Input);
             (se0_baosec.0, se0_baosec.1)
         }
-        #[cfg(not(feature = "oem-baosec-lite"))]
+        #[cfg(feature = "oem-baosec-lite")]
+        BoardTypeCoding::Oem => {
+            iox.set_gpio_dir(se0_dabao.0, se0_dabao.1, bao1x_api::IoxDir::Input);
+            (se0_baosec.0, se0_baosec.1)
+        }
         _ => {
             iox.set_gpio_dir(se0_baosec.0, se0_baosec.1, bao1x_api::IoxDir::Input);
             (se0_dabao.0, se0_dabao.1)
-        }
-        #[cfg(feature = "oem-baosec-lite")]
-        _ => {
-            iox.set_gpio_dir(se0_dabao.0, se0_dabao.1, bao1x_api::IoxDir::Input);
-            (se0_baosec.0, se0_baosec.1)
         }
     };
     boot(&iox, oled, se0_port, se0_pin, &mut csprng)

--- a/bao1x-boot/boot1/src/platform/bao1x/bao1x.rs
+++ b/bao1x-boot/boot1/src/platform/bao1x/bao1x.rs
@@ -514,7 +514,7 @@ pub fn early_init(mut board_type: bao1x_api::BoardTypeCoding) -> (bao1x_api::Boa
     crate::println!("boot1 udma console up, CPU @ {}MHz!", fclk_freq / 2_000_000);
 
     #[cfg(feature = "oem-baosec-lite")]
-    {
+    if board_type == BoardTypeCoding::Oem {
         // only enable WDT if we're not plugged in to a host
         if iox.get_gpio_pin_value(bao1x_api::IoxPort::PA, 4) == bao1x_api::IoxValue::Low {
             // enable watchdog timer at a very conservative timeout - main purpose is to ensure battery

--- a/bao1x-boot/boot1/src/repl.rs
+++ b/bao1x-boot/boot1/src/repl.rs
@@ -656,6 +656,9 @@ impl Repl {
                 crate::println!("Board type set to {:?} after {} increments", new_type, count);
                 crate::platform::slots::check_slots();
                 crate::println!("Key & data slots checked according to the new type");
+                // improve scripted recognition of confirmation message in noisy/flakey serial environments
+                use bao1x_hal::board::{BOOKEND_END, BOOKEND_START};
+                crate::println!("{}BOOT1.BOARDTYPE,{},{}", BOOKEND_START, args[0].as_str(), BOOKEND_END);
             }
             "altboot" => {
                 let owc = OneWayCounter::new();
@@ -735,6 +738,10 @@ impl Repl {
                 }
             }
             "baosec-init" => {
+                // NOTE: boardtype setting is removed from this routine. Test routine needs to be reworked to
+                // set this using a separate boardtype command.
+                // completion type is also BAOSEC-INIT now.
+
                 let full = match args.as_slice() {
                     [s] if s == "confirm" => false,
                     [s, f] if s == "confirm" && f == "full" => true,
@@ -810,25 +817,7 @@ impl Repl {
                     flash_spim.flash_erase_block(addr, SPINOR_BULK_ERASE_SIZE as usize);
                 }
                 crate::println!("...done!");
-                let one_way = bao1x_hal::acram::OneWayCounter::new();
-                let board_type =
-                    one_way.get_decoded::<bao1x_api::BoardTypeCoding>().expect("Board type coding error");
-                #[cfg(not(feature = "oem-baosec-lite"))]
-                if board_type != bao1x_api::BoardTypeCoding::Baosec {
-                    while one_way.get_decoded::<bao1x_api::BoardTypeCoding>().expect("owc coding error")
-                        != bao1x_api::BoardTypeCoding::Baosec
-                    {
-                        one_way.inc_coded::<bao1x_api::BoardTypeCoding>().expect("increment error");
-                    }
-                }
-                #[cfg(feature = "oem-baosec-lite")]
-                if board_type != bao1x_api::BoardTypeCoding::Oem {
-                    while one_way.get_decoded::<bao1x_api::BoardTypeCoding>().expect("owc coding error")
-                        != bao1x_api::BoardTypeCoding::Oem
-                    {
-                        one_way.inc_coded::<bao1x_api::BoardTypeCoding>().expect("increment error");
-                    }
-                }
+
                 // reset the USB stack so that we'll re-enumerate correctly after this reboot.
                 // This also has the side-effect of redirecting the console output back to the serial port.
                 crate::platform::usb::glue::shutdown();
@@ -840,16 +829,8 @@ impl Repl {
                 // CI note: this appears on the "hard UART", not on USB serial. If we want this on USB
                 // serial, we would want to add some wait time to ensure the USB packets get sent before
                 // issuing the reboot command.
-                #[cfg(not(feature = "oem-baosec-lite"))]
-                {
-                    crate::println!("{}BOOT1.SETBOARD,{}", BOOKEND_START, BOOKEND_END);
-                    crate::println!("Board type set to baosec");
-                }
-                #[cfg(feature = "oem-baosec-lite")]
-                {
-                    crate::println!("Board type set to baosec-lite");
-                    crate::println!("{}BOOT1.SETBOARD-LITE,{}", BOOKEND_START, BOOKEND_END);
-                }
+                crate::println!("{}BOOT1.BAOSEC-INIT,{}", BOOKEND_START, BOOKEND_END);
+                crate::println!("Board type set to baosec");
             }
             "ifr" => {
                 // safety: the IFR region is aligned and exists here. It is sealed by hardware in USER mode,

--- a/bao1x-boot/boot1/src/secboot.rs
+++ b/bao1x-boot/boot1/src/secboot.rs
@@ -116,6 +116,11 @@ pub fn try_boot(or_die: bool, csprng: &mut Csprng) {
             }
 
             csprng.random_delay();
+
+            // this must be called before secrets are sealed
+            #[cfg(feature = "fix-ifr")]
+            fix_ifr();
+
             bollard!(bao1x_hal::sigcheck::die_no_std, 4);
             // this has to be called *after* erase_secrets, because we can't erase the secrets
             // once the mappings have been sealed off. This is why we can't use the auto-jump method
@@ -152,5 +157,72 @@ pub fn try_boot(or_die: bool, csprng: &mut Csprng) {
     }
     if use_skipping {
         disable_clock_skipping();
+    }
+}
+
+#[cfg(feature = "fix-ifr")]
+pub fn fix_ifr() {
+    let mut rram = bao1x_hal::rram::Reram::new();
+    {
+        let mut ifr_0x280 = [0u8; 32];
+        ifr_0x280
+            .copy_from_slice(unsafe { core::slice::from_raw_parts((0x6040_0000 + 0x280) as *const u8, 32) });
+        if ifr_0x280
+            == [
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xA8, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00,
+            ]
+        {
+            // the 0x3a write protection is missing. Patch it.
+            ifr_0x280[31] = 0x3A;
+            if unsafe { rram.crazy_unsafe_write_slice(0x0040_0000 + 0x280, &ifr_0x280) }.is_err() {
+                crate::println!("Couldn't patch IFR 0x280");
+            } else {
+                crate::println!("IFR 0x280 patched");
+            }
+            bao1x_hal::cache_flush();
+        } else if ifr_0x280
+            == [
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xA8, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x3A,
+            ]
+        {
+            // everything is OK, don't print anything
+        } else {
+            crate::println!("IFR 0x280 has an unexpected value, skipping patch");
+        }
+    }
+    {
+        let mut ifr_0x340 = [0u8; 32];
+        ifr_0x340
+            .copy_from_slice(unsafe { core::slice::from_raw_parts((0x6040_0000 + 0x340) as *const u8, 32) });
+        if ifr_0x340
+            == [
+                0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00,
+            ]
+        {
+            // the 0x3a write protection is missing. Patch it.
+            ifr_0x340[31] = 0x3A;
+            if unsafe { rram.crazy_unsafe_write_slice(0x0040_0000 + 0x340, &ifr_0x340) }.is_err() {
+                crate::println!("Couldn't patch IFR 0x340");
+            } else {
+                crate::println!("IFR 0x340 patched");
+            }
+            bao1x_hal::cache_flush();
+        } else if ifr_0x340
+            == [
+                0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x3A,
+            ]
+        {
+            // everything is OK, don't print anything
+        } else {
+            crate::println!("IFR 0x340 has an unexpected value, skipping patch");
+        }
     }
 }


### PR DESCRIPTION
add IFR write protect patching to boot1 update

also make the boot1 and boot-updater agnostic between dabao and dc34

This does mean some tweaks would need to happen on factory test infra for dc34 but because that production run is "forever finished" I'm pretty comfortable breaking that now if it makes ongoing maintenance easier. This will then become a baosec problem to solve, but baosec production infra requires a full refactor anyways.