### PR TITLE
Baosec updater

### DIFF
--- a/bao1x-boot/boot-updater/src/update.rs
+++ b/bao1x-boot/boot-updater/src/update.rs
@@ -12,6 +12,7 @@ static BOOT0: &Aligned<[u8]> = &Aligned(*include_bytes!(env!("BOOT0_BIN")));
 #[unsafe(link_section = ".payload")]
 static BOOT1: &Aligned<[u8]> = &Aligned(*include_bytes!(env!("BOOT1_BIN")));
 
+#[cfg(feature = "boot0")]
 fn detect_stepping() -> &'static str {
     let mut rram = utralib::CSR::new(utralib::utra::rrc::HW_RRC_BASE as *mut u32);
     // this sets bit 12
@@ -180,6 +181,7 @@ pub fn run(mut csprng: &mut Csprng) -> bool {
     passing
 }
 
+#[cfg(feature = "boot0")]
 pub fn jump_to(target: usize, mask: usize) -> ! {
     // loader expects a0 to have the address of the kernel image pre-loaded
     let kernel_loc = bao1x_api::offsets::KERNEL_START;

--- a/libs/bao1x-hal/src/board/baosec.rs
+++ b/libs/bao1x-hal/src/board/baosec.rs
@@ -552,7 +552,6 @@ pub fn setup_trng_input_pin<T: IoSetup + IoGpio>(iox: &T) -> (IoxPort, u8) {
     (port, pin)
 }
 
-#[cfg(feature = "oem-baosec-lite")]
 pub fn get_power_off_pin() -> (IoxPort, u8) {
     let (port, pin) = (IoxPort::PF, 0);
     (port, pin)

--- a/tools/src/sign_image.rs
+++ b/tools/src/sign_image.rs
@@ -404,8 +404,8 @@ pub fn sign_image<P: AsRef<Path>>(
                     dst.populate_from(&fake_pk);
                 }
                 // fill in a "real" key for key 0
-                rand::rngs::OsRng.fill_bytes(&mut header.sealed_data.pubkeys_pq[0].tag); // tag may be random
                 header.sealed_data.pubkeys_pq[0].pk.copy_from_slice(&TEST_KEY_PQ_PUB); // however we need to have a correct pub key so we can sign it
+                header.sealed_data.pubkeys_pq[0].tag = *b"tpk0";
             }
 
             header._jal_instruction = generate_jal_x0(SIGBLOCK_LEN as isize)?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -831,6 +831,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
+        Some("bao1x-boot-updater") => {
+            let sigblock_size = bao1x_api::signatures::SIGBLOCK_LEN;
+            update_flash_origin(
+                "bao1x-boot/boot-updater/src/platform/bao1x/link.x",
+                (bao1x_api::BAREMETAL_START + sigblock_size + STATICS_LEN) as u32,
+            )?;
+            builder
+                .set_baremetal(true)
+                .target_baremetal_bao1x("boot-updater")
+                .set_sigblock_size(sigblock_size)
+                .is_updater(true, true);
+
+            if let Some(target) = &boot1_path {
+                builder.set_boot1(target.to_owned());
+            }
+        }
+
         Some("baosec") => {
             baosec_common(&mut builder)?;
         }


### PR DESCRIPTION
add support for baosec target in boot-updater

also fix a small bug in the pq key tag when generating fake third party keys