### PR TITLE
Keymap

### DIFF
--- a/apps-baosec/dc34-vault/src/main.rs
+++ b/apps-baosec/dc34-vault/src/main.rs
@@ -2,6 +2,7 @@ mod ux;
 use aes::{Aes256, cipher::BlockSizeUser};
 use aes_gcm_siv::aead::{Aead, Payload};
 use aes_gcm_siv::{Nonce, Tag};
+use bao1x_api::keyboard::KeyMap;
 use ux::*;
 mod itemcache;
 use itemcache::*;
@@ -24,7 +25,7 @@ mod tests;
 mod vendor_commands;
 
 use core::sync::atomic::{AtomicBool, Ordering};
-use std::io::Read;
+use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -294,6 +295,30 @@ fn main() -> ! {
     }
 
     let usb = usb_bao1x::UsbHid::new();
+    // setup the default keymap
+    match pddb.get(DC34_DICT, DC34_KEYMAP, None, false, false, None, None::<fn()>) {
+        Ok(mut entry) => {
+            let mut data = Vec::<u8>::new();
+            match entry.read_to_end(&mut data) {
+                Ok(4) => {
+                    let kbd_code = usize::from_le_bytes(data.try_into().unwrap());
+                    let kbd_decoded: KeyMap = kbd_code.into();
+                    log::info!("Setting host keyboard mapping to {:?}", kbd_decoded);
+                    usb.set_key_map(kbd_decoded);
+                }
+                _ => usb.set_key_map(KeyMap::Qwerty),
+            }
+        }
+        _ => {
+            // initialize the key
+            let mut kbd_key = pddb
+                .get(DC34_DICT, DC34_KEYMAP, None, true, true, None, None::<fn()>)
+                .expect("couldn't create PDDB key");
+            let qwerty_code: usize = KeyMap::Qwerty.into();
+            kbd_key.write(&qwerty_code.to_le_bytes()).ok();
+        }
+    }
+
     let mut menu_active = false;
     let mut jig_ready_seen = false;
     let mut mutation_param: u8 = 0;
@@ -1026,6 +1051,27 @@ fn main() -> ! {
                 } else {
                     usb.serial_clear_input_hooks();
                 }
+            }
+            Some(VaultOp::SetKeyMap) => {
+                let mut kbd_key = pddb
+                    .get(DC34_DICT, DC34_KEYMAP, None, true, true, None, None::<fn()>)
+                    .expect("couldn't get PDDB key");
+
+                modals.add_list_item("QWERTY").unwrap();
+                modals.add_list_item("Dvorak").unwrap();
+                modals.get_radiobutton("Select host keyboard mapping").unwrap();
+                let map_code: usize = match modals.get_radio_index() {
+                    Ok(code) => {
+                        if code == 1 {
+                            KeyMap::Dvorak.into()
+                        } else {
+                            KeyMap::Qwerty.into()
+                        }
+                    }
+                    _ => KeyMap::Qwerty.into(),
+                };
+                kbd_key.write(&map_code.to_le_bytes()).ok();
+                usb.set_key_map(map_code.into());
             }
             Some(VaultOp::Jig) => {
                 *mode.lock().unwrap() = VaultMode::FactoryTest;

--- a/apps-baosec/dc34-vault/src/submenu.rs
+++ b/apps-baosec/dc34-vault/src/submenu.rs
@@ -60,6 +60,13 @@ pub fn create_submenu(vault_conn: xous::CID, actions_conn: xous::CID, menu_mgr: 
         close_on_select: true,
     });
     menu_items.push(MenuItem {
+        name: String::from("Set keymap..."),
+        action_conn: Some(vault_conn),
+        action_opcode: VaultOp::SetKeyMap.to_u32().unwrap(),
+        action_payload: MenuPayload::Scalar([0, 0, 0, 0]),
+        close_on_select: true,
+    });
+    menu_items.push(MenuItem {
         name: String::from("Help"),
         action_conn: Some(vault_conn),
         action_opcode: VaultOp::MenuTokenHelp.to_u32().unwrap(),

--- a/apps-baosec/dc34-vault/src/vault_api.rs
+++ b/apps-baosec/dc34-vault/src/vault_api.rs
@@ -43,6 +43,7 @@ pub(crate) enum VaultOp {
     MenuUsernames,
     MenuFilter,
     UsbSerial,
+    SetKeyMap,
 
     /// Tour menu
     TourContinue,

--- a/libs/dc34-api/src/lib.rs
+++ b/libs/dc34-api/src/lib.rs
@@ -15,6 +15,7 @@ pub const DC34_IMAGE: &str = "image";
 pub const DC34_BIO: &str = "bio.code";
 pub const DC34_BIO_PINS: &str = "bio.pins";
 pub const DC34_BIO_CLK: &str = "bio.clk";
+pub const DC34_KEYMAP: &str = "keymap";
 
 pub const SERVER_NAME_VAULT2: &str = "_Vault2_";
 

--- a/services/usb-bao1x/src/api.rs
+++ b/services/usb-bao1x/src/api.rs
@@ -32,7 +32,7 @@ pub enum Opcode {
     /// Modify log level
     SetLogLevel = 12,
 
-    #[cfg(feature = "bao1x")]
+    /// Set the host-side key mapping (this translates data into e.g. dvorak or qwerty maps)
     SetKeyMap = 16,
 
     /// Send a U2F message

--- a/services/usb-bao1x/src/api.rs
+++ b/services/usb-bao1x/src/api.rs
@@ -32,6 +32,9 @@ pub enum Opcode {
     /// Modify log level
     SetLogLevel = 12,
 
+    #[cfg(feature = "bao1x")]
+    SetKeyMap = 16,
+
     /// Send a U2F message
     U2fTx = 128,
     /// Blocks the caller, waiting for a U2F message

--- a/services/usb-bao1x/src/lib.rs
+++ b/services/usb-bao1x/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod api;
 pub use api::*;
+use bao1x_api::keyboard::KeyMap;
 use num_traits::*;
 use packed_struct::PackedStruct;
 use rkyv::option::ArchivedOption;
@@ -415,6 +416,14 @@ impl UsbHid {
     }
 
     pub fn cid(&self) -> xous::CID { self.conn }
+
+    pub fn set_key_map(&self, map: KeyMap) {
+        send_message(
+            self.conn,
+            Message::new_blocking_scalar(Opcode::SetKeyMap.to_usize().unwrap(), map.into(), 0, 0, 0),
+        )
+        .unwrap();
+    }
 }
 
 use core::sync::atomic::{AtomicU32, Ordering};

--- a/services/usb-bao1x/src/main.rs
+++ b/services/usb-bao1x/src/main.rs
@@ -277,6 +277,8 @@ pub(crate) fn main_hw() -> ! {
     iox.set_gpio_pin_dir(se0_port, se0_pin, bao1x_api::IoxDir::Input); // release SE0 state, allowing for enumeration
     // NOTE: if SE0 is required, the KPC has to be un-configured to allow the SE0 I/O to actually be driven
 
+    let mut key_map = KeyMap::Qwerty;
+
     log::debug!("Entering main loop");
 
     let mut msg_opt = None;
@@ -481,21 +483,20 @@ pub(crate) fn main_hw() -> ! {
                     let code1 = scalar.arg2;
                     let code2 = scalar.arg3;
                     let autoup = scalar.arg4;
-                    let native_map = native_kbd.get_keymap().unwrap();
                     if code0 != 0 {
-                        cu.kbd_tx_queue.borrow_mut().push_back(match native_map {
+                        cu.kbd_tx_queue.borrow_mut().push_back(match key_map {
                             KeyMap::Dvorak => mappings::char_to_hid_code_dvorak(code0 as u8 as char)[0],
                             _ => mappings::char_to_hid_code_us101(code0 as u8 as char)[0],
                         });
                     }
                     if code1 != 0 {
-                        cu.kbd_tx_queue.borrow_mut().push_back(match native_map {
+                        cu.kbd_tx_queue.borrow_mut().push_back(match key_map {
                             KeyMap::Dvorak => mappings::char_to_hid_code_dvorak(code1 as u8 as char)[0],
                             _ => mappings::char_to_hid_code_us101(code1 as u8 as char)[0],
                         });
                     }
                     if code2 != 0 {
-                        cu.kbd_tx_queue.borrow_mut().push_back(match native_map {
+                        cu.kbd_tx_queue.borrow_mut().push_back(match key_map {
                             KeyMap::Dvorak => mappings::char_to_hid_code_dvorak(code2 as u8 as char)[0],
                             _ => mappings::char_to_hid_code_us101(code2 as u8 as char)[0],
                         });
@@ -529,10 +530,9 @@ pub(crate) fn main_hw() -> ! {
 
                 // check keymap on every call because we may need to toggle this for e.g. plugging
                 // into a new host with a different map
-                let native_map = native_kbd.get_keymap().unwrap();
                 for ch in usb_send.s.as_str().chars() {
                     // ASSUME: user's keyboard type matches the preference on their Precursor device.
-                    let codes = match native_map {
+                    let codes = match key_map {
                         KeyMap::Dvorak => mappings::char_to_hid_code_dvorak(ch),
                         _ => mappings::char_to_hid_code_us101(ch),
                     };
@@ -857,6 +857,11 @@ pub(crate) fn main_hw() -> ! {
                     let mut code = [0u8; 1];
                     cu.led_state.pack_to_slice(&mut code).unwrap();
                     scalar.arg1 = code[0] as usize;
+                }
+            }
+            Opcode::SetKeyMap => {
+                if let Some(scalar) = msg.body.scalar_message_mut() {
+                    key_map = KeyMap::from(scalar.arg1);
                 }
             }
             Opcode::InvalidCall => {


### PR DESCRIPTION
Sets the default key map for passwords to qwerty

Also adds a menu item to switch between key maps.

If people are using passwords generated by the device already, and not entering in their own passwords - set the key map to `dvorak` because that was the original default, and your passwords are actually typed through a dvorak key translation!