### PR TITLE
change keyboard default to dvorak

### DIFF
--- a/apps-baosec/dc34-vault/src/main.rs
+++ b/apps-baosec/dc34-vault/src/main.rs
@@ -314,8 +314,10 @@ fn main() -> ! {
             let mut kbd_key = pddb
                 .get(DC34_DICT, DC34_KEYMAP, None, true, true, None, None::<fn()>)
                 .expect("couldn't create PDDB key");
-            let qwerty_code: usize = KeyMap::Qwerty.into();
-            kbd_key.write(&qwerty_code.to_le_bytes()).ok();
+            // initialize to Dvorak, so that users who created passwords using the stock conference firmware
+            // don't have a surprising experience that their passwords stopped working on the firmware update
+            let kbd_code: usize = KeyMap::Dvorak.into();
+            kbd_key.write(&kbd_code.to_le_bytes()).ok();
         }
     }
 


### PR DESCRIPTION
the logic is:

- users who generated passwords using the stock conference firmware would have no change in behavior. However, their passwords would be "ceaser-cipher encrypted" due to the dvorak mapping applied to them.
- in the release notes we'll notify users of the need to change this before setting passwords, as those who are waiting for the update before using the device would likely also read the release notes?

The intersection of people who need to change this setting anyways are those who use the password feature *and* also enter legacy passwords through the manual UI.