### PR TITLE
pddb-fs-ci: fix lost arrow keys at the format prompt

### DIFF
--- a/emulation/tests/pddb-fs.robot
+++ b/emulation/tests/pddb-fs.robot
@@ -99,6 +99,34 @@ Inject Keys With Echo
         Wait For Line On Uart    injecting key    timeout=10
     END
 
+Inject Arrow Once
+    [Arguments]               ${letter}    ${code}
+    Inject Keys               sysbus.keyboard WriteDoubleWord 0x0 0x1b
+    ...                       sysbus.keyboard WriteDoubleWord 0x0 0x5b
+    ...                       sysbus.keyboard WriteDoubleWord 0x0 ${letter}
+    Wait For Line On Uart     injecting key .*\\(${code}\\)    timeout=10    treatAsRegex=true
+
+Inject Arrow
+    [Documentation]           Queue ESC [ <letter> in the keyboard model
+    ...                       (UART_CHAR register writes) and wait for the
+    ...                       keyboard service's echo of the parsed arrow,
+    ...                       with one retry.
+    [Arguments]               ${letter}    ${code}
+    ${ok}=                    Run Keyword And Return Status
+    ...                       Inject Arrow Once    ${letter}    ${code}
+    IF    not ${ok}
+        Log                   no arrow echo; re-injecting once    WARN
+        Inject Arrow Once     ${letter}    ${code}
+    END
+
+Answer Format Prompt With Okay
+    [Documentation]           Radio [Okay, Cancel], cursor on the item row,
+    ...                       Okay preselected: Down x2 to the OK row, CR.
+    Sleep                     ${FOCUS_DELAY}
+    Inject Arrow              0x42    2193
+    Inject Arrow              0x42    2193
+    Inject Keys With Echo     sysbus.keyboard InjectLine ""
+
 *** Test Cases ***
 Boot Format And Run PDDB FS Tests
     Prepare Fresh Flash
@@ -119,13 +147,12 @@ Boot Format And Run PDDB FS Tests
     Wait For Line On Uart     status: starting main loop    timeout=${BOOT_TIMEOUT}
     Wait For Line On Uart     Requesting login password    timeout=${BOOT_TIMEOUT}
 
-    # Format prompt: radio [Okay, Cancel] with the cursor on the item row.
-    # Down x2 reaches the OK row (CR on the item row only sets the payload),
-    # then CR submits. Arrows must go through the scan matrix, not ESC bytes.
+    # Format prompt: the arrows go through the keyboard model's inject queue
+    # as ESC [ B, which the keyboard service echoes per key. Scan-matrix
+    # Press/Release leaves no echo and is lost when the release lands before
+    # the interrupt handler has read the matrix.
     Wait For Line On Uart     _|TT|_PDDB.REQFMT,_|TE|_    timeout=${BOOT_TIMEOUT}
-    Inject Keys With Echo     sysbus.keyboard Press Down    sysbus.keyboard Release Down
-    ...                       sysbus.keyboard Press Down    sysbus.keyboard Release Down
-    ...                       sysbus.keyboard InjectLine ""
+    Answer Format Prompt With Okay
 
     # PIN entry #1
     Wait For Line On Uart     _|TT|_ROOTKEY.BOOTPW,_|TE|_    timeout=${BOOT_TIMEOUT}

--- a/tools/pddb-fs-ci.py
+++ b/tools/pddb-fs-ci.py
@@ -56,6 +56,11 @@ FOCUS_DELAY = 1.5
 # re-injecting (one retry).
 ECHO_TIMEOUT = 5.0
 MAX_PIN_ATTEMPTS = 3
+# One Down arrow as the ESC [ B byte sequence, written into the keyboard
+# model's UART_CHAR inject register (services/keyboard esc_match).
+ARROW_DOWN = ['sysbus.keyboard WriteDoubleWord 0x0 0x1b',
+              'sysbus.keyboard WriteDoubleWord 0x0 0x5b',
+              'sysbus.keyboard WriteDoubleWord 0x0 0x42']
 
 
 class RunFailure(Exception):
@@ -264,9 +269,10 @@ class RenodeRun:
             self.monitor(command)
             time.sleep(delay)
 
-    def inject_verified(self, keyboard_commands, what):
+    def inject_verified(self, keyboard_commands, what, expect_echoes=1):
         """Inject after the marker->focus delay; verify via the keyboard
-        service's 'injecting key' echo, with one re-injection retry."""
+        service's 'injecting key' echo (one per injected key), with one
+        re-injection retry."""
         time.sleep(FOCUS_DELAY)
         for attempt in (1, 2):
             baseline = self.tail.echo_count
@@ -277,7 +283,7 @@ class RenodeRun:
                 # poll_console preserves the lines for the next wait_for;
                 # echo_count is a tail-side counter independent of consumption
                 self.poll_console()
-                if self.tail.echo_count > baseline:
+                if self.tail.echo_count >= baseline + expect_echoes:
                     self.milestone('injected: {}'.format(what))
                     return
                 time.sleep(0.2)
@@ -302,15 +308,15 @@ class RenodeRun:
         self.wait_for([MARK_STATUS_MAIN], t_boot, ec_abort_ok=True)
         self.wait_for([MARK_PW_REQUEST], t_boot, ec_abort_ok=True)
         # Radio [Okay, Cancel], cursor on the item row: Down x2 to reach the
-        # OK row (CR on the item row only sets the payload), then CR.
+        # OK row (CR on the item row only sets the payload), then CR. The
+        # arrows go through the keyboard model's inject queue as ESC [ B so
+        # the keyboard service echoes each one; scan-matrix Press/Release
+        # leaves no echo and is lost when the release lands before the
+        # interrupt handler has read the matrix.
         self.wait_for([MARK_REQFMT], t_boot, ec_abort_ok=True)
-        self.inject_verified([
-            'sysbus.keyboard Press Down',
-            'sysbus.keyboard Release Down',
-            'sysbus.keyboard Press Down',
-            'sysbus.keyboard Release Down',
-            'sysbus.keyboard InjectLine ""',
-        ], 'REQFMT Okay')
+        self.inject_verified(
+            ARROW_DOWN + ARROW_DOWN + ['sysbus.keyboard InjectLine ""'],
+            'REQFMT Okay', expect_echoes=3)
         for attempt in range(1, MAX_PIN_ATTEMPTS + 1):
             # PIN entry #1
             self.wait_for([MARK_BOOTPW], t_boot)


### PR DESCRIPTION
Running `tools/pddb-fs-ci.py` on a fresh flash can hang at the format
prompt until the BOOTPW timeout, with only the Enter key echoed on
the console. The two Down arrows were sent as scan-matrix Press/Release
pairs, and the keyboard service only sees a matrix key if its
interrupt handler reads the row registers before the Release clears
them. On some hosts it doesn't, so the arrows are lost and the Enter
lands on the item row, which just sets the selection.

The arrows now go through the keyboard model's inject queue as
ESC [ B, which the service parses as a Down arrow and echoes like any
injected key, so the driver and the robot verify every key.
Reproduced by removing the driver's gap between monitor commands, and
green afterwards with and without it, in both the driver and
`renode-test`.

Made with the help of an AI agent.