### PR TITLE
Fix a1 arb

### DIFF
--- a/bao1x-boot/boot-updater/src/update.rs
+++ b/bao1x-boot/boot-updater/src/update.rs
@@ -45,15 +45,17 @@ pub fn run(mut csprng: &mut Csprng) -> bool {
             function_codes: BOOT0_SELF_CHECK.function_codes,
         };
         csprng.random_delay();
-        let boot0_check1 = bao1x_hal::sigcheck::validate_image(boot0_check, None, Some(&mut csprng))
-            .unwrap_or_else(|_| die());
+        let boot0_check1 =
+            bao1x_hal::sigcheck::validate_image(boot0_check, None, Some(&mut csprng), HardenedBool::TRUE)
+                .unwrap_or_else(|_| die());
         if boot0_check1.0 != !boot0_check1.1 {
             crate::println!("boot0 failed check");
             die();
         }
         csprng.random_delay();
-        let boot0_check2 = bao1x_hal::sigcheck::validate_image(boot0_check, None, Some(&mut csprng))
-            .unwrap_or_else(|_| die());
+        let boot0_check2 =
+            bao1x_hal::sigcheck::validate_image(boot0_check, None, Some(&mut csprng), HardenedBool::TRUE)
+                .unwrap_or_else(|_| die());
         bollard!(die, 4);
         if boot0_check2.0 != !boot0_check2.1 {
             bollard!(die, 4);
@@ -72,14 +74,16 @@ pub fn run(mut csprng: &mut Csprng) -> bool {
     };
     csprng.random_delay();
     let boot1_check1 =
-        bao1x_hal::sigcheck::validate_image(boot1_check, None, Some(&mut csprng)).unwrap_or_else(|_| die());
+        bao1x_hal::sigcheck::validate_image(boot1_check, None, Some(&mut csprng), HardenedBool::TRUE)
+            .unwrap_or_else(|_| die());
     if boot1_check1.0 != !boot1_check1.1 {
         crate::println!("boot1 failed check");
         die();
     }
     csprng.random_delay();
     let boot1_check2 =
-        bao1x_hal::sigcheck::validate_image(boot1_check, None, Some(&mut csprng)).unwrap_or_else(|_| die());
+        bao1x_hal::sigcheck::validate_image(boot1_check, None, Some(&mut csprng), HardenedBool::TRUE)
+            .unwrap_or_else(|_| die());
     bollard!(die, 4);
     if boot1_check2.0 != !boot1_check2.1 {
         bollard!(die, 4);
@@ -103,7 +107,9 @@ pub fn run(mut csprng: &mut Csprng) -> bool {
     }
 
     crate::println!("  Checking boot1");
-    let boot1_verify = bao1x_hal::sigcheck::validate_image(BOOT0_TO_BOOT1, None, Some(&mut csprng));
+    // we trigger boot1 ARB increment here because the only option is pass or brick
+    let boot1_verify =
+        bao1x_hal::sigcheck::validate_image(BOOT0_TO_BOOT1, None, Some(&mut csprng), HardenedBool::FALSE);
     match &boot1_verify {
         Ok(_) => {
             crate::println!("  boot1 update passed!")
@@ -137,7 +143,13 @@ pub fn run(mut csprng: &mut Csprng) -> bool {
             }
 
             crate::println!("  Checking boot0");
-            let boot0_verify = bao1x_hal::sigcheck::validate_image(BOOT0_SELF_CHECK, None, Some(&mut csprng));
+            // we do not increment the ARB here because there is a saving throw still
+            let boot0_verify = bao1x_hal::sigcheck::validate_image(
+                BOOT0_SELF_CHECK,
+                None,
+                Some(&mut csprng),
+                HardenedBool::TRUE,
+            );
             match &boot0_verify {
                 Ok(_) => {
                     crate::println!("  boot0 update passed!")

--- a/bao1x-boot/boot0/src/main.rs
+++ b/bao1x-boot/boot0/src/main.rs
@@ -282,8 +282,9 @@ pub unsafe extern "C" fn rust_entry() -> ! {
     let (paranoid1, paranoid2) = owc.hardened_get2(PARANOID_MODE, PARANOID_MODE_DUPE).unwrap();
 
     // == self-validate the image with the keys we put in, just to make sure our code wasn't tampered with ==
-    let boot0_check1 = bao1x_hal::sigcheck::validate_image(BOOT0_SELF_CHECK, None, Some(&mut csprng))
-        .unwrap_or_else(|_| die());
+    let boot0_check1 =
+        bao1x_hal::sigcheck::validate_image(BOOT0_SELF_CHECK, None, Some(&mut csprng), HardenedBool::FALSE)
+            .unwrap_or_else(|_| die());
     csprng.random_delay();
     if paranoid1 != paranoid2 || boot0_check1.0 != !boot0_check1.1 {
         die();
@@ -292,8 +293,13 @@ pub unsafe extern "C" fn rust_entry() -> ! {
     csprng.random_delay();
     if paranoid1 != 0 || paranoid2 != 0 {
         // do a redundant boot0 check if paranoid mode.
-        let boot0_check2 = bao1x_hal::sigcheck::validate_image(BOOT0_SELF_CHECK, None, Some(&mut csprng))
-            .unwrap_or_else(|_| die());
+        let boot0_check2 = bao1x_hal::sigcheck::validate_image(
+            BOOT0_SELF_CHECK,
+            None,
+            Some(&mut csprng),
+            HardenedBool::FALSE,
+        )
+        .unwrap_or_else(|_| die());
         csprng.random_delay();
         if boot0_check2.0 != !boot0_check2.1 {
             die();
@@ -366,7 +372,8 @@ pub unsafe extern "C" fn rust_entry() -> ! {
         if use_skipping {
             reseed_skipping(csprng.get_u32());
         }
-        match bao1x_hal::sigcheck::validate_image(configuration, None, Some(&mut csprng)) {
+        match bao1x_hal::sigcheck::validate_image(configuration, None, Some(&mut csprng), HardenedBool::FALSE)
+        {
             Ok((key, key_inv, tag, target, pq_tag)) => {
                 if key != !key_inv {
                     die();
@@ -381,8 +388,13 @@ pub unsafe extern "C" fn rust_entry() -> ! {
                 csprng.random_delay();
                 if paranoid1 != 0 || paranoid2 != 0 {
                     // re-check the image: it *should* pass. If not, die.
-                    bao1x_hal::sigcheck::validate_image(configuration, None, Some(&mut csprng))
-                        .unwrap_or_else(|_| die());
+                    bao1x_hal::sigcheck::validate_image(
+                        configuration,
+                        None,
+                        Some(&mut csprng),
+                        HardenedBool::FALSE,
+                    )
+                    .unwrap_or_else(|_| die());
                 }
                 csprng.random_delay();
                 bollard!(die, 4);

--- a/bao1x-boot/boot1/Cargo.toml
+++ b/bao1x-boot/boot1/Cargo.toml
@@ -62,7 +62,7 @@ qe-debug = ["verbose-debug", "bao1x-hal/debug-print-duart"]
 # various pocs for security issues
 pocs = []
 # check and fix IFR values - requires an unsafe setting from bao1x-hal
-# fix-ifr = ["bao1x-hal/redteam"]
+fix-ifr = ["bao1x-hal/redteam"]
 
 verilator-only = []
 default = ["oem-baosec-lite"]

--- a/bao1x-boot/boot1/src/audit.rs
+++ b/bao1x-boot/boot1/src/audit.rs
@@ -118,7 +118,7 @@ pub fn audit() {
     }
 
     let tag_owned;
-    match bao1x_hal::sigcheck::validate_image(BOOT0_SELF_CHECK, None, None) {
+    match bao1x_hal::sigcheck::validate_image(BOOT0_SELF_CHECK, None, None, HardenedBool::TRUE) {
         Ok((k, k2, tag, target, pq_tag)) => crate::println!(
             "Boot0: arb {}, key {}/{} ({}), pq {:?} -> {:x}",
             owc.get(BOOT0_ANTI_ROLLBACK).unwrap(),
@@ -136,7 +136,7 @@ pub fn audit() {
         Err(e) => crate::println!("Boot0 did not validate: {:?}", e),
     }
     let tag_owned;
-    match bao1x_hal::sigcheck::validate_image(BOOT0_TO_BOOT1, None, None) {
+    match bao1x_hal::sigcheck::validate_image(BOOT0_TO_BOOT1, None, None, HardenedBool::TRUE) {
         Ok((k, k2, tag, target, pq_tag)) => crate::println!(
             "Boot1: arb {}, key {}/{} ({}), pq {:?} -> {:x}",
             owc.get(BOOT1_ANTI_ROLLBACK).unwrap(),
@@ -154,7 +154,7 @@ pub fn audit() {
         Err(e) => crate::println!("Boot1 did not validate: {:?}", e),
     }
     let tag_owned;
-    match bao1x_hal::sigcheck::validate_image(BOOT1_TO_LOADER_OR_BAREMETAL, None, None) {
+    match bao1x_hal::sigcheck::validate_image(BOOT1_TO_LOADER_OR_BAREMETAL, None, None, HardenedBool::TRUE) {
         // anti-rollbacks for next stage are either loader or baremetal: print both as loader|baremetal in the
         // audit
         Ok((k, k2, tag, target, pq_tag)) => crate::println!(

--- a/bao1x-boot/boot1/src/repl.rs
+++ b/bao1x-boot/boot1/src/repl.rs
@@ -695,22 +695,26 @@ impl Repl {
             "audit" => {
                 crate::audit::audit();
             }
-            "lockdown" => match bao1x_hal::sigcheck::validate_image(BOOT0_TO_BOOT1, None, None) {
-                Ok((k, _k2, _tag, _target, _pq)) => {
-                    if k != bao1x_api::pubkeys::DEVELOPER_KEY_SLOT {
-                        crate::println!("This will permanently disable developer mode. It cannot be undone!");
-                        crate::println!("Proceed? (type 'YES' in all caps to proceed)");
-                        self.lockdown_armed = true;
-                    } else {
-                        crate::println!(
-                            "Boot1 is signed with the developer key. Refusing to lockdown, as that would brick the chip."
-                        )
+            "lockdown" => {
+                match bao1x_hal::sigcheck::validate_image(BOOT0_TO_BOOT1, None, None, HardenedBool::TRUE) {
+                    Ok((k, _k2, _tag, _target, _pq)) => {
+                        if k != bao1x_api::pubkeys::DEVELOPER_KEY_SLOT {
+                            crate::println!(
+                                "This will permanently disable developer mode. It cannot be undone!"
+                            );
+                            crate::println!("Proceed? (type 'YES' in all caps to proceed)");
+                            self.lockdown_armed = true;
+                        } else {
+                            crate::println!(
+                                "Boot1 is signed with the developer key. Refusing to lockdown, as that would brick the chip."
+                            )
+                        }
+                    }
+                    Err(_e) => {
+                        crate::println!("Boot1 has no valid signature, lockdown would brick the chip.")
                     }
                 }
-                Err(_e) => {
-                    crate::println!("Boot1 has no valid signature, lockdown would brick the chip.")
-                }
-            },
+            }
             "self_destruct" => {
                 if !matches!(args.as_slice(), [s] if s == "void_my_warrantee") {
                     return Err(Error::help(

--- a/bao1x-boot/boot1/src/secboot.rs
+++ b/bao1x-boot/boot1/src/secboot.rs
@@ -1,5 +1,5 @@
 use bao1x_api::{
-    Boot1DeveloperState, DEVELOPER_MODE, PARANOID_MODE, PARANOID_MODE_DUPE, bollard,
+    Boot1DeveloperState, DEVELOPER_MODE, HardenedBool, PARANOID_MODE, PARANOID_MODE_DUPE, bollard,
     pubkeys::BOOT1_TO_LOADER_OR_BAREMETAL,
 };
 use bao1x_hal::hardening::{Csprng, disable_clock_skipping, reseed_skipping, setup_clock_skipping};
@@ -66,7 +66,12 @@ pub fn try_boot(or_die: bool, csprng: &mut Csprng) {
 
     // loader is at the same offset as baremetal. Accept either as valid boot.
     // This diverges if the signature check is successful
-    match bao1x_hal::sigcheck::validate_image(BOOT1_TO_LOADER_OR_BAREMETAL, None, Some(csprng)) {
+    match bao1x_hal::sigcheck::validate_image(
+        BOOT1_TO_LOADER_OR_BAREMETAL,
+        None,
+        Some(csprng),
+        HardenedBool::FALSE,
+    ) {
         Ok((key, key_inv, tag, target, pq_tag)) => {
             if paranoid1 == 0 && paranoid2 == 0 {
                 let tag_owned;
@@ -116,13 +121,18 @@ pub fn try_boot(or_die: bool, csprng: &mut Csprng) {
                     reseed_skipping(csprng.get_u32());
                 }
                 bollard!(bao1x_hal::sigcheck::die_no_std, 4);
-                bao1x_hal::sigcheck::validate_image(BOOT1_TO_LOADER_OR_BAREMETAL, None, Some(csprng))
-                    .unwrap_or_else(|_| bao1x_hal::hardening::die());
+                bao1x_hal::sigcheck::validate_image(
+                    BOOT1_TO_LOADER_OR_BAREMETAL,
+                    None,
+                    Some(csprng),
+                    HardenedBool::FALSE,
+                )
+                .unwrap_or_else(|_| bao1x_hal::hardening::die());
             }
 
             // this must be called before secrets are sealed
-            // #[cfg(feature = "fix-ifr")]
-            // fix_ifr();
+            #[cfg(feature = "fix-ifr")]
+            fix_ifr();
 
             csprng.random_delay();
             bollard!(bao1x_hal::sigcheck::die_no_std, 4);
@@ -164,9 +174,9 @@ pub fn try_boot(or_die: bool, csprng: &mut Csprng) {
     }
 }
 
-/*
 #[cfg(feature = "fix-ifr")]
 pub fn fix_ifr() {
+    crate::println!("fix-ifr present");
     let mut rram = bao1x_hal::rram::Reram::new();
     {
         let mut ifr_0x280 = [0u8; 32];
@@ -231,4 +241,3 @@ pub fn fix_ifr() {
         }
     }
 }
-*/

--- a/libs/bao1x-hal/src/sigcheck.rs
+++ b/libs/bao1x-hal/src/sigcheck.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
+use bao1x_api::HardenedBool;
 use bao1x_api::PQ_REVOCATION_DUPE_DISTANCE;
 use bao1x_api::REQUIRE_PQ;
 use bao1x_api::REQUIRE_PQ_DUPE;
@@ -56,6 +57,12 @@ use crate::udma::Spim;
 ///
 /// `csprng`, when Some, allows the image validator to insert random delays to harden against glitch attacks
 ///
+/// `audit`, when TRUE, skips modifying the anti-rollback counter. This is because the validate_image()
+///     routine can also be used to check an image in an update before it is applied, and the ARB should
+///     not be incremented before application. This does introduce a possible ARB-increment bypass vector,
+///     however as a glitch target I think it's relatively inherently hardened because missing the glitch
+///     even once still causes the ARB counter to be advanced during the normal boot path.
+///
 /// Returns either Ok(key_index, !key_index, tag, jump_target, pq_advisory) or Err
 ///   - `key_index` is returned twice, once as the compliment of itself, to harden the return value and to
 ///     facilitate hardened logic based on the return values.
@@ -74,6 +81,7 @@ pub fn validate_image(
     configuration: SecurityConfiguration,
     mut spim: Option<&mut Spim>,
     mut csprng: Option<&mut Csprng>,
+    audit: HardenedBool,
 ) -> Result<(usize, usize, [u8; 4], u32, Option<[u8; 4]>), String> {
     // Unpack the arguments
     let img_offset: *const u32 = configuration.image_ptr;
@@ -414,20 +422,40 @@ pub fn validate_image(
                         return Err(err_msg);
                     }
                     bollard!(die_no_std, 4);
-                    if arb_value < sig.sealed_data.anti_rollback {
-                        csprng.as_deref_mut().map(|rng| rng.random_delay());
-                        if sig.sealed_data.anti_rollback >= crate::acram::ONEWAY_MAX_VALUE {
-                            return Err(String::from("Proposed anti-rollback value out of range"));
-                        }
-                        // enforce a maximum "reasonable" increment - just as belt-and-suspenders
-                        assert!(sig.sealed_data.anti_rollback - arb_value < crate::acram::ONEWAY_MAX_DELTA);
-                        // increment anti-rollback counter to match the current value of the signed image
-                        bollard!(die_no_std, 4);
-                        while one_way_counters.get(arb).unwrap() < sig.sealed_data.anti_rollback {
+
+                    // only side-effect the ARB if we are *not* doing an audit of a staged image.
+                    csprng.as_deref_mut().map(|rng| rng.random_delay());
+                    match audit.is_true() {
+                        None => die_no_std(),
+                        Some(false) => {
                             bollard!(die_no_std, 4);
-                            // safety: anti-rollback counter argument is from a set of constants in bao1x_api
-                            // that are pre-validated.
-                            unsafe { one_way_counters.inc(arb).ok() };
+                            if arb_value < sig.sealed_data.anti_rollback {
+                                csprng.as_deref_mut().map(|rng| rng.random_delay());
+                                if sig.sealed_data.anti_rollback >= crate::acram::ONEWAY_MAX_VALUE {
+                                    return Err(String::from("Proposed anti-rollback value out of range"));
+                                }
+                                // enforce a maximum "reasonable" increment - just as belt-and-suspenders
+                                assert!(
+                                    sig.sealed_data.anti_rollback - arb_value
+                                        < crate::acram::ONEWAY_MAX_DELTA
+                                );
+                                // increment anti-rollback counter to match the current value of the signed
+                                // image
+                                bollard!(die_no_std, 4);
+                                while one_way_counters.get(arb).unwrap() < sig.sealed_data.anti_rollback {
+                                    bollard!(die_no_std, 4);
+                                    // safety: anti-rollback counter argument is from a set of constants in
+                                    // bao1x_api that are pre-validated.
+                                    unsafe { one_way_counters.inc(arb).ok() };
+                                }
+                            }
+                        }
+                        Some(true) => {
+                            bollard!(die_no_std, 4);
+                            // doing an audit - do not advance the ARB. An attacker could glitch into this
+                            // state and skip the ARB increment, but they'd have to be able to repeatedly do
+                            // this reliably to totally avoid the ARB increment
+                            // over the life of the attack.
                         }
                     }
                 }

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -267,7 +267,9 @@ pub unsafe extern "C" fn rust_entry(signed_buffer: *const usize, signature: u32)
     // Run kernel image validation now that the heap is set up.
     #[cfg(feature = "bao1x")]
     let detached_app = {
-        use bao1x_api::{PARANOID_MODE, PARANOID_MODE_DUPE, bollard, pubkeys::LOADER_TO_KERNEL};
+        use bao1x_api::{
+            HardenedBool, PARANOID_MODE, PARANOID_MODE_DUPE, bollard, pubkeys::LOADER_TO_KERNEL,
+        };
         use bao1x_hal::{ERASE_VALUE, buram::ERASURE_PROOF_RANGE_BYTES};
 
         let owc = bao1x_hal::acram::OneWayCounter::new();
@@ -278,7 +280,12 @@ pub unsafe extern "C" fn rust_entry(signed_buffer: *const usize, signature: u32)
         csprng.random_delay();
         bollard!(bao1x_hal::sigcheck::die_no_std, 4);
         // validate using the bao1x signature scheme
-        match bao1x_hal::sigcheck::validate_image(LOADER_TO_KERNEL, None, Some(&mut csprng)) {
+        match bao1x_hal::sigcheck::validate_image(
+            LOADER_TO_KERNEL,
+            None,
+            Some(&mut csprng),
+            HardenedBool::FALSE,
+        ) {
             Ok((key, key_inv, tag, _target, pq_tag)) => {
                 if paranoid1 == 0 && paranoid2 == 0 {
                     let tag_owned;
@@ -370,7 +377,12 @@ pub unsafe extern "C" fn rust_entry(signed_buffer: *const usize, signature: u32)
             use bao1x_api::pubkeys::LOADER_TO_DETACHED_APP;
 
             csprng.random_delay();
-            match bao1x_hal::sigcheck::validate_image(LOADER_TO_DETACHED_APP, None, Some(&mut csprng)) {
+            match bao1x_hal::sigcheck::validate_image(
+                LOADER_TO_DETACHED_APP,
+                None,
+                Some(&mut csprng),
+                HardenedBool::FALSE,
+            ) {
                 Ok((key, key_inv, tag, _target, pq_tag)) => {
                     if paranoid1 == 0 && paranoid2 == 0 {
                         let tag_owned;

--- a/loader/src/platform/bao1x/swap.rs
+++ b/loader/src/platform/bao1x/swap.rs
@@ -256,8 +256,12 @@ impl SwapHal {
                     // boot to encrypt the swap memory to the local key. Once this is done, the TOCTOU is
                     // gone.
                     crate::println!("Fresh swap image found - checking signature before proceeding");
-                    match bao1x_hal::sigcheck::validate_image(LOADER_TO_SWAP, Some(&mut hal.flash_spim), None)
-                    {
+                    match bao1x_hal::sigcheck::validate_image(
+                        LOADER_TO_SWAP,
+                        Some(&mut hal.flash_spim),
+                        None,
+                        HardenedBool::FALSE,
+                    ) {
                         Ok((k, k2, tag, _target, pq_tag)) => {
                             let tag_owned;
                             println!(

--- a/services/bao1x-hal-service/src/trng/dabao.rs
+++ b/services/bao1x-hal-service/src/trng/dabao.rs
@@ -27,15 +27,11 @@ impl Trng {
         // has already been conditioned and whitened, so we can use it directly.
         let seed_l = xous::create_server_id().unwrap().to_array();
         let seed_h = xous::create_server_id().unwrap().to_array();
-        for chunk in seed[..16].chunks_mut(4) {
-            for s in seed_l {
-                chunk.copy_from_slice(&s.to_le_bytes())
-            }
+        for (chunk, s) in seed[..16].chunks_mut(4).zip(seed_l.iter()) {
+            chunk.copy_from_slice(&s.to_le_bytes());
         }
-        for chunk in seed[16..].chunks_mut(4) {
-            for s in seed_h {
-                chunk.copy_from_slice(&s.to_le_bytes())
-            }
+        for (chunk, s) in seed[16..].chunks_mut(4).zip(seed_h.iter()) {
+            chunk.copy_from_slice(&s.to_le_bytes());
         }
         Ok(Trng { csprng: RefCell::new(ChaCha8Rng::from_seed(seed)), mode: api::TrngTestMode::Raw })
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -764,7 +764,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .target_baremetal_bao1x("bao1x-boot1")
                 .add_loader_feature("oem-baosec-lite")
                 // todo: remove this after the update is published
-                // .add_loader_feature("fix-ifr")
+                .add_loader_feature("fix-ifr")
                 .set_sigblock_size(sigblock_size);
         }
 


### PR DESCRIPTION
Fix bricking issue on A1 devices because boot0 anti-rollback is being advanced by the incoming image audit without the incoming image actually being applied.