### PR TITLE
Improve Server Queue Full Resilience

### DIFF
--- a/kernel/src/server.rs
+++ b/kernel/src/server.rs
@@ -898,6 +898,10 @@ impl Server {
         self.queue.iter().any(|e| *e == QueuedMessage::Empty)
     }
 
+    pub fn has_queue_capacity_scalar(&self) -> bool {
+        self.tail_generation != self.head_generation.wrapping_sub(1)
+    }
+
     /// Add the given message to this server's queue.
     ///
     /// # Errors

--- a/kernel/src/server.rs
+++ b/kernel/src/server.rs
@@ -886,6 +886,18 @@ impl Server {
         }
     }
 
+    /// Returns true if the queue can accept one more message.
+    /// Does NOT reserve or mutate any state.
+    pub fn has_queue_capacity(&self) -> bool {
+        // Same full-check as queue_message, plus verify an Empty slot exists.
+        // The generation check is the fast path; the scan is the fallback
+        // for the case where WaitingReturn* tokens occupy slots.
+        if self.tail_generation == self.head_generation.wrapping_sub(1) {
+            return false;
+        }
+        self.queue.iter().any(|e| *e == QueuedMessage::Empty)
+    }
+
     /// Add the given message to this server's queue.
     ///
     /// # Errors

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -102,6 +102,15 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
         // so, switch to the server context right away.
         let blocking = message.is_blocking();
 
+        // helper for handling the error-recovery path
+        fn return_thread(ss: &mut SystemServices, sidx: usize, tid: Option<TID>) {
+            if let Some(st) = tid {
+                ss.server_from_sidx_mut(sidx)
+                    .expect("server couldn't be located")
+                    .return_available_thread(st);
+            }
+        }
+
         // --- decide delivery path BEFORE touching memory ---
         let has_memory =
             matches!(&message, Message::Move(_) | Message::MutableBorrow(_) | Message::Borrow(_));
@@ -143,11 +152,7 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
                         Ok(v) => v,
                         Err(e) => {
                             // Give the thread back before returning the error
-                            if let Some(st) = avail_tid {
-                                ss.server_from_sidx_mut(sidx)
-                                    .expect("server couldn't be located")
-                                    .return_available_thread(st);
-                            }
+                            return_thread(ss, sidx, avail_tid);
                             return Err(e);
                         }
                     };
@@ -183,31 +188,18 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
         let message = match message {
             Message::Scalar(_) | Message::BlockingScalar(_) => message,
             Message::Move(msg) => {
-                let new_virt = match ss.send_memory(
-                    msg.buf.as_mut_ptr() as *mut usize,
-                    server_pid,
-                    core::ptr::null_mut(),
-                    msg.buf.len(),
-                ) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        // Give the thread back before returning the error
-                        if let Some(st) = available_tid {
-                            ss.server_from_sidx_mut(sidx)
-                                .expect("server couldn't be located")
-                                .return_available_thread(st);
-                        }
-                        return Err(e);
-                    }
-                };
+                let new_virt = ss
+                    .send_memory(
+                        msg.buf.as_mut_ptr() as *mut usize,
+                        server_pid,
+                        core::ptr::null_mut(),
+                        msg.buf.len(),
+                    )
+                    .inspect_err(|_| return_thread(ss, sidx, available_tid))?;
                 Message::Move(MemoryMessage {
                     id: msg.id,
                     buf: unsafe { MemoryRange::new(new_virt as usize, msg.buf.len()) }.map_err(|e| {
-                        if let Some(st) = available_tid {
-                            ss.server_from_sidx_mut(sidx)
-                                .expect("server couldn't be located")
-                                .return_available_thread(st);
-                        }
+                        return_thread(ss, sidx, available_tid);
                         e
                     })?,
                     offset: msg.offset,
@@ -215,32 +207,19 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
                 })
             }
             Message::MutableBorrow(msg) => {
-                let new_virt = match ss.lend_memory(
-                    msg.buf.as_mut_ptr() as *mut usize,
-                    server_pid,
-                    core::ptr::null_mut(),
-                    msg.buf.len(),
-                    true,
-                ) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        // Give the thread back before returning the error
-                        if let Some(st) = available_tid {
-                            ss.server_from_sidx_mut(sidx)
-                                .expect("server couldn't be located")
-                                .return_available_thread(st);
-                        }
-                        return Err(e);
-                    }
-                };
+                let new_virt = ss
+                    .lend_memory(
+                        msg.buf.as_mut_ptr() as *mut usize,
+                        server_pid,
+                        core::ptr::null_mut(),
+                        msg.buf.len(),
+                        true,
+                    )
+                    .inspect_err(|_| return_thread(ss, sidx, available_tid))?;
                 Message::MutableBorrow(MemoryMessage {
                     id: msg.id,
                     buf: unsafe { MemoryRange::new(new_virt as usize, msg.buf.len()) }.map_err(|e| {
-                        if let Some(st) = available_tid {
-                            ss.server_from_sidx_mut(sidx)
-                                .expect("server couldn't be located")
-                                .return_available_thread(st);
-                        }
+                        return_thread(ss, sidx, available_tid);
                         e
                     })?,
                     offset: msg.offset,
@@ -248,24 +227,15 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
                 })
             }
             Message::Borrow(msg) => {
-                let new_virt = match ss.lend_memory(
-                    msg.buf.as_mut_ptr() as *mut usize,
-                    server_pid,
-                    core::ptr::null_mut(),
-                    msg.buf.len(),
-                    false,
-                ) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        // Give the thread back before returning the error
-                        if let Some(st) = available_tid {
-                            ss.server_from_sidx_mut(sidx)
-                                .expect("server couldn't be located")
-                                .return_available_thread(st);
-                        }
-                        return Err(e);
-                    }
-                };
+                let new_virt = ss
+                    .lend_memory(
+                        msg.buf.as_mut_ptr() as *mut usize,
+                        server_pid,
+                        core::ptr::null_mut(),
+                        msg.buf.len(),
+                        false,
+                    )
+                    .inspect_err(|_| return_thread(ss, sidx, available_tid))?;
                 // println!(
                 //     "Lending {} bytes from {:08x} in PID {} to {:08x} in PID {}",
                 //     msg.buf.len(),
@@ -277,11 +247,7 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
                 Message::Borrow(MemoryMessage {
                     id: msg.id,
                     buf: unsafe { MemoryRange::new(new_virt as usize, msg.buf.len()) }.map_err(|e| {
-                        if let Some(st) = available_tid {
-                            ss.server_from_sidx_mut(sidx)
-                                .expect("server couldn't be located")
-                                .return_available_thread(st);
-                        }
+                        return_thread(ss, sidx, available_tid);
                         e
                     })?,
                     offset: msg.offset,
@@ -350,11 +316,7 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
                         .unwrap_or(Err(xous_kernel::Error::ProcessNotFound));
 
                     if result.is_err() {
-                        if let Some(st) = available_tid {
-                            ss.server_from_sidx_mut(sidx)
-                                .expect("server couldn't be located")
-                                .return_available_thread(st);
-                        }
+                        return_thread(ss, sidx, available_tid);
                     }
 
                     // Keep track of which process owned the quantum. This ensures that the next
@@ -389,11 +351,7 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
                             Ok(xous_kernel::Result::MessageEnvelope(envelope))
                         }
                         _ => {
-                            if let Some(st) = available_tid {
-                                ss.server_from_sidx_mut(sidx)
-                                    .expect("server couldn't be located")
-                                    .return_available_thread(st);
-                            }
+                            return_thread(ss, sidx, available_tid);
                             Err(xous_kernel::Error::ProcessNotFound)
                         }
                     }

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -103,23 +103,43 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
         let blocking = message.is_blocking();
 
         // --- decide delivery path BEFORE touching memory ---
+        let has_memory =
+            matches!(&message, Message::Move(_) | Message::MutableBorrow(_) | Message::Borrow(_));
+
         let (available_tid, can_deliver) = {
             let server_pid = ss.server_from_sidx(sidx).expect("server couldn't be located").pid;
-            let current_pid = ss.current_pid();
-
-            // Switch to the server's address space so we can read the queue array
-            let server_process = ss.get_process(server_pid)?;
-            server_process.mapping.activate().unwrap();
 
             let server = ss.server_from_sidx_mut(sidx).expect("server couldn't be located");
             let tid = server.take_available_thread();
-            let has_capacity = tid.is_some() || server.has_queue_capacity();
 
-            // Switch back to the client's address space
-            let current_process = ss.get_process(current_pid).expect("couldn't get client process");
-            current_process.mapping.activate().unwrap();
+            if tid.is_some() {
+                // A thread is waiting - delivery is guaranteed regardless of queue state.
+                // No need to check queue at all, saves an address-space switch.
+                (tid, true)
+            } else if has_memory {
+                // Memory message: we MUST confirm the queue can accept this before
+                // transferring. This requires reading the queue array, which means
+                // switching to the server's page table.
+                let current_pid = ss.current_pid();
+                let server_process = ss.get_process(server_pid)?;
+                server_process.mapping.activate().unwrap();
 
-            (tid, has_capacity)
+                let server = ss.server_from_sidx_mut(sidx).expect("server couldn't be located");
+                let capacity = server.has_queue_capacity();
+
+                let current_process = ss.get_process(current_pid).expect("client process");
+                current_process.mapping.activate().unwrap();
+
+                (None, capacity)
+            } else {
+                // Scalar / BlockingScalar: no memory to protect. Just check the
+                // generation counters (lives in the Server struct, kernel static).
+                // If this says "full," we bail early (saves the switch that
+                // queue_server_message would have done). If it says "not full",
+                // we proceed and let queue_server_message do the real check.
+                let server = ss.server_from_sidx_mut(sidx).expect("server couldn't be located");
+                (None, server.has_queue_capacity_scalar())
+            }
         };
 
         if !can_deliver {

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -107,38 +107,71 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
             matches!(&message, Message::Move(_) | Message::MutableBorrow(_) | Message::Borrow(_));
 
         let (available_tid, can_deliver) = {
-            let server_pid = ss.server_from_sidx(sidx).expect("server couldn't be located").pid;
-
-            let server = ss.server_from_sidx_mut(sidx).expect("server couldn't be located");
-            let tid = server.take_available_thread();
-
-            if tid.is_some() {
-                // A thread is waiting - delivery is guaranteed regardless of queue state.
-                // No need to check queue at all, saves an address-space switch.
-                (tid, true)
-            } else if has_memory {
-                // Memory message: we MUST confirm the queue can accept this before
-                // transferring. This requires reading the queue array, which means
-                // switching to the server's page table.
-                let current_pid = ss.current_pid();
-                let server_process = ss.get_process(server_pid)?;
-                server_process.mapping.activate().unwrap();
-
+            let (server_pid, avail_tid) = {
                 let server = ss.server_from_sidx_mut(sidx).expect("server couldn't be located");
-                let capacity = server.has_queue_capacity();
+                let server_pid = server.pid;
 
-                let current_process = ss.get_process(current_pid).expect("client process");
-                current_process.mapping.activate().unwrap();
+                let avail_tid = server.take_available_thread();
+                (server_pid, avail_tid)
+            };
 
-                (None, capacity)
+            // A delivered message consumes at most one slot of the server's
+            // queue:
+            //   * no available thread: the message itself is enqueued by queue_message() in the "queue it"
+            //     path below,
+            //   * available thread + blocking: queue_response() enqueues a WaitingReturn* token -- the
+            //     message goes to the thread directly, but the response bookkeeping still occupies a queue
+            //     slot,
+            //   * available thread + non-blocking: direct handoff, no slot.
+            // So an available thread only exempts *non-blocking* sends from
+            // the capacity probe. Erring toward "full" is cheap: the
+            // dispatcher retries ServerQueueFull once capacity frees. Erring
+            // toward "not full" is unrecoverable for memory messages, because
+            // send_memory() has already moved the client's pages by the time
+            // the enqueue fails, and the ServerQueueFull retry would move
+            // them a second time against a now-empty client mapping. Memory
+            // messages therefore run the authoritative predicate before any
+            // transfer: has_queue_capacity() is exactly queue_message()'s
+            // acceptance rule, and strictly stricter than queue_response()'s.
+            let needs_slot = avail_tid.is_none() || blocking;
+
+            if has_memory {
+                let capacity = if needs_slot {
+                    // The queue array lives in the server's address space.
+                    let current_pid = ss.current_pid();
+                    let server_process = match ss.get_process(server_pid) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            // Give the thread back before returning the error
+                            if let Some(st) = avail_tid {
+                                ss.server_from_sidx_mut(sidx)
+                                    .expect("server couldn't be located")
+                                    .return_available_thread(st);
+                            }
+                            return Err(e);
+                        }
+                    };
+                    server_process.mapping.activate().unwrap();
+
+                    let server = ss.server_from_sidx_mut(sidx).expect("server couldn't be located");
+                    let capacity = server.has_queue_capacity();
+
+                    let current_process = ss.get_process(current_pid).expect("client process");
+                    current_process.mapping.activate().unwrap();
+                    capacity
+                } else {
+                    true
+                };
+                (avail_tid, capacity)
             } else {
-                // Scalar / BlockingScalar: no memory to protect. Just check the
-                // generation counters (lives in the Server struct, kernel static).
-                // If this says "full," we bail early (saves the switch that
-                // queue_server_message would have done). If it says "not full",
-                // we proceed and let queue_server_message do the real check.
+                // Scalar / BlockingScalar: no memory to protect, and the
+                // generation counters live in the kernel-static Server
+                // struct, so this costs no address-space switch. It can miss
+                // a queue full of WaitingReturn* tokens (tokens never move
+                // the generations), but a late ServerQueueFull there merely
+                // retries an idempotent syscall.
                 let server = ss.server_from_sidx_mut(sidx).expect("server couldn't be located");
-                (None, server.has_queue_capacity_scalar())
+                (avail_tid, !needs_slot || server.has_queue_capacity_scalar())
             }
         };
 
@@ -316,6 +349,14 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
                         .map(|_| Ok(xous_kernel::Result::ResumeProcess))
                         .unwrap_or(Err(xous_kernel::Error::ProcessNotFound));
 
+                    if result.is_err() {
+                        if let Some(st) = available_tid {
+                            ss.server_from_sidx_mut(sidx)
+                                .expect("server couldn't be located")
+                                .return_available_thread(st);
+                        }
+                    }
+
                     // Keep track of which process owned the quantum. This ensures that the next
                     // thread in sequence gets to run when this process is activated again.
                     ss.set_last_thread(
@@ -347,7 +388,14 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
                             let envelope = MessageEnvelope { sender: sender.into(), body: message };
                             Ok(xous_kernel::Result::MessageEnvelope(envelope))
                         }
-                        _ => Err(xous_kernel::Error::ProcessNotFound),
+                        _ => {
+                            if let Some(st) = available_tid {
+                                ss.server_from_sidx_mut(sidx)
+                                    .expect("server couldn't be located")
+                                    .return_available_thread(st);
+                            }
+                            Err(xous_kernel::Error::ProcessNotFound)
+                        }
                     }
                 }
             } else if blocking && !cfg!(baremetal) {

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -101,45 +101,118 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
         // process. Additionally, determine whether the call is blocking. If
         // so, switch to the server context right away.
         let blocking = message.is_blocking();
+
+        // --- decide delivery path BEFORE touching memory ---
+        let (available_tid, can_deliver) = {
+            let server_pid = ss.server_from_sidx(sidx).expect("server couldn't be located").pid;
+            let current_pid = ss.current_pid();
+
+            // Switch to the server's address space so we can read the queue array
+            let server_process = ss.get_process(server_pid)?;
+            server_process.mapping.activate().unwrap();
+
+            let server = ss.server_from_sidx_mut(sidx).expect("server couldn't be located");
+            let tid = server.take_available_thread();
+            let has_capacity = tid.is_some() || server.has_queue_capacity();
+
+            // Switch back to the client's address space
+            let current_process = ss.get_process(current_pid).expect("couldn't get client process");
+            current_process.mapping.activate().unwrap();
+
+            (tid, has_capacity)
+        };
+
+        if !can_deliver {
+            return Err(xous_kernel::Error::ServerQueueFull);
+        }
+
+        // --- Memory transfer (now guaranteed to be deliverable) ---
         let message = match message {
             Message::Scalar(_) | Message::BlockingScalar(_) => message,
             Message::Move(msg) => {
-                let new_virt = ss.send_memory(
+                let new_virt = match ss.send_memory(
                     msg.buf.as_mut_ptr() as *mut usize,
                     server_pid,
                     core::ptr::null_mut(),
                     msg.buf.len(),
-                )?;
+                ) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        // Give the thread back before returning the error
+                        if let Some(st) = available_tid {
+                            ss.server_from_sidx_mut(sidx)
+                                .expect("server couldn't be located")
+                                .return_available_thread(st);
+                        }
+                        return Err(e);
+                    }
+                };
                 Message::Move(MemoryMessage {
                     id: msg.id,
-                    buf: unsafe { MemoryRange::new(new_virt as usize, msg.buf.len()) }?,
+                    buf: unsafe { MemoryRange::new(new_virt as usize, msg.buf.len()) }.map_err(|e| {
+                        if let Some(st) = available_tid {
+                            ss.server_from_sidx_mut(sidx)
+                                .expect("server couldn't be located")
+                                .return_available_thread(st);
+                        }
+                        e
+                    })?,
                     offset: msg.offset,
                     valid: msg.valid,
                 })
             }
             Message::MutableBorrow(msg) => {
-                let new_virt = ss.lend_memory(
+                let new_virt = match ss.lend_memory(
                     msg.buf.as_mut_ptr() as *mut usize,
                     server_pid,
                     core::ptr::null_mut(),
                     msg.buf.len(),
                     true,
-                )?;
+                ) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        // Give the thread back before returning the error
+                        if let Some(st) = available_tid {
+                            ss.server_from_sidx_mut(sidx)
+                                .expect("server couldn't be located")
+                                .return_available_thread(st);
+                        }
+                        return Err(e);
+                    }
+                };
                 Message::MutableBorrow(MemoryMessage {
                     id: msg.id,
-                    buf: unsafe { MemoryRange::new(new_virt as usize, msg.buf.len()) }?,
+                    buf: unsafe { MemoryRange::new(new_virt as usize, msg.buf.len()) }.map_err(|e| {
+                        if let Some(st) = available_tid {
+                            ss.server_from_sidx_mut(sidx)
+                                .expect("server couldn't be located")
+                                .return_available_thread(st);
+                        }
+                        e
+                    })?,
                     offset: msg.offset,
                     valid: msg.valid,
                 })
             }
             Message::Borrow(msg) => {
-                let new_virt = ss.lend_memory(
+                let new_virt = match ss.lend_memory(
                     msg.buf.as_mut_ptr() as *mut usize,
                     server_pid,
                     core::ptr::null_mut(),
                     msg.buf.len(),
                     false,
-                )?;
+                ) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        // Give the thread back before returning the error
+                        if let Some(st) = available_tid {
+                            ss.server_from_sidx_mut(sidx)
+                                .expect("server couldn't be located")
+                                .return_available_thread(st);
+                        }
+                        return Err(e);
+                    }
+                };
                 // println!(
                 //     "Lending {} bytes from {:08x} in PID {} to {:08x} in PID {}",
                 //     msg.buf.len(),
@@ -150,17 +223,24 @@ fn send_message(pid: PID, tid: TID, cid: CID, message: Message) -> SysCallResult
                 // );
                 Message::Borrow(MemoryMessage {
                     id: msg.id,
-                    buf: unsafe { MemoryRange::new(new_virt as usize, msg.buf.len()) }?,
+                    buf: unsafe { MemoryRange::new(new_virt as usize, msg.buf.len()) }.map_err(|e| {
+                        if let Some(st) = available_tid {
+                            ss.server_from_sidx_mut(sidx)
+                                .expect("server couldn't be located")
+                                .return_available_thread(st);
+                        }
+                        e
+                    })?,
                     offset: msg.offset,
                     valid: msg.valid,
                 })
             }
         };
 
+        // --- Deliver ---
         // If the server has an available thread to receive the message,
         // transfer it right away.
-        let server = ss.server_from_sidx_mut(sidx).expect("server couldn't be located");
-        if let Some(server_tid) = server.take_available_thread() {
+        if let Some(server_tid) = available_tid {
             // klog!(
             //     "there are threads available in PID {} to handle this message -- marking as Ready",
             //     server_pid

--- a/kernel/src/test.rs
+++ b/kernel/src/test.rs
@@ -1242,3 +1242,94 @@ fn increase_heap_rejects_absurd_delta() {
     shutdown_kernel();
     main_thread.join().expect("join kernel");
 }
+
+#[cfg(test)]
+mod queue_capacity_tests {
+    use xous_kernel::{MemoryRange, Message, PID, SID};
+
+    use crate::server::Server;
+
+    fn scalar(id: usize) -> Message {
+        Message::Scalar(xous_kernel::ScalarMessage { id, arg1: 0, arg2: 0, arg3: 0, arg4: 0 })
+    }
+
+    fn make_server() -> Server {
+        let mut slot: Option<Server> = None;
+        let backing = unsafe { MemoryRange::new(0x1_0000, 0x1_000) }.unwrap();
+        Server::init(&mut slot, PID::new(3).unwrap(), SID::from_bytes(&[0x12, 0x34]).unwrap(), backing)
+            .unwrap();
+        slot.unwrap()
+    }
+
+    /// Response tokens (`WaitingReturn*`, enqueued by `queue_response()` on
+    /// every blocking handoff) occupy queue slots but never advance the
+    /// generation counters. A queue saturated with tokens must therefore be
+    /// reported as full by `has_queue_capacity()` -- this is the exact state
+    /// in which a blocking direct handoff (available server thread, full
+    /// queue) used to pass the pre-check, move its payload, and then fail
+    /// inside `queue_response()`. `has_queue_capacity_scalar()` deliberately
+    /// misses it; that is only sound because scalar sends have no payload to
+    /// strand on a retry.
+    #[test]
+    fn token_saturated_queue_reports_full() {
+        let mut server = make_server();
+        let client = PID::new(4).unwrap();
+        let mut tokens = 0;
+        while server.queue_response(client, 0, &scalar(1), None).is_ok() {
+            tokens += 1;
+        }
+        assert!(tokens > 0, "queue accepted no tokens");
+        assert!(!server.has_queue_capacity(), "token-saturated queue must read as full");
+        assert!(server.has_queue_capacity_scalar(), "gen-only probe is expected to miss token saturation");
+        assert_eq!(
+            server.queue_response(client, 0, &scalar(2), None),
+            Err(xous_kernel::Error::ServerQueueFull)
+        );
+        assert_eq!(
+            server.queue_message(client, 0, scalar(3), None),
+            Err(xous_kernel::Error::ServerQueueFull)
+        );
+    }
+
+    /// `has_queue_capacity()` is the pre-flight check that lets
+    /// `send_message()` decide it may transfer a payload before enqueueing.
+    /// It must never disagree with `queue_response()`'s acceptance in any
+    /// reachable state (here: progressive token fill through a wrapped
+    /// queue head).
+    #[test]
+    fn has_queue_capacity_agrees_with_response_enqueue() {
+        let mut server = make_server();
+        let client = PID::new(4).unwrap();
+        for round in 0..10_000usize {
+            let predicted = server.has_queue_capacity();
+            let accepted = server.queue_response(client, 0, &scalar(1), None).is_ok();
+            assert_eq!(
+                predicted, accepted,
+                "has_queue_capacity() and queue_response() diverged at round {}",
+                round
+            );
+            if !accepted {
+                break;
+            }
+        }
+    }
+
+    /// Same agreement property against the message-enqueue path.
+    #[test]
+    fn has_queue_capacity_agrees_with_message_enqueue() {
+        let mut server = make_server();
+        let client = PID::new(4).unwrap();
+        for round in 0..10_000usize {
+            let predicted = server.has_queue_capacity();
+            let accepted = server.queue_message(client, 0, scalar(1), None).is_ok();
+            assert_eq!(
+                predicted, accepted,
+                "has_queue_capacity() and queue_message() diverged at round {}",
+                round
+            );
+            if !accepted {
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
There is a problem where the memory pages associated with a move or lend are mapped first, and then the ability for the server to actually receive these pages is checked later. If the receiver turns out to be full, the lend either locks, or the move data is lost.

This patch fixes this by first checking for the ability of the receiver to take the messages, and then doing the memory movement. This does introduce a lot of "froth" in the error handling path because the available thread has to be returned in all possible failure cases.

Also, the receiver server queue checking requires a memory space pivot in order to check the receiver, increasing the amount of memory space churn and thus reducing the performance of message passing.
