### PR TITLE
Harden keystore

### DIFF
--- a/apps-baosec/dc34-vault/src/config.rs
+++ b/apps-baosec/dc34-vault/src/config.rs
@@ -65,9 +65,8 @@ pub(crate) struct GlobalConfig {
 }
 
 impl GlobalConfig {
-    pub fn init() -> (Self, VaultMode) {
+    pub fn init(keystore: &keystore::Keystore) -> (Self, VaultMode) {
         let xns = xous_names::XousNames::new().unwrap();
-        let keystore = keystore::Keystore::new(&xns);
         let is_developer = keystore.is_developer().expect("couldn't query developer mode");
         let pddb = pddb::Pddb::new();
 

--- a/apps-baosec/dc34-vault/src/main.rs
+++ b/apps-baosec/dc34-vault/src/main.rs
@@ -117,6 +117,7 @@ fn main() -> ! {
     // Protects access to the openSK PDDB entries from simultaneous readout on the UX while OpenSK is updating
     let opensk_mutex = Arc::new(Mutex::new(0));
     let allow_host = Arc::new(AtomicBool::new(false));
+    let keystore = keystore::Keystore::new(&xns);
 
     // spawn the actions server. This is responsible for grooming the UX elements. It
     // has to be in its own thread because it uses blocking modal calls that would cause
@@ -183,7 +184,7 @@ fn main() -> ! {
 
     log::info!("Read config...");
     // this must init after PDDB is mounted
-    let (global_config, init_mode) = GlobalConfig::init();
+    let (global_config, init_mode) = GlobalConfig::init(&keystore);
     let global_config = Arc::new(Mutex::new(global_config));
     *mode.lock().unwrap() = init_mode;
     vault_ui.set_global_config(global_config.clone());
@@ -247,7 +248,6 @@ fn main() -> ! {
     {
         // check/trigger swap encryption before starting the main loop
         let xns = xous_names::XousNames::new().unwrap();
-        let keystore = keystore::Keystore::new(&xns);
         const THROW_AWAY_SERVER: &'static str = "_use once server_";
         const THROW_AWAY_OP: usize = 42;
         // idle forever, maybe turn this into a full blocking server that just parks and ends
@@ -319,6 +319,12 @@ fn main() -> ! {
             let kbd_code: usize = KeyMap::Dvorak.into();
             kbd_key.write(&kbd_code.to_le_bytes()).ok();
         }
+    }
+
+    if !xns.trusted_init_done().expect("couldn't query trusted init state") {
+        panic!(
+            "Trusted init state is inconsistent; check that connection count required for keystore is consistent with reality."
+        );
     }
 
     let mut menu_active = false;

--- a/apps-baosec/dc34-vault/src/ux.rs
+++ b/apps-baosec/dc34-vault/src/ux.rs
@@ -537,6 +537,7 @@ pub struct VaultUi {
     edge: bool,
     last_mode: VaultMode,
     pub bio_loaded: bool,
+    keystore: keystore::Keystore,
 }
 
 impl VaultUi {
@@ -601,6 +602,7 @@ impl VaultUi {
             edge: false,
             last_mode: VaultMode::FactoryTest,
             bio_loaded: false,
+            keystore: keystore::Keystore::new(xns),
         }
     }
 
@@ -1564,9 +1566,7 @@ impl VaultUi {
                 }
                 if self.about_state.is_diagnostics() {
                     if k == '↑' {
-                        let xns = xous_names::XousNames::new().unwrap();
-                        let keystore = keystore::Keystore::new(&xns);
-                        keystore.bootwait(Some(false)).unwrap();
+                        self.keystore.bootwait(Some(false)).unwrap();
                         log::info!("Bootwait secret disable activated");
                     }
                 }

--- a/services/dc34-console/src/cmds/bio.rs
+++ b/services/dc34-console/src/cmds/bio.rs
@@ -74,6 +74,7 @@ impl BioLoader {
             use dc34_api::{BadgeType, DC34_BADGE, DC34_TOUR, FACTORY_ONE_WAY};
 
             let xns = xous_names::XousNames::new().unwrap();
+            // note: this fails now that keystore connection count is locked down
             let keystore = keystore::Keystore::new(&xns);
             if keystore.get_owc(FACTORY_ONE_WAY).unwrap_or(1) == 0 {
                 let pddb = pddb::Pddb::new();
@@ -101,6 +102,7 @@ impl BioLoader {
             use dc34_api::FACTORY_ONE_WAY;
 
             let xns = xous_names::XousNames::new().unwrap();
+            // note: this fails now that keystore connection count is locked down
             let keystore = keystore::Keystore::new(&xns);
             if keystore.get_owc(FACTORY_ONE_WAY).unwrap_or(1) == 0 {
                 let pddb = pddb::Pddb::new();

--- a/services/dc34-console/src/cmds/test.rs
+++ b/services/dc34-console/src/cmds/test.rs
@@ -9,6 +9,7 @@ use crate::{CommonEnv, ShellCmdApi};
 #[derive(Debug)]
 pub struct Test {
     pwr_mgr: xous::CID,
+    keystore: keystore::Keystore,
     #[cfg(feature = "qa-test")]
     mutation_rate: u8,
 }
@@ -17,6 +18,7 @@ impl Test {
         let xns = xous_names::XousNames::new().unwrap();
         Self {
             pwr_mgr: xns.request_connection_blocking(POWER_MANAGER_SERVER).unwrap(),
+            keystore: keystore::Keystore::new(&xns),
             #[cfg(feature = "qa-test")]
             mutation_rate: 1,
         }
@@ -41,15 +43,14 @@ impl<'a> ShellCmdApi<'a> for Test {
 
         match cmd.as_str() {
             "bootwait" => {
-                let keystore = keystore::Keystore::new(&_env.xns);
                 if args.len() != 1 {
                     write!(ret, "bootwait [check | enable | disable]").ok();
                     return Ok(Some(ret));
                 }
                 if args[0] == "check" {
-                    write!(ret, "bootwait is {:?}", keystore.bootwait(None).unwrap()).ok();
+                    write!(ret, "bootwait is {:?}", self.keystore.bootwait(None).unwrap()).ok();
                 } else if args[0] == "enable" {
-                    keystore.bootwait(Some(true)).unwrap();
+                    self.keystore.bootwait(Some(true)).unwrap();
                     write!(ret, "bootwait enabled").ok();
                     log::info!(
                         "{}BOOTWAIT.ENABLED,{}",
@@ -57,7 +58,7 @@ impl<'a> ShellCmdApi<'a> for Test {
                         bao1x_hal::board::BOOKEND_END
                     );
                 } else if args[0] == "disable" {
-                    keystore.bootwait(Some(false)).unwrap();
+                    self.keystore.bootwait(Some(false)).unwrap();
                     write!(ret, "bootwait disabled").ok();
                 } else {
                     write!(ret, "bootwait [check | enable | disable]").ok();
@@ -674,12 +675,23 @@ impl<'a> ShellCmdApi<'a> for Test {
             }
             #[cfg(feature = "owc-test")]
             "owc" => {
-                let keystore = keystore::Keystore::new(&_env.xns);
-                log::info!("{:?}", keystore.get_owc_decoded::<bao1x_api::offsets::common::BoardTypeCoding>());
+                log::info!(
+                    "{:?}",
+                    self.keystore.get_owc_decoded::<bao1x_api::offsets::common::BoardTypeCoding>()
+                );
 
-                log::info!("{:?}", keystore.get_owc_decoded::<bao1x_api::offsets::common::BootWaitCoding>());
-                log::info!("{:?}", keystore.inc_owc_coded::<bao1x_api::offsets::common::BootWaitCoding>());
-                log::info!("{:?}", keystore.get_owc_decoded::<bao1x_api::offsets::common::BootWaitCoding>());
+                log::info!(
+                    "{:?}",
+                    self.keystore.get_owc_decoded::<bao1x_api::offsets::common::BootWaitCoding>()
+                );
+                log::info!(
+                    "{:?}",
+                    self.keystore.inc_owc_coded::<bao1x_api::offsets::common::BootWaitCoding>()
+                );
+                log::info!(
+                    "{:?}",
+                    self.keystore.get_owc_decoded::<bao1x_api::offsets::common::BootWaitCoding>()
+                );
             }
             #[cfg(feature = "wfi-stress-test")]
             "wfistress" => {

--- a/services/keystore/src/main.rs
+++ b/services/keystore/src/main.rs
@@ -10,7 +10,18 @@ fn main() -> ! {
     log::info!("my PID is {}", xous::process::id());
 
     let xns = xous_names::XousNames::new().unwrap();
-    // TODO: limit connections to this server?? once we know all that will connect
+
+    // restrictive for baosec config. Verified handle list, all have lifetimes throughout correct runtime:
+    //  - dc34-vault:actions -> password store encryption
+    //  - dc34-vault:main -> check swap encryption state
+    //  - dc34-vault:ux -> trigger bootwait clear
+    //  - dc34-console:command shell -> bootwait clear
+    //  - pddb:PddbOs -> PDDB encryption
+    #[cfg(feature = "board-baosec")]
+    let keys_sid = xns.register_name(SERVER_NAME_KEYS, Some(5)).expect("can't register server");
+
+    // permissive default for e.g. Dabao
+    #[cfg(not(feature = "board-baosec"))]
     let keys_sid = xns.register_name(SERVER_NAME_KEYS, None).expect("can't register server");
 
     platform::keystore(keys_sid);

--- a/services/pddb/src/backend/hw.rs
+++ b/services/pddb/src/backend/hw.rs
@@ -70,7 +70,7 @@ const SCD_VERSION: u32 = 2;
 #[cfg(all(feature = "pddbtest", feature = "autobasis"))]
 pub const BASIS_TEST_ROOTNAME: &'static str = "test";
 
-#[cfg(all(feature = "gen2", target_os = "xous"))]
+#[cfg(all(feature = "gen2"))]
 const DOMAIN_SEPERATOR: &'static str = "PDDB's key";
 
 #[derive(Zeroize)]

--- a/services/pddb/src/backend/hw.rs
+++ b/services/pddb/src/backend/hw.rs
@@ -263,7 +263,8 @@ impl PddbOs {
         #[cfg(feature = "gen1")]
         let dna = llio.soc_dna().unwrap();
         #[cfg(feature = "gen2")]
-        let keystore = keystore::Keystore::new(&xns);
+        let keystore = keystore::Keystore::new_key(&xns, DOMAIN_SEPERATOR);
+
         #[cfg(feature = "gen2")]
         let dna = keystore.get_dna();
 
@@ -322,7 +323,7 @@ impl PddbOs {
         #[cfg(all(feature = "gen2", target_os = "xous"))]
         let ret = PddbOs {
             swapper: xous_swapper::Swapper::new().expect("couldn't connect to swapper"),
-            rootkeys: keystore::Keystore::new_key(&xns, DOMAIN_SEPERATOR),
+            rootkeys: keystore,
             flash_page: RefCell::new(xous_swapper::FlashPage::new()),
             tt: ticktimer_server::Ticktimer::new().unwrap(),
             pddb_mr: pddb,

--- a/services/xous-names/Cargo.toml
+++ b/services/xous-names/Cargo.toml
@@ -34,5 +34,8 @@ precursor = ["utralib/precursor"]
 hosted = ["utralib/hosted"]
 renode = ["utralib/renode"]
 
+# When enabled, prints the list of servers and their connection count when trusted init doneness is queried.
+debug-xns-init = []
+
 debugprint = []
 default = []    # "debugprint"

--- a/services/xous-names/src/main.rs
+++ b/services/xous-names/src/main.rs
@@ -506,6 +506,13 @@ fn main() -> ! {
                 unimplemented!("AuthenticatedLookup not yet implemented");
             }
             Some(api::Opcode::TrustedInitDone) => {
+                #[cfg(feature = "debug-xns-init")]
+                for (server, info) in &name_table.map {
+                    if let Ok(name) = server.as_str() {
+                        log::info!("{:?} : {:?}", name, info.current_conns);
+                    }
+                }
+
                 if name_table.trusted_init_done() {
                     xous::return_scalar(msg.sender, 1).expect("couldn't return trusted_init_done");
                 } else {


### PR DESCRIPTION
This patch enforces keystore connection discipline and erforces TOFU count to keystore.

This makes it harder for a new process to connect to the keystore process after the TOFU boot is done.