### PR TITLE
Harden against name server take-over

### DIFF
--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2020 Sean Cross <sean@xobs.io>
 // SPDX-License-Identifier: Apache-2.0
 
-use core::sync::atomic::{AtomicU8, AtomicUsize, Ordering::Relaxed};
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering::Relaxed};
 
 use xous_kernel::arch::PAGE_SIZE;
 use xous_kernel::*;
@@ -38,6 +38,8 @@ static mut SWITCHTO_CALLER: Option<(PID, TID)> = None;
 /// return control to the Client.
 static ORIGINAL_PID: AtomicU8 = AtomicU8::new(2);
 static ORIGINAL_TID: AtomicUsize = AtomicUsize::new(2);
+
+static NS_TOFU: AtomicBool = AtomicBool::new(false);
 
 #[derive(PartialEq)]
 enum ExecutionType {
@@ -944,6 +946,20 @@ pub fn handle_inner(pid: PID, tid: TID, in_irq: bool, call: SysCall) -> SysCallR
             ss.create_process(process_init).map(xous_kernel::Result::NewProcess)
         }),
         SysCall::CreateServerWithAddress(name) => SystemServices::with_mut(|ss| {
+            const NS_SID: SID = SID::from_u32(
+                u32::from_le_bytes(*b"xous"),
+                u32::from_le_bytes(*b"-nam"),
+                u32::from_le_bytes(*b"e-se"),
+                u32::from_le_bytes(*b"rver"),
+            );
+            // This counts on the `name==NS_SID` short-circuiting the NS_TOFU call. Short-circuit evaluation
+            // is the specified behavior in Rust, so this should always be correct.
+            if name == NS_SID && NS_TOFU.swap(true, Relaxed) {
+                return Err(xous_kernel::Error::ServerExists);
+            }
+            // note: if create_server_with_address() fails on the legitimate boot, it fails-closed forever.
+            // this should never happen - on early boot there is no reason for server creation to fail -
+            // so this is a deliberate choice to simplify the check logic.
             ss.create_server_with_address(pid, name, true)
                 .map(|(sid, cid)| xous_kernel::Result::NewServerID(sid, cid))
         }),

--- a/services/xous-names/src/main.rs
+++ b/services/xous-names/src/main.rs
@@ -360,7 +360,6 @@ fn main() -> ! {
 
     let mut name_table = CheckedHashMap::new();
 
-    info!("started");
     loop {
         let mut msg = xous::receive_message(name_server).unwrap();
         log::trace!("received message: {:?}", msg);
@@ -525,14 +524,8 @@ fn main() -> ! {
                 buffer.replace(response).expect("Can't return buffer");
             }
             None => {
-                error!("couldn't decode message: {:?}", msg);
-                break;
+                error!("Couldn't decode message: {:?}", msg);
             }
         }
     }
-    // clean up our program
-    log::trace!("main loop exit, destroying servers");
-    xous::destroy_server(name_server).unwrap();
-    log::trace!("quitting");
-    xous::terminate_process(0);
 }


### PR DESCRIPTION
Currently it's a bit too easy to take over the Xous name server. The name server is coded to die on any malformed message, and then, any process can spawn a new name server that takes over as this critical resource.

This patch does the following:

1. Remove the die-on-malformed message behavior. Instead, it just prints an error and keeps running.

2. Implements a TOFU policy in the kernel, where only the very first server that claims to be the name server can be the name server.

The TOFU policy of course assumse that the initial set of processes are trusted. This is generally the case because on a locked down system the code is signed and ideally you're not signing footguns.

Of course, if there is a supply chain attack and somehow some malicious code sneaks into the code base...but...this is probably not the first place you'd attack if you had that capability, anyways.