### PR TITLE
fix potential EP0 buffer overrun

### DIFF
--- a/bao1x-boot/boot-updater/src/platform/bao1x/usb/driver.rs
+++ b/bao1x-boot/boot-updater/src/platform/bao1x/usb/driver.rs
@@ -258,10 +258,15 @@ fn handle_event(this: &mut CorigineUsb, event_trb: &mut EventTrbS) -> CrgEvent {
                         this.set_addr(w_value as u8, CRG_INT_TARGET);
                     }
                     USB_REQ_SET_SEL => {
+                        // SET_SEL (USB 3.x, U1/U2 System Exit Latency) is not valid on this device:
+                        // bcdUSB is 0x0200 and SS is disabled (U3PORTPMSC/U2PORTPMSC zeroed in init).
+                        // USB 2.0 sec 9.2.7 requires stalling unsupported standard requests.
+                        // Never queue a host-controlled wLength into ep0_buf: the EP0 request buffer
+                        // is CRG_UDC_EP0_REQBUFSIZE bytes and CRG_UDC_APP_BUFOFFSET starts immediately
+                        // after it, so an over-long request walks forward into the EP1 app buffer.
                         crate::println_d!("USB_REQ_SET_SEL");
-                        this.ep0_receive(this.ep0_buf.load(Ordering::SeqCst) as usize, w_length as usize, 0);
-                        delay(100);
-                        crate::println_d!("SEL_VALUE NOT HANDLED");
+                        crate::println_d!("*** UNSUPPORTED (stall) ***");
+                        this.ep_halt(0, USB_RECV);
                     }
                     USB_REQ_SET_ISOCH_DELAY => {
                         crate::println_d!("USB_REQ_SET_ISOCH_DELAY");
@@ -389,9 +394,7 @@ fn handle_event(this: &mut CorigineUsb, event_trb: &mut EventTrbS) -> CrgEvent {
                         // SET_LINE_CODING (host -> device, 7 bytes)
                         // crate::println_d!("CDC SET_LINE_CODING");
                         let length = w_length as usize;
-                        if length == 7 {
-                            // queue EP0 OUT to receive the line coding structure
-                            this.ep0_receive(this.ep0_buf.load(Ordering::SeqCst) as usize, length, 0);
+                        if length == 7 && this.ep0_receive_bounded(length, 0).is_ok() {
                             // when complete, just ignore or store it
                         } else {
                             this.ep_halt(0, USB_RECV);

--- a/bao1x-boot/boot1/src/platform/bao1x/usb/driver.rs
+++ b/bao1x-boot/boot1/src/platform/bao1x/usb/driver.rs
@@ -258,10 +258,15 @@ fn handle_event(this: &mut CorigineUsb, event_trb: &mut EventTrbS) -> CrgEvent {
                         this.set_addr(w_value as u8, CRG_INT_TARGET);
                     }
                     USB_REQ_SET_SEL => {
+                        // SET_SEL (USB 3.x, U1/U2 System Exit Latency) is not valid on this device:
+                        // bcdUSB is 0x0200 and SS is disabled (U3PORTPMSC/U2PORTPMSC zeroed in init).
+                        // USB 2.0 sec 9.2.7 requires stalling unsupported standard requests.
+                        // Never queue a host-controlled wLength into ep0_buf: the EP0 request buffer
+                        // is CRG_UDC_EP0_REQBUFSIZE bytes and CRG_UDC_APP_BUFOFFSET starts immediately
+                        // after it, so an over-long request walks forward into the EP1 app buffer.
                         crate::println_d!("USB_REQ_SET_SEL");
-                        this.ep0_receive(this.ep0_buf.load(Ordering::SeqCst) as usize, w_length as usize, 0);
-                        delay(100);
-                        crate::println_d!("SEL_VALUE NOT HANDLED");
+                        crate::println_d!("*** UNSUPPORTED (stall) ***");
+                        this.ep_halt(0, USB_RECV);
                     }
                     USB_REQ_SET_ISOCH_DELAY => {
                         crate::println_d!("USB_REQ_SET_ISOCH_DELAY");
@@ -397,9 +402,7 @@ fn handle_event(this: &mut CorigineUsb, event_trb: &mut EventTrbS) -> CrgEvent {
                         // SET_LINE_CODING (host -> device, 7 bytes)
                         // crate::println_d!("CDC SET_LINE_CODING");
                         let length = w_length as usize;
-                        if length == 7 {
-                            // queue EP0 OUT to receive the line coding structure
-                            this.ep0_receive(this.ep0_buf.load(Ordering::SeqCst) as usize, length, 0);
+                        if length == 7 && this.ep0_receive_bounded(length, 0).is_ok() {
                             // when complete, just ignore or store it
                         } else {
                             this.ep_halt(0, USB_RECV);

--- a/baremetal/src/platform/bao1x/usb/driver.rs
+++ b/baremetal/src/platform/bao1x/usb/driver.rs
@@ -207,11 +207,15 @@ fn handle_event(this: &mut CorigineUsb, event_trb: &mut EventTrbS) -> CrgEvent {
                         // crate::println_d!(" ******* set address done {}", w_value & 0xff);
                     }
                     USB_REQ_SET_SEL => {
+                        // SET_SEL (USB 3.x, U1/U2 System Exit Latency) is not valid on this device:
+                        // bcdUSB is 0x0200 and SS is disabled (U3PORTPMSC/U2PORTPMSC zeroed in init).
+                        // USB 2.0 sec 9.2.7 requires stalling unsupported standard requests.
+                        // Never queue a host-controlled wLength into ep0_buf: the EP0 request buffer
+                        // is CRG_UDC_EP0_REQBUFSIZE bytes and CRG_UDC_APP_BUFOFFSET starts immediately
+                        // after it, so an over-long request walks forward into the EP1 app buffer.
                         crate::println_d!("USB_REQ_SET_SEL");
-                        this.ep0_receive(this.ep0_buf.load(Ordering::SeqCst) as usize, w_length as usize, 0);
-                        delay(100);
-                        /* do set sel */
-                        crate::println_d!("SEL_VALUE NOT HANDLED");
+                        crate::println_d!("*** UNSUPPORTED (stall) ***");
+                        this.ep_halt(0, USB_RECV);
                     }
                     USB_REQ_SET_ISOCH_DELAY => {
                         crate::println_d!("USB_REQ_SET_ISOCH_DELAY");
@@ -304,9 +308,7 @@ fn handle_event(this: &mut CorigineUsb, event_trb: &mut EventTrbS) -> CrgEvent {
                         // SET_LINE_CODING (host -> device, 7 bytes)
                         crate::println_d!("CDC SET_LINE_CODING");
                         let length = w_length as usize;
-                        if length == 7 {
-                            // queue EP0 OUT to receive the line coding structure
-                            this.ep0_receive(this.ep0_buf.load(Ordering::SeqCst) as usize, length, 0);
+                        if length == 7 && this.ep0_receive_bounded(length, 0).is_ok() {
                             // when complete, just ignore or store it
                         } else {
                             this.ep_halt(0, USB_RECV);

--- a/libs/bao1x-hal/src/usb/driver.rs
+++ b/libs/bao1x-hal/src/usb/driver.rs
@@ -922,6 +922,10 @@ pub struct CorigineUsb {
     pub remaining_wr: Option<(usize, usize)>,
 }
 impl CorigineUsb {
+    /// Some UDCs commit whole packets, so the EP0 buffer must be a whole number of
+    /// max packet sizes (64 at HS/FS) for a `length <= capacity` check to be sufficient.
+    const _CHECK_EP0_SIZE: () = assert!(CRG_UDC_EP0_REQBUFSIZE % 64 == 0);
+
     /// Safety: this function is generally pretty unsafe because the underlying hardware needs raw pointers,
     /// and will mutate values underneath the OS with no regard for safety.
     ///
@@ -1861,7 +1865,26 @@ impl CorigineUsb {
         self.knock_doorbell(0);
     }
 
-    pub fn ep0_receive(&mut self, addr: usize, length: usize, intr_target: u32) {
+    /// Queue an EP0 OUT data stage into the driver-owned EP0 request buffer.
+    ///
+    /// The destination address is computed internally and the length is checked
+    /// against buffer capacity, so a host-controlled `wLength` can neither steer
+    /// nor overrun the DMA. Returns `Err` if `length` exceeds capacity; callers
+    /// must stall EP0 in that case.
+    pub fn ep0_receive_bounded(
+        &mut self,
+        length: usize,
+        intr_target: u32,
+    ) -> core::result::Result<(), Error> {
+        if length > CRG_UDC_EP0_REQBUFSIZE {
+            return Err(Error::InvalidState);
+        }
+        let addr = self.ifram_base_ptr + CRG_UDC_EP0_BUF_OFFSET;
+        self.ep0_receive(addr, length, intr_target);
+        Ok(())
+    }
+
+    fn ep0_receive(&mut self, addr: usize, length: usize, intr_target: u32) {
         let udc_ep = &mut self.udc_ep[0];
         let mut enq_pt =
             unsafe { udc_ep.enq_pt.load(Ordering::SeqCst).as_mut().expect("couldn't deref pointer") };
@@ -2821,8 +2844,7 @@ impl UsbBus for CorigineWrapper {
     /// be IN or OUT, but not both at the same time. Devices with both IN/OUT may leave this as
     /// an empty stub.
     fn set_ep0_out(&self) {
-        // let addr = self.core().ep0_buf.load(Ordering::SeqCst) as usize;
-        // self.core().ep0_receive(addr, 64, 0);
+        // this.ep0_receive_bounded(64, 0).expect("64 <= EP0 buffer");
     }
 
     /// Causes the USB peripheral to enter USB suspend mode, lowering power consumption and
@@ -3010,7 +3032,7 @@ pub fn handle_event_inner(this: &mut CorigineUsb, event_trb: &mut EventTrbS) -> 
                 crate::println!(
                     "HACK: setup ep0 receive for ACM class - we ignore the result, but the receive must exist"
                 );
-                this.ep0_receive(this.ep0_buf.load(Ordering::SeqCst) as usize, 7, 0);
+                this.ep0_receive_bounded(7, 0).expect("7 <= EP0 buffer");
             }
 
             ret = CrgEvent::Data(0, 0, 1);


### PR DESCRIPTION
SET_SEL is not valid on our link but we still handle it. This allows a host to potentially overrun the EP0 region into an adjacent buffer by cranking the size beyond the allocated limit. This introduces range checks and hardening to prevent this situation, and also reject the call correctly if it happens (it shouldn't happen as we aren't a USB3.0 device).