### PR TITLE
docs: fix dead GitHub collaboration guide link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions are welcome!
 
 Contributions can be bug reports, feature requests, testing and documentation
 in addition to code. Please see the github guide on
-[Collaborating on projects using issues and pull requests](https://help.github.com/categories/collaborating-on-projects-using-issues-and-pull-requests/) for details.
+[Collaborating on projects using issues and pull requests](https://docs.github.com/en/pull-requests) for details.
 
 Contributions to this project are accepted on an
 ["inbound=outbound"](https://opensource.com/law/11/7/trouble-harmony-part-1) basis.


### PR DESCRIPTION
The opening paragraph of `CONTRIBUTING.md` sends new contributors to

`help.github.com/categories/collaborating-on-projects-using-issues-and-pull-requests/`

which returns 404 — GitHub retired that category page. `https://docs.github.com/en/pull-requests` is the current hub for the same material and returns 200.

The other two `help.github.com` links in the file, for closing-issues keywords and adding a GPG key, still redirect correctly to `docs.github.com`, so I left them as they are — only the retired category URL is actually broken. One concern, one PR, per the Scope and Cadence section.

Per the Transparency section: the commit carries `Assisted-by: Claude Code (claude-opus-5)`, and this PR should carry the `AI` tag your policy asks for — I tried to set it and GitHub refused (`does not have permission to update the pull request`), since labels need collaborator rights, so please add it. Claude Code found this while sweeping the repository markdown through the GitHub API; I verified the dead URL, the replacement, and the two redirecting links myself before submitting.
