### PR TITLE
Fix Baochip keyboard keymap persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,7 @@ dependencies = [
  "bitfield",
  "bytemuck",
  "chrono",
+ "early_settings",
  "flatipc",
  "flatipc-derive",
  "log",

--- a/services/bao1x-hal-service/Cargo.toml
+++ b/services/bao1x-hal-service/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+early_settings = { path = "../early_settings" }
 utralib = { version = "0.1.27", optional = true, default-features = false, features = [
     "bao1x",
 ] }

--- a/services/bao1x-hal-service/src/servers/keyboard.rs
+++ b/services/bao1x-hal-service/src/servers/keyboard.rs
@@ -225,6 +225,7 @@ fn keyboard_bouncer() {
 
 fn keyboard_service() {
     let xns = xous_names::XousNames::new().unwrap();
+    let early_settings = early_settings::EarlySettings::new(&xns).unwrap();
 
     // "own" the KPC & Always-on registers
     #[cfg(feature = "board-baosec")]
@@ -411,14 +412,12 @@ fn keyboard_service() {
                     );
                 }
             }
-            Some(KeyboardOpcode::SelectKeyMap) => {
-                // only one key map for the input keyboard. Key mapping for translation of
-                // key presess to USB key codes should be set in the USB stack, not here.
-                unimplemented!()
-            }
+            Some(KeyboardOpcode::SelectKeyMap) => msg_scalar_unpack!(msg, km, _, _, _, {
+                early_settings.set_keymap(km).expect("cannot set early keymap");
+            }),
             Some(KeyboardOpcode::GetKeyMap) => msg_blocking_scalar_unpack!(msg, _, _, _, _, {
-                log::warn!("Defaulting to DVORAK map");
-                xous::return_scalar(msg.sender, KeyMap::Dvorak.into()).expect("can't retrieve keymap");
+                let kb_raw = early_settings.get_keymap().expect("cannot fetch early keymap");
+                xous::return_scalar(msg.sender, kb_raw).expect("can't retrieve keymap");
             }),
             #[cfg(feature = "board-baosec")]
             Some(KeyboardOpcode::SetRepeat) => msg_scalar_unpack!(msg, rate, delay, _, _, {


### PR DESCRIPTION
The Baochip keyboard service currently leaves SelectKeyMap unimplemented and hardcodes GetKeyMap to Dvorak.

This causes USB autotype on devices such as the DEF CON 34 Baochip to emit Dvorak-mapped HID codes when the host is using QWERTY.

This change wires bao1x-hal-service into the existing early_settings keymap persistence mechanism used by the standard Xous keyboard service:

- adds early_settings as a dependency
- persists SelectKeyMap values
- returns the persisted layout from GetKeyMap

I reproduced the issue on a DEF CON 34 Baochip. For example, the stored text:

    rxxb7oE^iWbAfsiLc!

was emitted as:

    obbn7sD^g<nAy;pPi!

The patched firmware builds successfully through the DC34 baosec-lite build path.