### PR TITLE
Antirollback

### DIFF
--- a/bao1x-boot/boot1/src/audit.rs
+++ b/bao1x-boot/boot1/src/audit.rs
@@ -120,7 +120,8 @@ pub fn audit() {
     let tag_owned;
     match bao1x_hal::sigcheck::validate_image(BOOT0_SELF_CHECK, None, None) {
         Ok((k, k2, tag, target, pq_tag)) => crate::println!(
-            "Boot0: key {}/{} ({}) pq {:?} -> {:x}",
+            "Boot0: arb {}, key {}/{} ({}), pq {:?} -> {:x}",
+            owc.get(BOOT0_ANTI_ROLLBACK),
             k,
             !k2,
             core::str::from_utf8(&tag).unwrap_or("invalid tag"),
@@ -137,7 +138,8 @@ pub fn audit() {
     let tag_owned;
     match bao1x_hal::sigcheck::validate_image(BOOT0_TO_BOOT1, None, None) {
         Ok((k, k2, tag, target, pq_tag)) => crate::println!(
-            "Boot1: key {}/{} ({}) pq {:?} -> {:x}",
+            "Boot1: arb {}, key {}/{} ({}) pq {:?} -> {:x}",
+            owc.get(BOOT1_ANTI_ROLLBACK),
             k,
             !k2,
             core::str::from_utf8(&tag).unwrap_or("invalid tag"),
@@ -153,8 +155,12 @@ pub fn audit() {
     }
     let tag_owned;
     match bao1x_hal::sigcheck::validate_image(BOOT1_TO_LOADER_OR_BAREMETAL, None, None) {
+        // anti-rollbacks for next stage are either loader or baremetal: print both as loader|baremetal in the
+        // audit
         Ok((k, k2, tag, target, pq_tag)) => crate::println!(
-            "Next stage: key {}/{} ({}) pq {:?} -> {:x}",
+            "Next stage: arb {}|{}, key {}/{} ({}), pq {:?} -> {:x}",
+            owc.get(LOADER_ANTI_ROLLBACK),
+            owc.get(BAREMETAL_ANTI_ROLLBACK),
             k,
             !k2,
             core::str::from_utf8(&tag).unwrap_or("invalid tag"),

--- a/bao1x-boot/boot1/src/audit.rs
+++ b/bao1x-boot/boot1/src/audit.rs
@@ -121,7 +121,7 @@ pub fn audit() {
     match bao1x_hal::sigcheck::validate_image(BOOT0_SELF_CHECK, None, None) {
         Ok((k, k2, tag, target, pq_tag)) => crate::println!(
             "Boot0: arb {}, key {}/{} ({}), pq {:?} -> {:x}",
-            owc.get(BOOT0_ANTI_ROLLBACK),
+            owc.get(BOOT0_ANTI_ROLLBACK).unwrap(),
             k,
             !k2,
             core::str::from_utf8(&tag).unwrap_or("invalid tag"),
@@ -139,7 +139,7 @@ pub fn audit() {
     match bao1x_hal::sigcheck::validate_image(BOOT0_TO_BOOT1, None, None) {
         Ok((k, k2, tag, target, pq_tag)) => crate::println!(
             "Boot1: arb {}, key {}/{} ({}) pq {:?} -> {:x}",
-            owc.get(BOOT1_ANTI_ROLLBACK),
+            owc.get(BOOT1_ANTI_ROLLBACK).unwrap(),
             k,
             !k2,
             core::str::from_utf8(&tag).unwrap_or("invalid tag"),
@@ -159,8 +159,8 @@ pub fn audit() {
         // audit
         Ok((k, k2, tag, target, pq_tag)) => crate::println!(
             "Next stage: arb {}|{}, key {}/{} ({}), pq {:?} -> {:x}",
-            owc.get(LOADER_ANTI_ROLLBACK),
-            owc.get(BAREMETAL_ANTI_ROLLBACK),
+            owc.get(LOADER_ANTI_ROLLBACK).unwrap(),
+            owc.get(BAREMETAL_ANTI_ROLLBACK).unwrap(),
             k,
             !k2,
             core::str::from_utf8(&tag).unwrap_or("invalid tag"),

--- a/signing/anti-rollback.hjson
+++ b/signing/anti-rollback.hjson
@@ -12,8 +12,8 @@
 // and more device types; this might have to be handled with the reserved rollback counters and/or
 // reserved function codes in the future.
 {
-    "boot0": "1",
-    "boot1": "1",
+    "boot0": "2",
+    "boot1": "2",
     "loader": "1",
     "kernel": "1",
     "app": "1",


### PR DESCRIPTION
This arms the anti-rollback counters so that boot1 can't be downgraded on devices that have had the jump trampoline patched.