### PR TITLE
Fix arb check

### DIFF
--- a/libs/bao1x-hal/src/sigcheck.rs
+++ b/libs/bao1x-hal/src/sigcheck.rs
@@ -422,26 +422,29 @@ pub fn validate_image(
                         return Err(err_msg);
                     }
                     bollard!(die_no_std, 4);
-
-                    // only side-effect the ARB if we are *not* doing an audit of a staged image.
+                    // validate the audit flag
                     csprng.as_deref_mut().map(|rng| rng.random_delay());
-                    match audit.is_true() {
-                        None => die_no_std(),
-                        Some(false) => {
-                            bollard!(die_no_std, 4);
-                            if arb_value < sig.sealed_data.anti_rollback {
-                                csprng.as_deref_mut().map(|rng| rng.random_delay());
-                                if sig.sealed_data.anti_rollback >= crate::acram::ONEWAY_MAX_VALUE {
-                                    return Err(String::from("Proposed anti-rollback value out of range"));
-                                }
-                                // enforce a maximum "reasonable" increment - just as belt-and-suspenders
-                                assert!(
-                                    sig.sealed_data.anti_rollback - arb_value
-                                        < crate::acram::ONEWAY_MAX_DELTA
-                                );
-                                // increment anti-rollback counter to match the current value of the signed
-                                // image
-                                bollard!(die_no_std, 4);
+                    if audit.is_true().is_none() {
+                        die_no_std();
+                    }
+                    if arb_value < sig.sealed_data.anti_rollback {
+                        bollard!(die_no_std, 4);
+                        csprng.as_deref_mut().map(|rng| rng.random_delay());
+                        if sig.sealed_data.anti_rollback >= crate::acram::ONEWAY_MAX_VALUE {
+                            return Err(String::from("Proposed anti-rollback value out of range"));
+                        }
+                        // enforce a maximum "reasonable" increment - just as belt-and-suspenders
+                        if sig.sealed_data.anti_rollback - arb_value >= crate::acram::ONEWAY_MAX_DELTA {
+                            return Err(String::from("Proposed anti-rollback increment out of range"));
+                        }
+                        // increment anti-rollback counter to match the current value of the signed
+                        // image
+                        bollard!(die_no_std, 4);
+                        csprng.as_deref_mut().map(|rng| rng.random_delay());
+                        // only side-effect the ARB if we are *not* doing an audit of a staged image.
+                        match audit.is_true() {
+                            None => die_no_std(),
+                            Some(false) => {
                                 while one_way_counters.get(arb).unwrap() < sig.sealed_data.anti_rollback {
                                     bollard!(die_no_std, 4);
                                     // safety: anti-rollback counter argument is from a set of constants in
@@ -449,13 +452,13 @@ pub fn validate_image(
                                     unsafe { one_way_counters.inc(arb).ok() };
                                 }
                             }
-                        }
-                        Some(true) => {
-                            bollard!(die_no_std, 4);
-                            // doing an audit - do not advance the ARB. An attacker could glitch into this
-                            // state and skip the ARB increment, but they'd have to be able to repeatedly do
-                            // this reliably to totally avoid the ARB increment
-                            // over the life of the attack.
+                            Some(true) => {
+                                bollard!(die_no_std, 4);
+                                // doing an audit - do not advance the ARB. An attacker could glitch into this
+                                // state and skip the ARB increment, but they'd have to be able to repeatedly
+                                // do this reliably to totally avoid the ARB
+                                // increment over the life of the attack.
+                            }
                         }
                     }
                 }

--- a/tools/src/bin/xous-sign-image.rs
+++ b/tools/src/bin/xous-sign-image.rs
@@ -150,7 +150,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
 
     let arb_override = if let Some(arb_str) = matches.value_of("antirollback-override") {
-        parse_u32(arb_str).ok()
+        Some(parse_u32(arb_str).expect("Malformed antirollback override"))
     } else {
         None
     };


### PR DESCRIPTION
This pulls the ARB value sanity-check into the audit path, instead of skipping it.