### PR TITLE
ATE features

### DIFF
--- a/bao1x-boot/boot-updater/src/platform/bao1x/usb/handlers.rs
+++ b/bao1x-boot/boot-updater/src/platform/bao1x/usb/handlers.rs
@@ -220,8 +220,9 @@ pub fn usb_ep1_bulk_out_complete(
                     bollard!(die, 4);
                     // This range check prevents UF2 from being an arbitrary-write primitive to e.g. RAM
                     // or sensitive bootloader code.
-                    if matches!(record.address() as usize, START_RANGE..=END_RANGE)
+                    if matches!(record.address() as usize, START_RANGE..END_RANGE)
                         && record.family() == bao1x_api::BAOCHIP_1X_UF2_FAMILY
+                        && record.address() as usize + record.data().len() <= END_RANGE
                     {
                         let mut rram = bao1x_hal::rram::Reram::new();
                         let offset = record.address() as usize - utralib::HW_RERAM_MEM;

--- a/bao1x-boot/boot1/Cargo.toml
+++ b/bao1x-boot/boot1/Cargo.toml
@@ -62,7 +62,7 @@ qe-debug = ["verbose-debug", "bao1x-hal/debug-print-duart"]
 # various pocs for security issues
 pocs = []
 # check and fix IFR values - requires an unsafe setting from bao1x-hal
-fix-ifr = ["bao1x-hal/redteam"]
+# fix-ifr = ["bao1x-hal/redteam"]
 
 verilator-only = []
 default = ["oem-baosec-lite"]

--- a/bao1x-boot/boot1/src/platform/bao1x/ate.rs
+++ b/bao1x-boot/boot1/src/platform/bao1x/ate.rs
@@ -57,6 +57,7 @@ impl Ate {
             iox.set_gpio_pin_value(bao1x_api::IoxPort::PF, 1, bao1x_api::IoxValue::High);
             crate::platform::delay(5);
             iox.set_gpio_pin_value(bao1x_api::IoxPort::PF, 1, bao1x_api::IoxValue::Low);
+            crate::platform::delay(5);
             // 1->0 on PF1 indicates sampling values
             for (channel, source) in sources.iter().enumerate() {
                 let _dummy = adc.read_raw_averaged(*source, 8); // dummy reading still required every source change, some bug in ADC driver?
@@ -73,7 +74,6 @@ impl Ate {
                 );
                 */
             }
-            crate::platform::delay(5);
         }
         ate
     }

--- a/bao1x-boot/boot1/src/platform/bao1x/usb/handlers.rs
+++ b/bao1x-boot/boot1/src/platform/bao1x/usb/handlers.rs
@@ -252,6 +252,7 @@ pub fn usb_ep1_bulk_out_complete(
                     // or sensitive bootloader code.
                     if matches!(record.address() as usize, START_RANGE..END_RANGE)
                         && record.family() == bao1x_api::BAOCHIP_1X_UF2_FAMILY
+                        && record.address() as usize + record.data().len() <= END_RANGE
                     {
                         let mut rram = bao1x_hal::rram::Reram::new();
                         let offset = record.address() as usize - utralib::HW_RERAM_MEM;

--- a/bao1x-boot/boot1/src/repl.rs
+++ b/bao1x-boot/boot1/src/repl.rs
@@ -1036,7 +1036,7 @@ impl Repl {
                 use bao1x_api::{IoGpio, IoSetup};
                 use bao1x_hal::iox::Iox;
                 let iox = Iox::new(utralib::utra::iox::HW_IOX_BASE as *mut u32);
-                // setup PF1 as an "index" pin
+                // setup PF5 as the test active pin
                 iox.setup_pin(
                     bao1x_api::IoxPort::PF,
                     5,
@@ -1055,10 +1055,205 @@ impl Repl {
                 let slot_mgr = bao1x_hal::acram::SlotManager::new();
                 let mut rram = bao1x_hal::rram::Reram::new();
                 let slot = &bao1x_api::offsets::ATE_RESERVED;
-                let ate = crate::platform::ate::Ate::new(self.perclk);
+
                 let mut data = [0u8; 32];
-                ate.serialize_into(&mut data);
-                slot_mgr.write(&mut rram, slot, &data).ok();
+                if args.len() == 0 {
+                    let ate = crate::platform::ate::Ate::new(self.perclk);
+                    ate.serialize_into(&mut data);
+                    slot_mgr.write(&mut rram, slot, &data).ok();
+                } else {
+                    match args[0].as_str() {
+                        "0" => {
+                            // clears the slot
+                            let mut rram = bao1x_hal::rram::Reram::new();
+                            let slot = &bao1x_api::offsets::ATE_RESERVED;
+                            slot_mgr.write(&mut rram, slot, &[0x0; 32]).ok();
+                        }
+                        "1" => {
+                            // writes a known pattern into the data slot
+                            let mut rram = bao1x_hal::rram::Reram::new();
+                            let slot = &bao1x_api::offsets::ATE_RESERVED;
+                            slot_mgr.write(&mut rram, slot, &[0x5a; 32]).ok();
+                        }
+                        "2" => {
+                            // slow down clocks before calling to save power
+                            let perclk = unsafe {
+                                bao1x_hal::clocks::init_clock_asic(
+                                    350_000_000,
+                                    utra::sysctrl::HW_SYSCTRL_BASE,
+                                    utralib::HW_AO_SYSCTRL_BASE,
+                                    Some(utra::duart::HW_DUART_BASE),
+                                    crate::delay_at_sysfreq,
+                                    false,
+                                )
+                            };
+                            let ate = crate::platform::ate::Ate::new(perclk);
+                            let mut data = [0u8; 32];
+                            ate.serialize_into(&mut data);
+                            slot_mgr.write(&mut rram, slot, &data).ok();
+                        }
+                        _ => {
+                            // non-RRAM testing path - dynamically sample triggers from the ATE
+                            use bao1x_api::{IoGpio, IoSetup};
+                            use bao1x_hal::iox::Iox;
+                            let iox = Iox::new(utralib::utra::iox::HW_IOX_BASE as *mut u32);
+                            let udma_global = GlobalConfig::new();
+                            udma_global.clock_on(bao1x_api::PeriphId::Adc);
+                            // safety: clocks have been turned on. The ADC buffer is located at the base of
+                            // IFRAM0 which should be empty, as IFRAM reserved
+                            // addresses allocate from top-down.
+                            let mut adc = unsafe {
+                                bao1x_hal::udma::Adc::new_baremetal(self.perclk, utralib::HW_IFRAM0_MEM)
+                            };
+                            // PF1 indicates that a sample is ready by going high
+                            iox.setup_pin(
+                                bao1x_api::IoxPort::PF,
+                                1,
+                                Some(bao1x_api::IoxDir::Output),
+                                Some(bao1x_api::IoxFunction::Gpio),
+                                None,
+                                Some(bao1x_api::IoxEnable::Disable),
+                                None,
+                                None,
+                            );
+                            iox.set_gpio_pin_value(bao1x_api::IoxPort::PF, 1, bao1x_api::IoxValue::Low);
+
+                            // setup PA4..=PA7 as inputs - just to make sure we aren't accidentally driving
+                            // them. disable the pull-up, too.
+                            for pin in 4..=7 {
+                                iox.setup_pin(
+                                    bao1x_api::IoxPort::PA,
+                                    pin,
+                                    Some(bao1x_api::IoxDir::Input),
+                                    Some(bao1x_api::IoxFunction::Gpio),
+                                    Some(bao1x_api::IoxEnable::Disable),
+                                    Some(bao1x_api::IoxEnable::Disable),
+                                    None,
+                                    None,
+                                );
+                            }
+
+                            // setup relay I/O. PB[15:0] is the DAC data output
+                            iox.set_gpio_bank(IoxPort::PB, 0, 0xFFFF);
+                            for pin in 0..16 {
+                                iox.setup_pin(
+                                    bao1x_api::IoxPort::PB,
+                                    pin,
+                                    Some(bao1x_api::IoxDir::Output),
+                                    Some(bao1x_api::IoxFunction::Gpio),
+                                    Some(bao1x_api::IoxEnable::Disable),
+                                    Some(bao1x_api::IoxEnable::Disable),
+                                    Some(IoxEnable::Enable),
+                                    Some(IoxDriveStrength::Drive4mA),
+                                );
+                            }
+                            // PC[4:0] selects the ADC, lowest bit that is 0 is the selected ADC
+                            // PC[5] triggers a sample when it rises; put a pullup on this to avoid false
+                            // PC[6] low stops the test
+                            // triggering on floating input
+                            for pin in 0..7 {
+                                iox.setup_pin(
+                                    bao1x_api::IoxPort::PC,
+                                    pin,
+                                    Some(bao1x_api::IoxDir::Input),
+                                    Some(bao1x_api::IoxFunction::Gpio),
+                                    Some(bao1x_api::IoxEnable::Enable),
+                                    Some(bao1x_api::IoxEnable::Enable),
+                                    None,
+                                    None,
+                                );
+                            }
+
+                            // pipe-clear any stale ADC values
+                            let _dummy = adc.read_raw_averaged(AdcSource::Ext(AdcExtChannel::Adc0), 8);
+
+                            use bao1x_hal::udma::{AdcExtChannel, AdcSource, GlobalConfig};
+                            enum State {
+                                Armed,
+                                Triggered,
+                            }
+                            let sources = [
+                                AdcSource::Temperature,
+                                AdcSource::Ext(AdcExtChannel::Adc0),
+                                AdcSource::Ext(AdcExtChannel::Adc1),
+                                AdcSource::Ext(AdcExtChannel::Adc2),
+                                AdcSource::Ext(AdcExtChannel::Adc3),
+                            ];
+
+                            while iox.get_gpio_pin(IoxPort::PC, 5) != IoxValue::Low {
+                                // wait for PC5 to go low before arming the system
+                                // if test abort, break
+                                if iox.get_gpio_pin(IoxPort::PC, 6) == IoxValue::Low {
+                                    break;
+                                }
+                            }
+                            let mut state = State::Armed;
+
+                            while iox.get_gpio_pin(IoxPort::PC, 6) == IoxValue::High {
+                                match state {
+                                    State::Armed => {
+                                        if iox.get_gpio_pin(IoxPort::PC, 5) == IoxValue::High {
+                                            state = State::Triggered;
+                                        }
+                                    }
+                                    State::Triggered => {
+                                        let adc_code = iox.get_gpio_bank(IoxPort::PC) & 0x1F;
+                                        let mut got_channel = false;
+                                        for channel in 0..5 {
+                                            if ((adc_code >> channel as u16) & 1) == 0 {
+                                                let source = sources[channel];
+                                                let _dummy = adc.read_raw_averaged(source, 8); // dummy reading still required every source change, some bug in ADC driver?
+                                                let raw = adc.read_raw_averaged(source, 8);
+                                                iox.set_gpio_bank(IoxPort::PB, raw, 0xFFFF);
+                                                got_channel = true;
+                                                break;
+                                            }
+                                        }
+                                        if !got_channel {
+                                            // apply a test pattern to confirm port configuration
+                                            iox.set_gpio_bank(IoxPort::PB, 0xa5a5, 0xFFFF);
+                                        }
+                                        // indicate that the sample is done
+                                        iox.set_gpio_pin_value(
+                                            bao1x_api::IoxPort::PF,
+                                            1,
+                                            bao1x_api::IoxValue::High,
+                                        );
+
+                                        // wait for PC5 to drop
+                                        while iox.get_gpio_pin(IoxPort::PC, 5) == IoxValue::High {
+                                            // if test abort, break
+                                            if iox.get_gpio_pin(IoxPort::PC, 6) == IoxValue::Low {
+                                                break;
+                                            }
+                                        }
+                                        // acknowledge the drop before next iteration
+                                        iox.set_gpio_pin_value(
+                                            bao1x_api::IoxPort::PF,
+                                            1,
+                                            bao1x_api::IoxValue::Low,
+                                        );
+                                        iox.set_gpio_bank(IoxPort::PB, 0, 0xFFFF);
+                                        state = State::Armed;
+                                    }
+                                }
+                            }
+                            // revert PB to inputs
+                            for pin in 0..16 {
+                                iox.setup_pin(
+                                    bao1x_api::IoxPort::PB,
+                                    pin,
+                                    Some(bao1x_api::IoxDir::Input),
+                                    Some(bao1x_api::IoxFunction::Gpio),
+                                    Some(bao1x_api::IoxEnable::Enable),
+                                    Some(bao1x_api::IoxEnable::Enable),
+                                    None,
+                                    None,
+                                );
+                            }
+                        }
+                    }
+                }
 
                 // indicates test finish
                 iox.set_gpio_pin_value(bao1x_api::IoxPort::PF, 5, bao1x_api::IoxValue::High);

--- a/bao1x-boot/boot1/src/secboot.rs
+++ b/bao1x-boot/boot1/src/secboot.rs
@@ -17,9 +17,11 @@ fn seal_boot1_keys() {
     // locks out future modifications to the Coreuser setting. Also inverts mm sense, which means you must
     // enter a virtual memory user state to access sealed keys.
     cu.protect();
+    bollard!(bao1x_hal::sigcheck::die_no_std, 4);
     // call twice, in case someone tries to glitch past this. The second call should essentially be
     // a no-op if the protection is active.
     cu.protect();
+    bollard!(bao1x_hal::sigcheck::die_no_std, 4);
 }
 
 pub fn try_boot(or_die: bool, csprng: &mut Csprng) {
@@ -118,12 +120,11 @@ pub fn try_boot(or_die: bool, csprng: &mut Csprng) {
                     .unwrap_or_else(|_| bao1x_hal::hardening::die());
             }
 
-            csprng.random_delay();
-
             // this must be called before secrets are sealed
-            #[cfg(feature = "fix-ifr")]
-            fix_ifr();
+            // #[cfg(feature = "fix-ifr")]
+            // fix_ifr();
 
+            csprng.random_delay();
             bollard!(bao1x_hal::sigcheck::die_no_std, 4);
             // this has to be called *after* erase_secrets, because we can't erase the secrets
             // once the mappings have been sealed off. This is why we can't use the auto-jump method
@@ -163,6 +164,7 @@ pub fn try_boot(or_die: bool, csprng: &mut Csprng) {
     }
 }
 
+/*
 #[cfg(feature = "fix-ifr")]
 pub fn fix_ifr() {
     let mut rram = bao1x_hal::rram::Reram::new();
@@ -229,3 +231,4 @@ pub fn fix_ifr() {
         }
     }
 }
+*/

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -764,7 +764,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .target_baremetal_bao1x("bao1x-boot1")
                 .add_loader_feature("oem-baosec-lite")
                 // todo: remove this after the update is published
-                .add_loader_feature("fix-ifr")
+                // .add_loader_feature("fix-ifr")
                 .set_sigblock_size(sigblock_size);
         }
 


### PR DESCRIPTION
Cutting a release for ATE infra. Added/enhanced some ATE command sets to give us more chances to debug things.

Remove the fix-ifr stuff because that's just for the A1 update; A2 release the IFRs are fixed at the source.
