### PR TITLE
Fix PTE take over vulnerability

### DIFF
--- a/kernel/src/arch/arm/mem.rs
+++ b/kernel/src/arch/arm/mem.rs
@@ -182,6 +182,55 @@ impl MemoryMapping {
             false,
         )
     }
+
+    /// Undo a reservation made by `reserve_address`. This will refuse to
+    /// unmap a page that has actually been mapped, and is a no-op if nothing
+    /// was ever reserved at this address.
+    ///
+    /// This code is entirely machine generated in an attempt to try and support
+    /// the ARM target with improvements in the mainline Xous code, but without
+    /// a target to test against this is just a best-effort guess at what this
+    /// might be. An actual ARM architecture expert should review this.
+    ///
+    /// Generated with Claude Opus 5 (medium) with a prompt asking for a parallel
+    /// implementation of unreserve_address() from the RV32 code, given the current
+    /// ARM code as a starting point.
+    pub fn unreserve_address(&self, addr: usize) -> Result<(), xous_kernel::Error> {
+        let v = VirtualAddress::new(addr as u32);
+        let vpn1 = v.translation_table_index();
+        let vpn2 = v.page_table_index();
+        assert!(vpn1 < 4096);
+        assert!(vpn2 < 256);
+
+        let l1_pt_addr = PAGE_TABLE_ROOT_OFFSET;
+        let l2_pt_addr = PAGE_TABLE_OFFSET + vpn1 * PAGE_SIZE;
+
+        let existing_l1_entry = unsafe {
+            ((l1_pt_addr as *mut u32).add(vpn1) as *mut TranslationTableDescriptor).read_volatile()
+        };
+        if existing_l1_entry.get_type() == TranslationTableType::Invalid {
+            // No L2 table, so nothing was ever reserved here.
+            return Ok(());
+        }
+
+        let l2_entry_ptr = unsafe { (l2_pt_addr as *mut u32).add(vpn2) };
+        let existing_l2_entry = unsafe { (l2_entry_ptr as *mut PageTableDescriptor).read_volatile() };
+
+        // Refuse to touch a live mapping. Only undo reservations.
+        // Reservations go through `map_page_inner` with `MemoryFlags::RESERVE`,
+        // which deliberately leaves the `VALID` bit clear because the page
+        // hasn't been backed or zeroed yet.
+        if existing_l2_entry.as_u32() & u32::from(SMALL_PAGE_FLAGS::VALID::Enable) != 0 {
+            return Err(xous_kernel::Error::ShareViolation);
+        }
+
+        unsafe {
+            l2_entry_ptr.write_volatile(0);
+            flush_mmu();
+        }
+
+        Ok(())
+    }
 }
 
 pub fn hand_page_to_user(virt: *mut u8) -> Result<(), xous_kernel::Error> {

--- a/kernel/src/arch/hosted/mem.rs
+++ b/kernel/src/arch/hosted/mem.rs
@@ -41,6 +41,8 @@ impl MemoryMapping {
     ) -> Result<(), Error> {
         Ok(())
     }
+
+    pub fn unreserve_address(&self, _addr: usize) -> Result<(), Error> { Ok(()) }
 }
 
 /// Determine whether a virtual address has been mapped

--- a/kernel/src/arch/riscv/mem.rs
+++ b/kernel/src/arch/riscv/mem.rs
@@ -410,9 +410,35 @@ impl MemoryMapping {
         let l0_pt = &mut unsafe { &mut (*(l0pt_virt as *mut LeafPageTable)) };
         let current_mapping = l0_pt.entries[vpn0];
         if current_mapping & 1 == 1 {
-            return Ok(());
+            // can't double-reserve pages
+            return Err(xous_kernel::Error::ShareViolation);
         }
         l0_pt.entries[vpn0] = translate_flags(flags).bits();
+        Ok(())
+    }
+
+    pub fn unreserve_address(&self, addr: usize) -> Result<(), xous_kernel::Error> {
+        let vpn1 = (addr >> 22) & ((1 << 10) - 1);
+        let vpn0 = (addr >> 12) & ((1 << 10) - 1);
+
+        let l1_pt = unsafe { &mut (*(PAGE_TABLE_ROOT_OFFSET as *mut RootPageTable)) };
+        if l1_pt.entries[vpn1] & MMUFlags::VALID.bits() == 0 {
+            // No leaf table, so nothing was ever reserved here.
+            return Ok(());
+        }
+
+        let l0pt_virt = PAGE_TABLE_OFFSET + vpn1 * PAGE_SIZE;
+        let l0_pt = unsafe { &mut (*(l0pt_virt as *mut LeafPageTable)) };
+
+        // Refuse to touch a live mapping. Only undo reservations.
+        // This works under the assumption that the flags going into reserve_address don't already include the
+        // valid bit, which I believe is correct because reservations can't mark a page as valid as it
+        // hasn't been zero'd yet.
+        if l0_pt.entries[vpn0] & MMUFlags::VALID.bits() != 0 {
+            return Err(xous_kernel::Error::ShareViolation);
+        }
+
+        l0_pt.entries[vpn0] = 0;
         Ok(())
     }
 }

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -915,11 +915,16 @@ impl MemoryManager {
             match action {
                 ClaimReleaseMove::Claim => {
                     if allow_alias {
-                        if owner_addr.is_some() {
-                            println!(
-                                "WARN: aliasing physical address {:x} {:?} (me: {:?})",
-                                addr, owner_addr, pid
-                            );
+                        if let Some(previous_owner) = owner_addr {
+                            if previous_owner.get() == pid.get() {
+                                // only allow aliases within the same process
+                                println!(
+                                    "WARN: aliasing physical address {:x} {:?} (me: {:?})",
+                                    addr, owner_addr, pid
+                                );
+                            } else {
+                                return Err(xous_kernel::Error::MemoryInUse);
+                            }
                         }
                         *owner_addr = Some(pid);
                     } else {

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -590,6 +590,13 @@ impl MemoryManager {
         (phys as usize) >= self.ram_start && (phys as usize) < self.ram_start + self.ram_size
     }
 
+    #[cfg(feature = "bao1x")]
+    /// This test is needed because peripheral memory is unmappable, but peripherals are not.
+    pub fn is_peripheral_ram(&self, phys: usize) -> bool {
+        phys >= utralib::HW_IFRAM0_MEM
+            && phys < utralib::HW_IFRAM0_MEM + utralib::HW_IFRAM0_MEM_LEN + utralib::HW_IFRAM1_MEM_LEN
+    }
+
     #[cfg(feature = "memmap-flash")]
     pub fn is_mapped_flash(&self, virt: *mut u8) -> bool {
         // true if the address starts with the bitmask of the virtual start of the MMAP region
@@ -629,8 +636,12 @@ impl MemoryManager {
         #[cfg(baremetal)]
         if phys == 0
             && (flags & MemoryFlags::VIRT == MemoryFlags::VIRT)
-            && ((virt_ptr as usize & MMAP_VIRT_BASE) == MMAP_VIRT_BASE)
+            && ((virt_ptr as usize & 0xF000_0000) == MMAP_VIRT_BASE)
         {
+            // only the range from 0xB000_0000 - 0xBFFF_FFFF is reserved for this purpose
+            if (virt_ptr as usize).saturating_add(size) & 0xF000_0000 != MMAP_VIRT_BASE {
+                return Err(xous_kernel::Error::BadAddress);
+            }
             let mut mm = MemoryMapping::current();
             // round down any virtual address to the next page
             let start = virt_ptr as usize & !(PAGE_SIZE - 1);
@@ -919,7 +930,7 @@ impl MemoryManager {
                             if previous_owner.get() == pid.get() {
                                 // only allow aliases within the same process
                                 println!(
-                                    "WARN: aliasing physical address {:x} {:?} (me: {:?})",
+                                    "WARN: aliasing physical address {:x} {:?} (requester: {:?})",
                                     addr, owner_addr, pid
                                 );
                             } else {
@@ -932,7 +943,7 @@ impl MemoryManager {
                             *owner_addr = Some(pid);
                         } else {
                             println!(
-                                "ERR: physical address {:x} already used by {:?} (claimer: {:?})",
+                                "ERR: physical address {:x} already used by {:?} (requester: {:?})",
                                 addr, owner_addr, pid
                             );
                             return Err(xous_kernel::Error::MemoryInUse);
@@ -982,7 +993,7 @@ impl MemoryManager {
                     } else {
                         // even self-claims should be denied
                         println!(
-                            "ERR: swap claim already in use by {:x}({:?}) (claimer: {:?})",
+                            "ERR: swap claim already in use by {:x}({:?}) (requester: {:?})",
                             owner_addr.get_raw_vpn(),
                             owner_addr.get_pid(),
                             pid
@@ -1009,7 +1020,7 @@ impl MemoryManager {
 
         let mut offset = 0;
         // Happy path: The address is in main RAM
-        if addr >= self.ram_start && addr < self.ram_start + self.ram_size {
+        if self.is_main_memory(addr as *mut u8) {
             offset += (addr - self.ram_start) / PAGE_SIZE;
             #[cfg(not(feature = "swap"))]
             return unsafe { action_inner(&mut MEMORY_ALLOCATIONS[offset], pid, action, false, addr) };
@@ -1043,7 +1054,14 @@ impl MemoryManager {
                     // -------------------------------
 
                     offset += (addr - (region.mem_start as usize)) / PAGE_SIZE;
-                    return action_inner(&mut EXTRA_ALLOCATIONS[offset], pid, action, true, addr);
+                    if self.is_peripheral_ram(offset) {
+                        // don't allow aliasing of peripheral RAM, because peripheral RAM can be unmapped
+                        return action_inner(&mut EXTRA_ALLOCATIONS[offset], pid, action, false, addr);
+                    } else {
+                        // aliasing is allowed, however, unmapping is NOT allowed. This allows us to not have
+                        // to do reference counting to avoid unmap races
+                        return action_inner(&mut EXTRA_ALLOCATIONS[offset], pid, action, true, addr);
+                    }
                 }
                 offset += region.mem_size as usize / PAGE_SIZE;
             }

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -590,11 +590,25 @@ impl MemoryManager {
         (phys as usize) >= self.ram_start && (phys as usize) < self.ram_start + self.ram_size
     }
 
-    #[cfg(feature = "bao1x")]
     /// This test is needed because peripheral memory is unmappable, but peripherals are not.
+    /// The characteristic of peripheral memory is that it is:
+    ///   - not in the allocation pool for stack/heap RAM
+    ///   - primarily used for I/O buffers
+    ///   - in an isolated address space
+    ///   - multi-purpose in nature (i.e., not a dedicated frame buffer that would only have one sensible
+    ///     driver mapping)
+    /// The last point - the fact that the memory could have multiple purposes - is the reason that
+    /// drives the need to potentially unmap it, as it may need to be handed off between drivers
+    /// that are mutually exclusive in use.
+    ///
+    /// Peripheral memory currently only exists on the bao1x target.
     pub fn is_peripheral_ram(&self, phys: usize) -> bool {
-        phys >= utralib::HW_IFRAM0_MEM
-            && phys < utralib::HW_IFRAM0_MEM + utralib::HW_IFRAM0_MEM_LEN + utralib::HW_IFRAM1_MEM_LEN
+        #[cfg(feature = "bao1x")]
+        let ret = phys >= utralib::HW_IFRAM0_MEM
+            && phys < utralib::HW_IFRAM0_MEM + utralib::HW_IFRAM0_MEM_LEN + utralib::HW_IFRAM1_MEM_LEN;
+        #[cfg(not(feature = "bao1x"))]
+        let ret = false;
+        ret
     }
 
     #[cfg(feature = "memmap-flash")]

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -529,11 +529,16 @@ impl MemoryManager {
         }
 
         let mut mm = MemoryMapping::current();
-        for virt in (virt..(virt + size)).step_by(PAGE_SIZE) {
-            // FIXME: Un-reserve addresses if we encounter an error here
-            mm.reserve_address(self, virt, flags)?;
+        for addr in (virt..(virt + size)).step_by(PAGE_SIZE) {
+            if let Err(e) = mm.reserve_address(self, addr, flags) {
+                // Roll back the prefix we already reserved.
+                for undo in (virt..addr).step_by(PAGE_SIZE) {
+                    mm.unreserve_address(undo).expect("Internal error: couldn't unwind failed reservation");
+                }
+                return Err(e);
+            }
         }
-        unsafe { xous_kernel::MemoryRange::new(virt_ptr as usize, size) }
+        unsafe { xous_kernel::MemoryRange::new(virt as usize, size) }
     }
 
     /// Attempt to allocate a single page from the default section.
@@ -885,6 +890,8 @@ impl MemoryManager {
             owner_addr: &mut Option<PID>,
             pid: PID,
             action: ClaimReleaseMove,
+            allow_alias: bool,
+            addr: usize,
         ) -> Result<(), xous_kernel::Error> {
             if let Some(current_pid) = *owner_addr {
                 if current_pid != pid {
@@ -906,7 +913,28 @@ impl MemoryManager {
                 }
             }
             match action {
-                ClaimReleaseMove::Claim | ClaimReleaseMove::Move(_) => {
+                ClaimReleaseMove::Claim => {
+                    if allow_alias {
+                        if owner_addr.is_some() {
+                            println!(
+                                "WARN: aliasing physical address {:x} {:?} (me: {:?})",
+                                addr, owner_addr, pid
+                            );
+                        }
+                        *owner_addr = Some(pid);
+                    } else {
+                        if owner_addr.is_none() {
+                            *owner_addr = Some(pid);
+                        } else {
+                            println!(
+                                "ERR: physical address {:x} already used by {:?} (claimer: {:?})",
+                                addr, owner_addr, pid
+                            );
+                            return Err(xous_kernel::Error::MemoryInUse);
+                        }
+                    }
+                }
+                ClaimReleaseMove::Move(_) => {
                     *owner_addr = Some(pid);
                 }
                 ClaimReleaseMove::Release => {
@@ -943,7 +971,21 @@ impl MemoryManager {
                 }
             }
             match action {
-                ClaimReleaseMove::Claim | ClaimReleaseMove::Move(_) => {
+                ClaimReleaseMove::Claim => {
+                    if owner_addr.is_none() {
+                        unsafe { owner_addr.update(Some(pid), Some(addr)) };
+                    } else {
+                        // even self-claims should be denied
+                        println!(
+                            "ERR: swap claim already in use by {:x}({:?}) (claimer: {:?})",
+                            owner_addr.get_raw_vpn(),
+                            owner_addr.get_pid(),
+                            pid
+                        );
+                        return Err(xous_kernel::Error::MemoryInUse);
+                    }
+                }
+                ClaimReleaseMove::Move(_) => {
                     unsafe { owner_addr.update(Some(pid), Some(addr)) };
                 }
                 ClaimReleaseMove::Release => {
@@ -965,7 +1007,7 @@ impl MemoryManager {
         if addr >= self.ram_start && addr < self.ram_start + self.ram_size {
             offset += (addr - self.ram_start) / PAGE_SIZE;
             #[cfg(not(feature = "swap"))]
-            return unsafe { action_inner(&mut MEMORY_ALLOCATIONS[offset], pid, action) };
+            return unsafe { action_inner(&mut MEMORY_ALLOCATIONS[offset], pid, action, false, addr) };
             #[cfg(feature = "swap")]
             return unsafe { action_inner_tracking(&mut MEMORY_ALLOCATIONS[offset], pid, action, addr) };
         }
@@ -996,7 +1038,7 @@ impl MemoryManager {
                     // -------------------------------
 
                     offset += (addr - (region.mem_start as usize)) / PAGE_SIZE;
-                    return action_inner(&mut EXTRA_ALLOCATIONS[offset], pid, action);
+                    return action_inner(&mut EXTRA_ALLOCATIONS[offset], pid, action, true, addr);
                 }
                 offset += region.mem_size as usize / PAGE_SIZE;
             }

--- a/kernel/src/services.rs
+++ b/kernel/src/services.rs
@@ -1379,7 +1379,7 @@ impl SystemServices {
         if dest_virt as usize & 0xfff != 0 {
             return Err(xous_kernel::Error::BadAddress);
         }
-        if (dest_virt as usize) + len > USER_AREA_END {
+        if (dest_virt as usize).saturating_add(len) > USER_AREA_END {
             return Err(xous_kernel::Error::BadAddress);
         }
 

--- a/kernel/src/swap.rs
+++ b/kernel/src/swap.rs
@@ -160,7 +160,6 @@ impl SwapAlloc {
 
     pub fn set_wired(&mut self) { self.vpn |= SWAP_FLG_WIRED; }
 
-    #[cfg(feature = "debug-swap-verbose")]
     pub fn get_raw_vpn(&self) -> u32 { self.vpn }
 
     pub fn get_timestamp(&self) -> u32 { self.timestamp }

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -798,7 +798,7 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
             if cfg!(baremetal) && virt & 0xfff != 0 {
                 return Err(xous_kernel::Error::BadAlignment);
             }
-            if virt >= USER_AREA_END || virt + size >= USER_AREA_END {
+            if virt >= USER_AREA_END || virt.saturating_add(size) >= USER_AREA_END {
                 // don't allow processes to unmap kernel or page table memory
                 return Err(xous_kernel::Error::BadAddress);
             }
@@ -1142,15 +1142,21 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
                         let paddr = crate::arch::mem::virt_to_phys(vaddr_to_release).unwrap() as usize;
                         #[cfg(feature = "debug-swap-verbose")]
                         println!("ReleaseMemory - paddr {:x}", paddr);
-                        // this call unmaps the virtual page from the page table
-                        crate::arch::mem::unmap_page_inner(mm, vaddr_to_release)
-                            .expect("couldn't unmap page");
-                        // This call releases the physical page from the RPT - the pid has to match that of
-                        // the original owner. This is the "pointy end" of the stick;
-                        // after this call, the memory is now back into the free pool.
-                        mm.release_page_swap(paddr as *mut usize, PID::new(original_pid).unwrap())
-                            .expect("couldn't free page that was swapped out");
-                        Ok(xous_kernel::Result::Ok)
+                        if mm.is_main_memory(paddr as *mut u8) || mm.is_peripheral_ram(paddr) {
+                            // this call unmaps the virtual page from the page table
+                            crate::arch::mem::unmap_page_inner(mm, vaddr_to_release)
+                                .expect("couldn't unmap page");
+                            // This call releases the physical page from the RPT - the pid has to match that
+                            // of the original owner. This is the "pointy end" of
+                            // the stick; after this call, the memory is now back
+                            // into the free pool.
+                            mm.release_page_swap(paddr as *mut usize, PID::new(original_pid).unwrap())
+                                .expect("couldn't free page that was swapped out");
+                            Ok(xous_kernel::Result::Ok)
+                        } else {
+                            // you are not allowed to unmap a peripheral address space once you have mapped it
+                            Err(xous_kernel::Error::InvalidArgument)
+                        }
                     })
                 }
                 SwapAbi::HardOom => {

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -4,6 +4,7 @@
 use core::sync::atomic::{AtomicU8, AtomicUsize, Ordering::Relaxed};
 
 use xous_kernel::arch::PAGE_SIZE;
+use xous_kernel::arch::USER_AREA_END;
 use xous_kernel::*;
 
 use crate::arch;
@@ -738,7 +739,11 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
 
                 // Don't let the address exceed the user area (unless it's PID 1)
                 if pid.get() != 1
-                    && virt.map(|x| x.get() >= xous_kernel::arch::USER_AREA_END).unwrap_or(false)
+                    && virt.is_some_and(|x| {
+                        x.get()
+                            .checked_add(size.get())
+                            .is_none_or(|end| end >= xous_kernel::arch::USER_AREA_END)
+                    })
                 {
                     klog!("Exceeded user area");
                     return Err(xous_kernel::Error::BadAddress);
@@ -772,11 +777,7 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
 
                 if !phys_ptr.is_null() {
                     if mm.is_main_memory(phys_ptr) {
-                        let range_start = range.as_mut_ptr() as *mut usize;
-                        let range_end = range_start.wrapping_add(range.len() / core::mem::size_of::<usize>());
-                        unsafe {
-                            crate::mem::bzero(range_start, range_end);
-                        };
+                        unsafe { core::ptr::write_bytes(range.as_mut_ptr(), 0, range.len()) };
                     }
                     for offset in
                         (range.as_ptr() as usize..(range.as_ptr() as usize + range.len())).step_by(PAGE_SIZE)
@@ -796,6 +797,10 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
             let size = range.len();
             if cfg!(baremetal) && virt & 0xfff != 0 {
                 return Err(xous_kernel::Error::BadAlignment);
+            }
+            if virt >= USER_AREA_END || virt + size >= USER_AREA_END {
+                // don't allow processes to unmap kernel or page table memory
+                return Err(xous_kernel::Error::BadAddress);
             }
             for addr in (virt..(virt + size)).step_by(PAGE_SIZE) {
                 if let Err(e) = mm.unmap_page(addr as *mut usize) {
@@ -1057,10 +1062,15 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
         },
         #[cfg(feature = "v2p")]
         SysCall::VirtToPhys(vaddr) => {
-            let phys_addr = crate::arch::mem::virt_to_phys(vaddr as usize);
-            match phys_addr {
-                Ok(pa) => Ok(xous_kernel::Result::Scalar1(pa)),
-                Err(_) => Err(xous_kernel::Error::BadAddress),
+            if vaddr < USER_AREA_END {
+                let phys_addr = crate::arch::mem::virt_to_phys(vaddr as usize);
+                match phys_addr {
+                    Ok(pa) => Ok(xous_kernel::Result::Scalar1(pa)),
+                    Err(_) => Err(xous_kernel::Error::BadAddress),
+                }
+            } else {
+                // don't allow discovery of kernel or page tables
+                Err(xous_kernel::Error::BadAddress)
             }
         }
         #[cfg(feature = "v2p")]

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -1075,10 +1075,15 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
         }
         #[cfg(feature = "v2p")]
         SysCall::VirtToPhysPid(pid, vaddr) => {
-            let phys_addr = crate::arch::mem::virt_to_phys_pid(pid, vaddr as usize);
-            match phys_addr {
-                Ok(pa) => Ok(xous_kernel::Result::Scalar1(pa)),
-                Err(_) => Err(xous_kernel::Error::BadAddress),
+            if vaddr < USER_AREA_END {
+                let phys_addr = crate::arch::mem::virt_to_phys_pid(pid, vaddr as usize);
+                match phys_addr {
+                    Ok(pa) => Ok(xous_kernel::Result::Scalar1(pa)),
+                    Err(_) => Err(xous_kernel::Error::BadAddress),
+                }
+            } else {
+                // don't allow discovery of kernel or page tables
+                Err(xous_kernel::Error::BadAddress)
             }
         }
         #[cfg(feature = "swap")]

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -142,6 +142,7 @@ userspace-swap-debug = []     # sets up app UART mapping.
 
 # general flags
 debug-print = []
+verbose-debug = []
 unsafe-debug-print = []
 debug-swap-sig = []
 early-printk = []

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -691,28 +691,28 @@ fn boot_sequence(
 
         // this can help debug XPT allocation issues
         #[cfg(feature = "verbose-debug")]
-        println!(
-            "RPT len: {:x} / XPT len: {:x}",
-            cfg.runtime_page_tracker.len(),
-            cfg.extra_page_tracker.len()
-        );
-        #[cfg(feature = "verbose-debug")]
-        fn xpt_index_to_addr(cfg: &BootConfig, idx: usize) -> Option<usize> {
-            let mut offset = 0;
-            for region in cfg.regions.iter() {
-                let pages_in_region = (region.length as usize + PAGE_SIZE - 1) / PAGE_SIZE;
-                if idx < offset + pages_in_region {
-                    let within = idx - offset;
-                    return Some(region.start as usize + within * PAGE_SIZE);
+        {
+            println!(
+                "RPT len: {:x} / XPT len: {:x}",
+                cfg.runtime_page_tracker.len(),
+                cfg.extra_page_tracker.len()
+            );
+            fn xpt_index_to_addr(cfg: &BootConfig, idx: usize) -> Option<usize> {
+                let mut offset = 0;
+                for region in cfg.regions.iter() {
+                    let pages_in_region = (region.length as usize + PAGE_SIZE - 1) / PAGE_SIZE;
+                    if idx < offset + pages_in_region {
+                        let within = idx - offset;
+                        return Some(region.start as usize + within * PAGE_SIZE);
+                    }
+                    offset += pages_in_region;
                 }
-                offset += pages_in_region;
+                None
             }
-            None
-        }
-        #[cfg(feature = "verbose-debug")]
-        for (i, chunk) in cfg.extra_page_tracker.chunks(16).enumerate() {
-            if !chunk.iter().all(|&x| x == 0) {
-                println!("{:08x} ({:x?}): {:x?}", i * 16, xpt_index_to_addr(&cfg, i * 16), chunk);
+            for (i, chunk) in cfg.extra_page_tracker.chunks(16).enumerate() {
+                if !chunk.iter().all(|&x| x == 0) {
+                    println!("{:08x} ({:x?}): {:x?}", i * 16, xpt_index_to_addr(&cfg, i * 16), chunk);
+                }
             }
         }
 

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -688,6 +688,34 @@ fn boot_sequence(
         let rpt_offset =
             cfg.runtime_page_tracker.as_ptr() as usize - krn_struct_start + KERNEL_ARGUMENT_OFFSET;
         let xpt_offset = cfg.extra_page_tracker.as_ptr() as usize - krn_struct_start + KERNEL_ARGUMENT_OFFSET;
+
+        // this can help debug XPT allocation issues
+        #[cfg(feature = "verbose-debug")]
+        println!(
+            "RPT len: {:x} / XPT len: {:x}",
+            cfg.runtime_page_tracker.len(),
+            cfg.extra_page_tracker.len()
+        );
+        #[cfg(feature = "verbose-debug")]
+        fn xpt_index_to_addr(cfg: &BootConfig, idx: usize) -> Option<usize> {
+            let mut offset = 0;
+            for region in cfg.regions.iter() {
+                let pages_in_region = (region.length as usize + PAGE_SIZE - 1) / PAGE_SIZE;
+                if idx < offset + pages_in_region {
+                    let within = idx - offset;
+                    return Some(region.start as usize + within * PAGE_SIZE);
+                }
+                offset += pages_in_region;
+            }
+            None
+        }
+        #[cfg(feature = "verbose-debug")]
+        for (i, chunk) in cfg.extra_page_tracker.chunks(16).enumerate() {
+            if !chunk.iter().all(|&x| x == 0) {
+                println!("{:08x} ({:x?}): {:x?}", i * 16, xpt_index_to_addr(&cfg, i * 16), chunk);
+            }
+        }
+
         #[cfg(not(feature = "atsama5d27"))]
         let _tt_addr = { cfg.processes[0].satp };
         #[cfg(feature = "atsama5d27")]

--- a/services/dc34-console/src/cmds/test.rs
+++ b/services/dc34-console/src/cmds/test.rs
@@ -727,6 +727,29 @@ impl<'a> ShellCmdApi<'a> for Test {
                 });
                 write!(ret, "Starting suspend/resume stress test. Hard reboot required to exit.").unwrap();
             }
+            #[cfg(feature = "qa-test")]
+            "pt0map" => {
+                // This test will print out the L0 page table mapping on older, unpatched versions of the
+                // kernel. Converting the flags from R to R|W would transitively allow a
+                // process to rewrite its page tables which can then lead to all sorts of
+                // chaos.
+                //
+                // On patched kernels, this test should return a BadAddress violation
+                let result = xous::map_memory(
+                    None,
+                    xous::MemoryAddress::new(0xfeff_f000),
+                    0x0040_2000,
+                    xous::MemoryFlags::R,
+                );
+                log::info!("Result: {:x?}", result);
+                if let Ok(m) = result {
+                    log::info!("L0 PT:");
+                    let ms: &[u8] = unsafe { m.as_slice() };
+                    for (i, chunk) in ms[0x40_1000..0x40_1200].chunks(16).enumerate() {
+                        log::info!("{:04x}: {:02x?}", i * 16, chunk);
+                    }
+                }
+            }
             _ => {
                 write!(ret, "{}", helpstring).unwrap();
             }

--- a/tools/src/tags/memory.rs
+++ b/tools/src/tags/memory.rs
@@ -34,7 +34,7 @@ pub struct MemoryRegions {
 
 impl fmt::Display for MemoryRegions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "    Additional regions:")?;
+        writeln!(f, "    Additional regions (MREx):")?;
         for region in &self.regions {
             let tag_name_bytes = region.name.to_le_bytes();
             let tag_name_str = String::from_utf8_lossy(&tag_name_bytes);


### PR DESCRIPTION
This is a vuln reported by lisdexico 

The gist of it is that due to improper range checks and overlooked aliasing checks, it is possible for a user to request a mapping that goes beyond the end of USER memory, and into kernel virtual memory. This includes the page tables of the process itself.

Once the the page table has an alias mapping into user space, one could then rewrite page tables to access other locations in memory, bypassing kernel memory protection.

This series of patches closes this vulnerability:

1. Range checks are added to Map/Unmap and VirtToPhys syscalls.
2. Page aliasing is detected by the routine that maps pages, and now returns an error instead of allowing aliasing (this should defeat cases which were missed in (1)).
3. The aliasing policy in ClaimReleaseMove operation is tightened up to disallow aliases in "regular" RAM or swap memory. However, aliases are *still* allowed in peripheral registers and memory space, but the alias policy enforces an invariant that the alias can only be within a single process space. This means that another process can't "steal" a peripheral map arbitrarily; however, within a single process (for example, the HAL manager process), multiple *threads* and *interrupt handlers* can alias the same memory bank. This allows for a cleaner abstraction and more performant handling of things like registers that have shared functions across multiple blocks, such as the interrupt status registers that get shared between more than one hardware function, or the power management functions that exist in the low power domain that can span everything from clock management to key press management to I/O configuration registers.

See the individual commit comments for further details.