### PR TITLE
pddb-fs-tests: empty the XFAIL registry and tidy the comments

### DIFF
--- a/.github/workflows/pddb-renode-ci.yml
+++ b/.github/workflows/pddb-renode-ci.yml
@@ -14,7 +14,7 @@
 # fail=.. xfail=.. xpass=.. total=..`, `CI done`). Known product bugs are
 # pinned as XFAIL so the suite is green while still detecting regressions AND
 # accidental fixes (XPASS fails the run: update the registry).
-# Expected steady-state totals: pass=101 fail=0 xfail=11 xpass=0 total=112.
+# Expected steady-state totals: pass=113 fail=0 xfail=0 xpass=0 total=113.
 #
 # The robot suite (emulation/tests/pddb-fs.robot) drives the first-boot UX
 # (format prompt, boot PIN x2, unattended 4 MiB smalldb format) through

--- a/services/pddb-fs-tests/README.md
+++ b/services/pddb-fs-tests/README.md
@@ -31,23 +31,17 @@ is the equivalent `renode-test` suite used by `.github/workflows/pddb-renode-ci.
 
 The suite is green while every open bug stays visible: a test that reproduces a
 known defect asserts the *correct* behavior and is registered as an expected
-failure (`XFAIL`) rather than being weakened. If a bug is fixed, its test flips to
-`XPASS` and the run goes red until the registry is updated. One reproducer
-(`smoke::overwrite_shorter_large`) shipped disabled rather than XFAIL while a
-truncating `File::create` over an existing key ≥ 4 KiB still panicked the pddb
-server outright (the same symptom as issue #297, whose 2023 fix touched only the
-shell command, not the server path std::fs uses); with that server path fixed, it
-is now a normal expected-pass test.
-
-Each XFAIL test's doc comment states the defect, its mechanism, and the suspected
-code path; grep the theme files under `src/tests/` for `XFAIL`.
+failure in `XFAILS` (`src/tests/mod.rs`) rather than being weakened. If a bug is
+fixed, its test flips to `XPASS` and the run goes red until the registry is
+updated. The commit that registers an entry describes the defect; the commit that
+removes it says what fixed it. The registry is currently empty.
 
 ## Adding a test
 
 Write a `pub fn` in the appropriate `src/tests/<theme>.rs` (panic to fail, return
 to pass), then add it to that file's `TESTS` table; `src/tests/mod.rs` aggregates
 the per-theme tables. The important xous/PDDB gotchas — the `/` (not `:`) dict/key
-separator, that `File::create` does not auto-create its parent dict, and that
-`metadata().len()` is always 0 — are documented at the top of `src/tests/mod.rs`
-and in the existing tests. Use `TmpDict` for isolation, verify every write by
-reading it back, and clean up what you create.
+separator and that `File::create` does not auto-create its parent dict — are
+documented at the top of `src/tests/mod.rs` and in the existing tests. Use
+`TmpDict` for isolation, verify every write by reading it back, and clean up what
+you create.

--- a/services/pddb-fs-tests/src/harness.rs
+++ b/services/pddb-fs-tests/src/harness.rs
@@ -16,11 +16,9 @@ impl TmpDict {
     pub fn new(name: &str) -> Self {
         let counter = DICT_COUNTER.fetch_add(1, Ordering::SeqCst);
         let dict = format!("pddbtest.{}.{}", name, counter);
-        // std::fs semantics apply on xous too: the parent "directory" (the
-        // dict) must exist before keys can be created in it — File::create
-        // does NOT auto-create the dict (empirically verified in the harness
-        // pilot; the server only adds a dict when the create_path flag is
-        // set, which plain opens never set).
+        // The dict must exist before keys can be created in it: the server
+        // only adds a dict when the create_path flag is set, which plain
+        // opens never set.
         if let Err(e) = std::fs::create_dir(&dict) {
             panic!("could not create test dict {}: {}", dict, e);
         }
@@ -31,8 +29,8 @@ impl TmpDict {
     /// be '/': std::path::MAIN_SEPARATOR is '/' on xous (SEPARATORS[0] of
     /// ['/', ':'] in the rust fork), and the pddb server splits the final
     /// dict/key pair with rsplit_once(MAIN_SEPARATOR) -- a ':' join makes
-    /// every open fail with "no key was specified" (harness pilot, toolchain
-    /// 1.96.1.1). ':' is only for basis prefixes (`:basis:dict/key`).
+    /// every open fail with "no key was specified". ':' is only for basis
+    /// prefixes (`:basis:dict/key`).
     pub fn path(&self, key: &str) -> String { format!("{}/{}", self.dict, key) }
 
     /// Get the dict name (path) itself, useful for read_dir and similar dict-level operations.

--- a/services/pddb-fs-tests/src/main.rs
+++ b/services/pddb-fs-tests/src/main.rs
@@ -57,7 +57,6 @@ fn main() -> ! {
     // let the rest of the boot sequence quiesce before hammering the PDDB server
     tt.sleep_ms(1000).unwrap();
     let all_tests = tests::all_tests();
-    let all_xfails = tests::all_xfails();
     log::info!("PDDB mounted; running {} tests", all_tests.len());
 
     let mut pass = 0usize;
@@ -67,7 +66,8 @@ fn main() -> ! {
     for &(name, test) in all_tests.iter() {
         PANIC_MSG.lock().unwrap().take();
         let result = panic::catch_unwind(AssertUnwindSafe(test));
-        let expected_bug = all_xfails.iter().find_map(|&(n, bug)| if n == name { Some(bug) } else { None });
+        let expected_bug =
+            tests::XFAILS.iter().find_map(|&(n, bug)| if n == name { Some(bug) } else { None });
         match (result, expected_bug) {
             (Ok(()), None) => {
                 pass += 1;

--- a/services/pddb-fs-tests/src/tests/concur.rs
+++ b/services/pddb-fs-tests/src/tests/concur.rs
@@ -2,27 +2,15 @@
 //!
 //! std::thread works on xous (128 KiB default stacks; none of these tests need
 //! more). See the `tests` module header
-//! (services/pddb-fs-tests/src/tests/mod.rs) for authoring rules and
-//! services/pddb-fs-tests/README.md for the PFC registry.
+//! (services/pddb-fs-tests/src/tests/mod.rs) for authoring rules.
 //!
-//! KNOWN LANDMINE, source-confirmed (services/pddb/src/main.rs:601, 1467):
-//! `fd_mapping` is keyed by `msg.sender.pid()` ALONE, not by (pid, tid). Every
-//! thread of this process shares one PID, so PFC-4's "any successful close
-//! drops the WHOLE per-process fd table" (`fd_mapping.remove(&pid)`) is not
-//! just a same-thread, sequential-handles hazard (as smoke::two_files_close_one
-//! and concur::four_handles_close_one pin it) -- it generalizes structurally
-//! to CONCURRENT threads: if thread A closes any handle while thread B has a
-//! different handle open (even on a totally unrelated dict), B's handle can go
-//! dead. Tests below that run genuinely concurrent open/close cycles
+//! The server keys its per-process fd table by PID alone
+//! (services/pddb/src/main.rs), so every thread of this process shares one
+//! table. The tests that run concurrent open/close cycles
 //! (two_threads_separate_dicts_cycles, three_threads_same_dict_distinct_keys)
-//! are therefore written to TOLERATE isolated I/O errors as already-known
-//! PFC-4 noise (logged, counted, not asserted to be zero) while still
-//! strictly asserting the property that actually matters and that PFC-4 does
-//! NOT license: no thread may ever observe wrong/cross-contaminated DATA, and
-//! at least some concurrent work must get through cleanly (a total wedge would
-//! be a new, more severe bug). This is a deliberate design choice to keep the
-//! suite deterministic (registering a genuinely racy test as a hard XFAIL
-//! risks intermittent XPASS, which the driver treats as a failure).
+//! count isolated I/O errors instead of asserting zero, and assert strictly
+//! what matters: no thread may ever observe wrong or cross-contaminated data,
+//! and at least some concurrent work must get through cleanly.
 
 #![allow(unused_imports)]
 use std::collections::BTreeSet;
@@ -39,11 +27,9 @@ fn read_back(path: &str) -> Vec<u8> {
 }
 
 /// One thread's repeated create/write/read/delete cycle against its OWN key
-/// in its OWN dict. Returns (successful_cycles, tolerated_errors). A cycle
-/// error (e.g. a stale fd from the OTHER thread's concurrent close, PFC-4) is
-/// tolerated and counted; a WRONG value read back never is -- that would be
-/// actual cross-thread data corruption, not a clean I/O error, and is asserted
-/// against unconditionally.
+/// in its OWN dict. Returns (successful_cycles, tolerated_errors). A clean
+/// cycle error is counted; a WRONG value read back never is, since that would
+/// be cross-thread data corruption.
 fn cycle_worker(thread_id: &'static str, cycles: usize) -> (usize, usize) {
     let tmp = TmpDict::new(&format!("two_threads_{}", thread_id));
     let path = tmp.path("cycle");
@@ -67,15 +53,12 @@ fn cycle_worker(thread_id: &'static str, cycles: usize) -> (usize, usize) {
                         content.as_bytes()
                     );
                     ok += 1;
-                    // best-effort: a missing key here is itself PFC-4 noise
-                    // (a concurrent close from the other thread can also
-                    // invalidate the delete path's own fd-table lookups),
-                    // not asserted.
+                    // best-effort: a missing key here is counted, not asserted
                     let _ = fs::remove_file(&path);
                 }
-                Err(_) => errs += 1, // tolerated PFC-4 cross-thread noise (see module doc)
+                Err(_) => errs += 1,
             },
-            Err(_) => errs += 1, // tolerated PFC-4 cross-thread noise (see module doc)
+            Err(_) => errs += 1,
         }
         if (i + 1) % 5 == 0 {
             log::info!(
@@ -95,10 +78,7 @@ fn cycle_worker(thread_id: &'static str, cycles: usize) -> (usize, usize) {
 /// create/write/read/delete cycles concurrently. Asserts no cross-talk: every
 /// successful read-back must equal exactly what THAT thread itself wrote
 /// (thread-tagged content makes any cross-contamination immediately visible),
-/// and both threads must get at least some cycles through cleanly (a total
-/// wedge would be a new, more severe bug than PFC-4's already-documented
-/// noise). See the module doc for why isolated I/O errors are tolerated
-/// rather than hard-asserted to never happen.
+/// and both threads must get at least some cycles through cleanly.
 pub fn two_threads_separate_dicts_cycles() {
     let cycles = 15;
     let t1 = std::thread::spawn(move || cycle_worker("alpha", cycles));
@@ -117,13 +97,12 @@ pub fn two_threads_separate_dicts_cycles() {
 }
 
 /// (2) Three threads write three DISTINCT keys into the SAME dict
-/// concurrently (single open/write/close per thread -- the smallest possible
-/// exposure to the PFC-4 cross-thread landmine described in the module doc).
-/// The main thread then read_dir's the dict and reads back every key whose
-/// writer thread reported success. A reported success that turns out
-/// unreadable or wrong is real corruption and is never tolerated; an
-/// individual writer erroring out cleanly is tolerated PFC-4 noise, but not
-/// all three failing (that would mean the dict itself is wedged).
+/// concurrently (single open/write/close per thread). The main thread then
+/// read_dir's the dict and reads back every key whose writer thread reported
+/// success. A reported success that turns out unreadable or wrong is real
+/// corruption and is never tolerated; an individual writer erroring out
+/// cleanly is counted, but not all three failing (that would mean the dict
+/// itself is wedged).
 pub fn three_threads_same_dict_distinct_keys() {
     let tmp = TmpDict::new("three_threads_same_dict_distinct_keys");
     let dict = tmp.dict().to_string();
@@ -143,15 +122,12 @@ pub fn three_threads_same_dict_distinct_keys() {
             Ok(pair) => written.push(pair),
             Err(e) => log::info!(
                 "three_threads_same_dict_distinct_keys: a concurrent write errored ({}) -- \
-                 tolerated as PFC-4 cross-thread fd-table-wipe noise, see module doc",
+                 counted, not asserted",
                 e
             ),
         }
     }
-    assert!(
-        !written.is_empty(),
-        "every concurrent writer failed -- the dict looks wedged, not merely PFC-4-noisy"
-    );
+    assert!(!written.is_empty(), "every concurrent writer failed -- the dict looks wedged");
 
     let entries = check!(fs::read_dir(&dict));
     let found: BTreeSet<String> =
@@ -219,9 +195,8 @@ pub fn read_dir_races_writer() {
         racy_names.difference(&final_set).collect::<Vec<_>>()
     );
 
-    // Every write path must be verified by read-back:
-    // the race itself is only about read_dir's ENUMERATION, but each key the
-    // writer thread reported as written must still hold its exact content.
+    // The race is about read_dir's enumeration, but each key the writer
+    // thread reported as written must still hold its exact content.
     for (i, name) in writer_names.iter().enumerate() {
         let path = format!("{}/{}", dict, name);
         let content = check!(fs::read(&path));
@@ -236,23 +211,19 @@ pub fn read_dir_races_writer() {
 /// smoke::two_files_close_one: open 4 handles on 4 distinct keys, close the
 /// FIRST one, then probe the other three. Correct POSIX behavior: closing one
 /// fd never affects any other fd, so all three keep working exactly as
-/// before. Pins the PFC-4 fix: `CloseKeyStd`'s unconditional
-/// `fd_mapping.remove(&pid)` used to drop the WHOLE per-process fd table on
-/// that one successful close, failing all three probes.
+/// before.
 ///
-/// Ordering follows smoke::two_files_close_one's PFC-7 hazard rule: Results
-/// are collected first and ALL still-live handles are dropped in a normal
-/// (non-panicking) context before anything here is allowed to panic --
-/// panicking while a dead-fd `File` is still in scope would drop it during
-/// unwind, and a second panic there would abort the whole runner.
+/// As in smoke::two_files_close_one, Results are collected first and all
+/// still-live handles are dropped in a normal context before anything here
+/// is allowed to panic, so a close that panics cannot abort the runner as a
+/// double panic during unwind.
 pub fn four_handles_close_one() {
     let tmp = TmpDict::new("four_handles_close_one");
     let paths: Vec<String> = (0..4).map(|i| tmp.path(&format!("h{}", i))).collect();
     for (i, p) in paths.iter().enumerate() {
         check!(fs::write(p, format!("init-{}", i).as_bytes()));
-        // Every write path must be verified by read-back
-        // -- including handle 0's, even though it is about to be closed
-        // deliberately below and never probed again afterward.
+        // Verify every write, including handle 0's, which is closed below
+        // and never probed again.
         assert_eq!(
             &read_back(p)[..],
             format!("init-{}", i).as_bytes(),
@@ -268,8 +239,8 @@ pub fn four_handles_close_one() {
     let doomed = handles.remove(0);
     drop(doomed);
 
-    // Probe the remaining three WITHOUT panicking while any of them is still
-    // open (see the PFC-7 hazard note above): collect every Result first.
+    // Probe the remaining three without panicking while any of them is still
+    // open: collect every Result first.
     let mut seek_results = Vec::new();
     let mut read_results = Vec::new();
     for h in handles.iter_mut() {
@@ -297,36 +268,20 @@ pub fn four_handles_close_one() {
 }
 
 /// (5) Two independent handles opened on the SAME key, from two GENUINELY
-/// concurrent std::thread workers. (The brief scopes item (4)'s many-handles
-/// test explicitly to "sequential" characterization but says no such thing
-/// here, and a same-key multi-handle test that never actually runs on two
-/// threads would under-deliver the "concur" theme.) Each thread owns a
-/// DISJOINT byte range of the shared 10-byte key (A: 0-1 then 2-3; B: 4-5
-/// then 8-9), so the final layout is deterministic regardless of scheduling
-/// order -- the point under test is whether the server's shared-buffer
-/// writes stay non-overlapping-safe under real concurrent access, not
-/// scheduler order itself (no seeks past the seeded length, so this also
-/// stays outside PFC-5's stale-length territory).
+/// concurrent std::thread workers. Each thread owns a DISJOINT byte range of
+/// the shared 10-byte key (A: 0-1 then 2-3; B: 4-5 then 8-9), so the final
+/// layout is deterministic regardless of scheduling order. Neither handle is
+/// closed until both threads have finished their writes and been joined.
 ///
-/// Neither handle is closed until BOTH threads have finished all of their
-/// writes and been joined back into the main thread: PFC-4 (`CloseKeyStd`'s
-/// whole-process fd-table wipe, see the module doc) fires only on a
-/// successful CLOSE, so deferring both closes this way keeps the test about
-/// same-key write semantics rather than accidentally becoming another PFC-4
-/// reproducer.
-///
-/// Documents xous's actual semantics: the server holds one shared in-memory/
-/// on-disk copy of the key's bytes and each write opcode splices directly
-/// into it at the given offset (backend/dictionary.rs key_update) -- there is
-/// no per-handle private buffering, so two handles on the same key behave
-/// like two independent POSIX opens of the same inode with disjoint-range
-/// pwrite()s: whichever thread's writes the scheduler lands first, the final
-/// byte layout is the same. This matches POSIX and is asserted as-is (no
-/// XFAIL).
+/// The server holds one shared copy of the key's bytes and each write opcode
+/// splices directly into it at the given offset (backend/dictionary.rs
+/// key_update); there is no per-handle private buffering, so two handles on
+/// the same key behave like two independent POSIX opens of the same inode
+/// with disjoint-range pwrite()s.
 pub fn same_file_two_handles_interleaved_writes() {
     let tmp = TmpDict::new("same_file_two_handles_interleaved_writes");
     let path = tmp.path("shared");
-    check!(fs::write(&path, &[0u8; 10])); // seed: 10 zero bytes, well under 4 KiB
+    check!(fs::write(&path, &[0u8; 10])); // seed: 10 zero bytes
 
     let path_a = path.clone();
     let ta = std::thread::spawn(move || -> File {
@@ -355,9 +310,7 @@ pub fn same_file_two_handles_interleaved_writes() {
 
     let content = read_back(&path);
     // A owns bytes 0-3 (AACC), B owns bytes 4-5 and 8-9 (BB..DD); bytes 6-7
-    // stay the untouched 0x00 NUL bytes from the seed (NOT ASCII '0' -- the
-    // suite cold run caught exactly that authoring slip) -- disjoint ranges
-    // make this deterministic.
+    // stay the untouched 0x00 NUL bytes from the seed, not ASCII '0'.
     assert_eq!(
         &content[..],
         b"AACCBB\x00\x00DD",
@@ -374,17 +327,10 @@ pub fn same_file_two_handles_interleaved_writes() {
 /// works), so the worker thread's death must be fully contained to that
 /// thread.
 ///
-/// PFC-4 EXPOSURE (empirically hit on the suite warm run): the worker's
-/// `File` close -- explicit or via drop-during-unwind -- wipes this whole
-/// process's fd table, so a main-thread op caught mid-cycle (fs::write holds
-/// an fd between its open and close) can fail with a clean I/O error while
-/// the worker unwinds. Per this theme's design (module doc), the CONCURRENT
-/// phase therefore tolerates clean I/O errors as known PFC-4 noise (logged,
-/// counted, never wrong-data), and the STRICT health proof runs after join,
-/// when no concurrent closer can exist any more. The worker also drops its
-/// handle in normal (non-unwind) context before panicking, per the PFC-7
-/// drop-handles-before-panicking rule (so a close during unwind cannot
-/// double-panic and abort the runner).
+/// The concurrent phase counts clean I/O errors and never tolerates wrong
+/// data; the strict health check runs after join. The worker drops its
+/// handle in normal context before panicking, so a close during unwind
+/// cannot abort the runner as a double panic.
 pub fn thread_panic_mid_io_isolation() {
     let tmp = TmpDict::new("thread_panic_mid_io_isolation");
     let victim_path = tmp.path("victim");
@@ -397,9 +343,7 @@ pub fn thread_panic_mid_io_isolation() {
         let read_res = File::open(&worker_path).and_then(|mut f| f.read_to_end(&mut buf).map(|_| ()));
         // The handle is dropped inside and_then, in normal (non-unwind)
         // context. Whichever arm runs, this thread panics ON PURPOSE: that
-        // containment is the property under test. (The Err arm exists because
-        // the main thread's concurrent closes can kill this thread's fd first
-        // -- PFC-4 -- which must not turn into a different test outcome.)
+        // containment is the property under test.
         match read_res {
             Ok(()) => assert_eq!(
                 &buf[..],
@@ -407,14 +351,14 @@ pub fn thread_panic_mid_io_isolation() {
                 "deliberate panic to exercise harness thread isolation"
             ),
             Err(e) => {
-                panic!("deliberate panic (read errored first: {} -- tolerated PFC-4 noise)", e)
+                panic!("deliberate panic (read errored first: {})", e)
             }
         }
     });
 
     // Main thread keeps doing normal fs ops WHILE the worker thread panics.
-    // Clean I/O errors here are tolerated PFC-4 cross-thread noise (see the
-    // doc comment above); wrong DATA on a successful read never is.
+    // Clean I/O errors here are counted; wrong DATA on a successful read is
+    // never tolerated.
     let main_path = tmp.path("main");
     let mut ok = 0usize;
     let mut errs = 0usize;
@@ -431,9 +375,9 @@ pub fn thread_panic_mid_io_isolation() {
                     );
                     ok += 1;
                 }
-                Err(_) => errs += 1, // tolerated PFC-4 noise
+                Err(_) => errs += 1,
             },
-            Err(_) => errs += 1, // tolerated PFC-4 noise
+            Err(_) => errs += 1,
         }
     }
     log::info!("thread_panic_mid_io_isolation: concurrent phase done ({} ok, {} tolerated errs)", ok, errs);
@@ -458,7 +402,7 @@ pub fn thread_panic_mid_io_isolation() {
     check!(fs::remove_file(&victim_path));
 }
 
-/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// This theme's tests (aggregated by tests::all_tests).
 pub const TESTS: &[(&str, fn())] = &[
     ("concur::two_threads_separate_dicts_cycles", two_threads_separate_dicts_cycles as fn()),
     ("concur::three_threads_same_dict_distinct_keys", three_threads_same_dict_distinct_keys as fn()),
@@ -467,5 +411,3 @@ pub const TESTS: &[(&str, fn())] = &[
     ("concur::same_file_two_handles_interleaved_writes", same_file_two_handles_interleaved_writes as fn()),
     ("concur::thread_panic_mid_io_isolation", thread_panic_mid_io_isolation as fn()),
 ];
-
-pub const XFAILS: &[(&str, &str)] = &[];

--- a/services/pddb-fs-tests/src/tests/content.rs
+++ b/services/pddb-fs-tests/src/tests/content.rs
@@ -77,17 +77,6 @@ pub fn binary_file() {
 }
 
 /// Test fs::copy with valid source and destination.
-///
-/// PASSES on target (empirically confirmed 2026-07-07; formerly registered
-/// XFAIL PFC-4). The predicted close cascade half-happens: fs::copy holds
-/// both files open, the writer drops first, and its successful CloseKeyStd
-/// really does drop the WHOLE per-process fd table (PFC-4 is real -- see
-/// smoke::two_files_close_one), so the reader's follow-up close is answered
-/// with an error retcode via `return_scalar`. But the fork's
-/// `blocking_scalar` (os/xous/ffi.rs) maps ANY Scalar1/Scalar2 reply to Ok,
-/// so `File::drop`'s unwrap (PFC-7) never observes the retcode -- the close
-/// error is silently discarded instead of panicking. `io::copy` completes
-/// before either close, so the copy and its content survive intact.
 pub fn copy_file_ok() {
     let tmp = TmpDict::new("copy_file_ok");
     let src = tmp.path("source");
@@ -190,23 +179,18 @@ pub fn copy_file_src_dir() {
     assert!(fs::metadata(&dst).is_err(), "destination should not be created for a failed copy");
 }
 
-/// Test fs::copy when destination file already exists (both files small < 4 KiB).
+/// Test fs::copy when destination file already exists.
 /// The copy should succeed and overwrite the destination with source content.
-///
-/// PASSES on target (empirically confirmed 2026-07-07; formerly registered
-/// XFAIL PFC-4): same silently-discarded close cascade as copy_file_ok --
-/// see its doc comment. (The truncating re-create of `dst` stays far under
-/// the 4 KiB PFC-1 hazard line.)
 pub fn copy_file_dst_exists() {
     let tmp = TmpDict::new("copy_file_dst_exists");
     let src = tmp.path("source");
     let dst = tmp.path("dest");
 
-    // Create source file with content (keep small < 4 KiB)
+    // Create source file with content
     let src_content = b"new content from source";
     check!(fs::write(&src, src_content));
 
-    // Create destination file with different content (keep small < 4 KiB)
+    // Create destination file with different content
     let dst_initial = b"old content at destination";
     check!(fs::write(&dst, dst_initial));
 
@@ -225,12 +209,8 @@ pub fn copy_file_dst_exists() {
 /// Multi-file test: create ~30 small keys in one dict, enumerate with read_dir,
 /// verify all names are present, spot-check 3 contents, remove all, verify empty.
 ///
-/// `readdir` is a single ListPathStd call with a 4096-byte senres reply, and
-/// truncation behavior past that size
-/// is unverified; this test's ~30 short names is deliberately in that
-/// unexplored range. Assert the CORRECT (full-enumeration) behavior as-is --
-/// if the reply truncates in practice, that is a new characterization to
-/// register as a PFC/XFAIL, not a reason to shrink the assertion here.
+/// `readdir` is a single ListPathStd call with a 4096-byte senres reply;
+/// this test's ~30 short names must all be enumerated.
 pub fn read_dir_enumerate() {
     let tmp = TmpDict::new("read_dir_enumerate");
 
@@ -244,11 +224,9 @@ pub fn read_dir_enumerate() {
         let content = format!("content_{}", i).into_bytes();
         check!(fs::write(&path, &content));
         expected_names.insert(name);
-        // Console liveness: a fresh key write emits NO console output and
-        // costs ~4-8 s host under Renode, so 30 silent writes overran the
-        // driver's 180 s inactivity reaper on the first suite cold run
-        // (the system was healthy; the reaper presumed the server dead).
-        // Any long fs-op loop must emit periodic diagnostics like this.
+        // Liveness: a key write emits no console output and costs seconds
+        // under Renode, so a silent loop would trip the driver's inactivity
+        // reaper.
         if (i + 1) % 5 == 0 {
             log::info!("read_dir_enumerate: created {}/{} files", i + 1, num_files);
         }
@@ -298,7 +276,7 @@ pub fn read_dir_enumerate() {
     assert_eq!(remaining_count, 0, "dict should be empty after removing all files");
 }
 
-/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// This theme's tests (aggregated by tests::all_tests).
 pub const TESTS: &[(&str, fn())] = &[
     ("content::write_then_read", write_then_read as fn()),
     ("content::binary_file", binary_file as fn()),
@@ -309,13 +287,4 @@ pub const TESTS: &[(&str, fn())] = &[
     ("content::copy_file_src_dir", copy_file_src_dir as fn()),
     ("content::copy_file_dst_exists", copy_file_dst_exists as fn()),
     ("content::read_dir_enumerate", read_dir_enumerate as fn()),
-];
-
-pub const XFAILS: &[(&str, &str)] = &[
-    // content::copy_file_ok / copy_file_dst_exists were registered XFAIL
-    // PFC-4 on the theory that PFC-4's whole-fd-table drop on the first
-    // close plus PFC-7's drop unwrap panics every fs::copy; both XPASSed on
-    // target 2026-07-07 (the close-error retcode is silently discarded, not
-    // unwrapped -- see the tests' doc comments and PFC-7), so they are now
-    // expected to PASS.
 ];

--- a/services/pddb-fs-tests/src/tests/dirs.rs
+++ b/services/pddb-fs-tests/src/tests/dirs.rs
@@ -1,8 +1,7 @@
 //! Theme: directories (PDDB dicts) and metadata-kind (is_file/is_dir,
 //! exists, read_dir/DirEntry). Ported/adapted from upstream
 //! library/std/src/fs/tests.rs -- see the `tests` module header
-//! (services/pddb-fs-tests/src/tests/mod.rs) for the path grammar ('/'), the
-//! truncate hazard, and XFAIL discipline.
+//! (services/pddb-fs-tests/src/tests/mod.rs) for the path grammar ('/').
 //!
 //! PDDB dicts are FLAT, not a real directory tree: `create_dict`
 //! (services/pddb/src/libstd/mod.rs) takes the entire path remainder (after
@@ -40,8 +39,7 @@ pub fn stat_is_correct_on_is_file() {
         let fstat_res = check!(f.metadata());
         assert!(fstat_res.is_file(), "open handle metadata should report is_file()");
     }
-    // Every write path must be read-back verified, not
-    // just checked for success -- confirm the content before checking stat.
+    // Confirm the content before checking stat.
     assert_eq!(check!(fs::read(&path)), b"hw", "content should read back intact");
     let stat_res_fn = check!(fs::metadata(&path));
     assert!(stat_res_fn.is_file(), "fs::metadata should report is_file()");
@@ -79,8 +77,6 @@ pub fn fileinfo_check_exists_before_and_after_file_creation() {
     assert!(!Path::new(&path).exists(), "key should not exist before creation");
     check!(check!(File::create(&path)).write_all(b"foo"));
     assert!(Path::new(&path).exists(), "key should exist after creation");
-    // metadata().len() is always 0 on xous (PFC-5): verify content by
-    // read-back, never via metadata length.
     let content = check!(fs::read(&path));
     assert_eq!(content, b"foo", "content should read back intact");
     check!(fs::remove_file(&path));
@@ -99,10 +95,9 @@ pub fn directoryinfo_check_exists_before_and_after_mkdir() {
     assert!(!Path::new(&dir).exists(), "dict should not exist after removal");
 }
 
-/// Port of `file_test_directoryinfo_readdir`, adapted: `metadata().len()` is
-/// always 0 on xous (PFC-5), so content is verified by read-back instead of
-/// length; entries are asserted `is_file()` (a dict's own listing only ever
-/// contains keys -- see the module-level flatness note).
+/// Port of `file_test_directoryinfo_readdir`, adapted: entries are asserted
+/// `is_file()` (a dict's own listing only ever contains keys -- see the
+/// module-level flatness note).
 pub fn directoryinfo_readdir() {
     let tmp = TmpDict::new("directoryinfo_readdir");
     let prefix = "foo";
@@ -143,9 +138,7 @@ pub fn dir_entry_methods() {
         assert!(check!(entry.file_type()).is_file(), "file_type() should report is_file()");
         assert!(check!(entry.metadata()).is_file(), "metadata() should report is_file()");
         let name = entry.file_name().into_string().expect("utf8 filename");
-        // Read-back verification of the write behind this entry:
-        // don't just trust fs::write's Ok(()), confirm the content DirEntry::path()
-        // resolves to is exactly what was written for that key.
+        // Confirm the content DirEntry::path() resolves to is what was written.
         let expected_content: &[u8] = match name.as_str() {
             "a" => b"aaa",
             "b" => b"bbb",
@@ -161,25 +154,15 @@ pub fn dir_entry_methods() {
     check!(fs::remove_file(tmp.path("b")));
 }
 
-/// Port of `read_dir_not_found`. Don't assert a specific ErrorKind: the
-/// contract only requires that for `Unsupported`-characterization tests
-/// (most xous errors collapse to `ErrorKind::Other`). Still routed through a
-/// `TmpDict` (counter-unique prefix) rather than a bare string literal, per
-/// the isolation rules, even though nothing is created here:
-/// `_missing` is never created, so the dict genuinely does not exist.
-///
-/// XFAIL PFC-9: `fs::read_dir` on a nonexistent directory returns Ok with an
-/// EMPTY iterator instead of an error. The server's `list_path`
-/// (services/pddb/src/libstd/mod.rs ~184: "Ignore errors, since sometimes
-/// the dict doesn't exist" -- `key_list(...).unwrap_or_default()`) never
-/// reports a missing dict, and the client's `readdir` (rust fork
-/// sys/fs/xous.rs) has no retcode check either. POSIX requires ENOENT here;
-/// assert the error and expect the XFAIL until PFC-9 is fixed.
+/// Port of `read_dir_not_found`: `fs::read_dir` on a nonexistent dict must
+/// error, never return an empty iterator. Don't assert a specific ErrorKind
+/// (most xous errors collapse to `ErrorKind::Other`). The name comes from a
+/// `TmpDict` so it is unique, but `_missing` is never created.
 pub fn read_dir_not_found() {
     let tmp = TmpDict::new("read_dir_not_found");
     let missing = format!("{}_missing", tmp.dict());
     let res = fs::read_dir(&missing);
-    let err = res.expect_err("read_dir on a nonexistent dict should error (PFC-9)");
+    let err = res.expect_err("read_dir on a nonexistent dict should error");
     log::info!("read_dir on nonexistent dict returned ErrorKind::{:?}", err.kind());
 }
 
@@ -217,17 +200,13 @@ pub fn unicode_path_exists() {
 }
 
 /// Port of `mkdir_path_already_exists_error`: POSIX mkdir semantics require
-/// `create_dir` on an existing path to fail. XFAIL PFC-6: the xous client's
-/// `create_dir` discards the server's error retcode and returns Ok even when
-/// the dict already exists (rust fork sys/fs/xous.rs ~444-448; contrast
-/// unlink/rmdir, which do check it). Never weaken
-/// this to `is_ok()` -- the correct behavior is `is_err()`.
+/// `create_dir` on an existing path to fail.
 pub fn mkdir_path_already_exists_error() {
     let tmp = TmpDict::new("mkdir_path_already_exists_error");
     let dir = format!("{}_twice", tmp.dict());
     check!(fs::create_dir(&dir));
     let r = fs::create_dir(&dir);
-    assert!(r.is_err(), "create_dir on an already-existing dict must fail (PFC-6)");
+    assert!(r.is_err(), "create_dir on an already-existing dict must fail");
     check!(fs::remove_dir(&dir));
 }
 
@@ -242,8 +221,7 @@ pub fn recursive_rmdir() {
     for i in 0..3 {
         let key_path = victim.path(&format!("k{i}"));
         check!(fs::write(&key_path, format!("v{i}")));
-        // Read-back verification of every write before
-        // the key is destroyed by remove_dir_all below.
+        // Verify every write before remove_dir_all destroys the keys.
         assert_eq!(
             check!(fs::read_to_string(&key_path)),
             format!("v{i}"),
@@ -344,7 +322,7 @@ pub fn concurrent_recursive_mkdir() {
     check!(fs::remove_dir(nested.as_str()));
 }
 
-/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// This theme's tests (aggregated by tests::all_tests).
 pub const TESTS: &[(&str, fn())] = &[
     ("dirs::stat_is_correct_on_is_file", stat_is_correct_on_is_file as fn()),
     ("dirs::stat_is_correct_on_is_dir", stat_is_correct_on_is_dir as fn()),
@@ -374,5 +352,3 @@ pub const TESTS: &[(&str, fn())] = &[
     ),
     ("dirs::concurrent_recursive_mkdir", concurrent_recursive_mkdir as fn()),
 ];
-
-pub const XFAILS: &[(&str, &str)] = &[];

--- a/services/pddb-fs-tests/src/tests/dirs.rs
+++ b/services/pddb-fs-tests/src/tests/dirs.rs
@@ -375,9 +375,4 @@ pub const TESTS: &[(&str, fn())] = &[
     ("dirs::concurrent_recursive_mkdir", concurrent_recursive_mkdir as fn()),
 ];
 
-pub const XFAILS: &[(&str, &str)] = &[
-    ("dirs::mkdir_path_already_exists_error", "PFC-6"),
-    // read_dir on a missing dict returns Ok(empty) instead of an error --
-    // see the test's doc comment and PFC-9.
-    ("dirs::read_dir_not_found", "PFC-9"),
-];
+pub const XFAILS: &[(&str, &str)] = &[];

--- a/services/pddb-fs-tests/src/tests/errors.rs
+++ b/services/pddb-fs-tests/src/tests/errors.rs
@@ -367,9 +367,4 @@ pub const TESTS: &[(&str, fn())] = &[
     ("errors::churn_create_delete", churn_create_delete as fn()),
 ];
 
-pub const XFAILS: &[(&str, &str)] = &[
-    // create_dir swallows ALL server retcodes (fork mkdir never reads the
-    // reply), so the over-length name "succeeds" -- see the test's comment.
-    ("errors::dict_name_length_boundary", "PFC-6"),
-    ("errors::metadata_len_characterization", "PFC-5"),
-];
+pub const XFAILS: &[(&str, &str)] = &[];

--- a/services/pddb-fs-tests/src/tests/errors.rs
+++ b/services/pddb-fs-tests/src/tests/errors.rs
@@ -1,8 +1,4 @@
 //! THEME errors: error paths and boundary conditions.
-//!
-//! All assertions state the CORRECT (or, where it is a documented xous
-//! semantic rather than a bug, the documented) behavior; known bugs are pinned
-//! in this theme's XFAILS table -- never weaken an assertion.
 
 use std::fs::{self, File, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
@@ -32,7 +28,7 @@ pub fn open_missing_is_err() {
 /// retcode-to-ErrorKind mapping upstream (services/pddb/src/libstd/mod.rs
 /// `open_key` returns `PddbRetcode::BasisLost` when the dict/key doesn't
 /// exist in any basis). Pinned here so a future retcode-mapping change shows
-/// up as a loud XPASS-shaped surprise rather than silently drifting.
+/// up rather than silently drifting.
 pub fn open_missing_kind_characterization() {
     let tmp = TmpDict::new("open_missing_kind_characterization");
     let path = tmp.path("never_created");
@@ -115,11 +111,9 @@ pub fn open_empty_path() {
 /// that (called synchronously from `dict_add` -> `dict_sync` on every
 /// `create_dir`, so the error surfaces immediately, not asynchronously).
 ///
-/// NOTE for the registry maintainer: the documented dict-name limit of
-/// "<= 111 bytes" reads api.rs's `DICT_NAME_LEN` constant alone
-/// without the backend struct's reserved length byte. This test asserts the
-/// verified real boundary (110 ok / 111 errors) instead of weakening to match
-/// the doc; flagged as an open question to reconcile the doc.
+/// The documented dict-name limit of "<= 111 bytes" reads api.rs's
+/// `DICT_NAME_LEN` constant alone, without the backend struct's length byte.
+/// This test asserts the real boundary (110 ok / 111 errors).
 ///
 /// This needs a bare top-level dict name of an exact byte length -- `TmpDict`
 /// always appends an unpredictable `.<counter>` suffix (`harness.rs`) -- so it
@@ -151,20 +145,8 @@ pub fn dict_name_length_boundary() {
     check!(fs::remove_dir(&ok_name));
 
     // One byte over: must error cleanly (POSIX ENAMETOOLONG territory).
-    // XFAIL PFC-6: the client's `DirBuilder::mkdir` (rust fork
-    // sys/fs/xous.rs) never reads the server's reply retcode at all, so the
-    // server-side InternalError from `DictName::try_from_str` is swallowed
-    // and create_dir returns Ok. Same client bug as the already-exists case
-    // pinned by dirs::mkdir_path_already_exists_error.
     let over_res = fs::create_dir(&over_name);
     // Cleanup BEFORE the assert (a failing assert must not strand state).
-    // Historically this also cleared server-side damage: `dict_add` used to
-    // insert the dict into the in-memory basis cache and bump num_dicts
-    // *before* the dict_sync that validated the name length, stranding the
-    // rejected dict in RAM and drifting the basis's num_dicts accounting
-    // (the dict-name twin of PFC-8) until it was explicitly removed.
-    // `dict_add` now validates the name up front, so nothing is created and
-    // this remove is just a harmless failed no-op.
     let _ = fs::remove_dir_all(&over_name);
     assert!(over_res.is_err(), "create_dir with a {}-byte dict name unexpectedly succeeded", over_name.len());
 
@@ -187,16 +169,8 @@ pub fn dict_name_length_boundary() {
 /// `KEY_NAME_LEN - 1` = 94 bytes -- `KeyName::try_from_str` errors past that
 /// (checked at the top of every `key_update`, including the create-file
 /// path, before any cache mutation). Same off-by-one relative to the
-/// documented "<= 95" as `dict_name_length_boundary` above.
-///
-/// Formerly XFAIL PFC-8: `key_update`'s new-key path used to insert the
-/// KeyCacheEntry and bump key_count *before* the `dict_sync` whose
-/// `KeyName::try_from_str` rejected the over-length name, so the rejected
-/// key stayed poisoned -- valid+dirty -- in the dict's key cache, and EVERY
-/// later `dict_sync` of this dict re-failed on it (the follow-up "alive"
-/// create below is what caught that). `key_update` now validates the name
-/// before any cache mutation, so the over-length create errors cleanly and
-/// the dict stays usable.
+/// documented "<= 95" as `dict_name_length_boundary` above. The follow-up
+/// create checks that a rejected name leaves the dict usable.
 pub fn key_name_length_boundary() {
     const KEY_MAX: usize = 94;
     let tmp = TmpDict::new("key_name_length_boundary");
@@ -230,13 +204,7 @@ pub fn key_name_length_boundary() {
     check!(fs::remove_file(&alive_path));
 }
 
-/// `fs::metadata(path).len()` characterization. POSIX-correct behavior is
-/// that the returned length matches the actual content length; xous instead
-/// always reports 0 (PFC-5: the server half is fixed -- `stat_path` now
-/// sends the key's real length -- but the client libstd `stat()` never
-/// reads the length word and hardcodes `len: 0`, so metadata stays 0 until
-/// a rebuilt client ships). Assert the CORRECT length and register the
-/// XFAIL -- never assert the buggy `0`.
+/// `fs::metadata(path).len()` must report the actual content length.
 pub fn metadata_len_characterization() {
     let tmp = TmpDict::new("metadata_len_characterization");
     let path = tmp.path("sized");
@@ -250,7 +218,7 @@ pub fn metadata_len_characterization() {
     assert_eq!(
         md.len(),
         content.len() as u64,
-        "PFC-5: fs::metadata(..).len() should report the actual content length"
+        "fs::metadata(..).len() should report the actual content length"
     );
     check!(fs::remove_file(&path));
 }
@@ -259,16 +227,8 @@ pub fn metadata_len_characterization() {
 /// every currently-open `FileHandle` for the removed dict/key `deleted`,
 /// and `get_fd` (used by `read_key`/`write_key`/`seek_key`) then rejects
 /// all further I/O on it with `BasisLost` -- the intended (POSIX-divergent
-/// but deliberate) xous behavior this test asserts.
-///
-/// Regression pin for PFC-11 (fixed): the marking loop used to compare
-/// `fd.basis` against the raw `split_basis_and_dict` result of the unlink
-/// path -- `None` for any non-`:basis:`-prefixed path -- while `open_key`
-/// always records `fd.basis = Some(<actual basis>)`. The handle was never
-/// marked: the read still errored (the key's data really was gone
-/// server-side), but the write went through `write_key` -> `key_update`,
-/// silently RE-CREATING the deleted key at the old path. `delete_key` now
-/// resolves the effective default basis before comparing.
+/// but deliberate) xous behavior this test asserts. A write through the
+/// stale handle must not re-create the deleted key.
 pub fn delete_while_open() {
     let tmp = TmpDict::new("delete_while_open");
     let path = tmp.path("victim");
@@ -293,7 +253,7 @@ pub fn delete_while_open() {
         "write through a deleted-while-open handle unexpectedly succeeded (POSIX divergence; \
          xous errors here by design)"
     );
-    drop(f); // close_key does not check the `deleted` flag; this does not hit PFC-7.
+    drop(f); // close_key does not check the `deleted` flag, so this close succeeds
 }
 
 /// `File::create` of a key inside a dict that was never created must fail:
@@ -349,7 +309,7 @@ pub fn churn_create_delete() {
     check!(fs::remove_file(&anchor));
 }
 
-/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// This theme's tests (aggregated by tests::all_tests).
 pub const TESTS: &[(&str, fn())] = &[
     ("errors::open_missing_is_err", open_missing_is_err as fn()),
     ("errors::open_missing_kind_characterization", open_missing_kind_characterization as fn()),
@@ -366,5 +326,3 @@ pub const TESTS: &[(&str, fn())] = &[
     ("errors::create_in_missing_dict", create_in_missing_dict as fn()),
     ("errors::churn_create_delete", churn_create_delete as fn()),
 ];
-
-pub const XFAILS: &[(&str, &str)] = &[];

--- a/services/pddb-fs-tests/src/tests/mod.rs
+++ b/services/pddb-fs-tests/src/tests/mod.rs
@@ -1,11 +1,12 @@
 //! Test registry, plus the rules for adding a test.
 //!
-//! Each theme module owns its own `TESTS` and `XFAILS` tables; this module only
-//! aggregates them. A test is a `pub fn` that panics to fail and returns to
-//! pass; register it in its theme's `TESTS` table and, if it reproduces a known
-//! bug, add it to that theme's `XFAILS` table against the bug's ID. Never weaken
-//! an assertion to make a test pass — assert the correct behavior and register
-//! the XFAIL.
+//! Each theme module owns its own `TESTS` table; this module aggregates them
+//! and holds the expected-failure registry `XFAILS`. A test is a `pub fn` that
+//! panics to fail and returns to pass; register it in its theme's `TESTS`
+//! table and, if it reproduces a known bug, add it to `XFAILS` against the
+//! bug's ID, with the defect described in the commit that registers it. Never
+//! weaken an assertion to make a test pass — assert the correct behavior and
+//! register the XFAIL.
 //!
 //! xous/PDDB semantics that trip up std::fs habits:
 //! - The dict/key separator is `/`, not `:`. `std::path::MAIN_SEPARATOR` on xous is `/`; the server splits
@@ -13,14 +14,8 @@
 //!   (`:basis:dict/key`).
 //! - `File::create` does NOT create the parent dict (the client sends `create_path=false`). Use
 //!   `TmpDict::new`, which creates its dict first.
-//! - `fs::metadata(..).len()` is always 0 (bug PFC-5): verify sizes by reading content back, never via
-//!   metadata.
 //! - Most failures map to `ErrorKind::Other`, not the POSIX-specific kind. Assert `is_err()`; only assert a
 //!   specific kind for the `Unsupported` surface.
-//! - Truncating (`File::create` / `.truncate(true)`) over an existing key >= ~4 KiB used to panic the pddb
-//!   server and hang the rest of the run (bug PFC-1, fixed: the large-key truncate arm in
-//!   backend/dictionary.rs now truncates the length only); `smoke::overwrite_shorter_large` covers it as a
-//!   normal expected-pass test.
 //! - A loop of more than ~10 fs ops must `log::info!` every ~5 iterations: a successful op emits no output,
 //!   and a long silent loop trips the driver's inactivity reaper (which treats console silence as a dead
 //!   server).
@@ -44,10 +39,12 @@ pub mod unsupported;
 /// (unique `theme::snake_case` name, test fn). A test panics to fail and
 /// returns normally to pass.
 pub type TestEntry = (&'static str, fn());
-/// (test name, PFC bug ID) — see services/pddb-fs-tests/README.md.
-/// A listed test that fails reports XFAIL; one that passes reports XPASS (bug
-/// apparently fixed — update the theme's table!).
+/// (test name, bug ID). A listed test that fails reports XFAIL; one that
+/// passes reports XPASS and fails the run until it is removed from `XFAILS`.
 pub type XfailEntry = (&'static str, &'static str);
+
+/// The known-bug registry.
+pub const XFAILS: &[XfailEntry] = &[];
 
 /// Every registered test, aggregated from the theme modules.
 pub fn all_tests() -> Vec<TestEntry> {
@@ -63,22 +60,5 @@ pub fn all_tests() -> Vec<TestEntry> {
     v.extend_from_slice(sizes::TESTS);
     v.extend_from_slice(concur::TESTS);
     v.extend_from_slice(persist::TESTS);
-    v
-}
-
-/// The known-bug registry, aggregated from the theme modules.
-pub fn all_xfails() -> Vec<XfailEntry> {
-    let mut v: Vec<XfailEntry> = Vec::new();
-    v.extend_from_slice(smoke::XFAILS);
-    v.extend_from_slice(rw::XFAILS);
-    v.extend_from_slice(openflags::XFAILS);
-    v.extend_from_slice(dirs::XFAILS);
-    v.extend_from_slice(errors::XFAILS);
-    v.extend_from_slice(content::XFAILS);
-    v.extend_from_slice(unsupported::XFAILS);
-    v.extend_from_slice(paths::XFAILS);
-    v.extend_from_slice(sizes::XFAILS);
-    v.extend_from_slice(concur::XFAILS);
-    v.extend_from_slice(persist::XFAILS);
     v
 }

--- a/services/pddb-fs-tests/src/tests/openflags.rs
+++ b/services/pddb-fs-tests/src/tests/openflags.rs
@@ -360,4 +360,4 @@ pub const TESTS: &[(&str, fn())] = &[
     ("openflags::double_create_truncates_each_time", double_create_truncates_each_time as fn()),
 ];
 
-pub const XFAILS: &[(&str, &str)] = &[("openflags::create_new_creates_missing", "PFC-10")];
+pub const XFAILS: &[(&str, &str)] = &[];

--- a/services/pddb-fs-tests/src/tests/openflags.rs
+++ b/services/pddb-fs-tests/src/tests/openflags.rs
@@ -11,9 +11,6 @@
 //! the wire at all, and `FileHandle` has no access-mode field for `write_key`/
 //! `read_key` to consult. This corroborates the documented claim that
 //! `OpenOptions::read()/write()` are silently dropped client-side.
-//!
-//! SERVER-CRASH HAZARD: every file below is small
-//! (well under 4 KiB) even across repeated truncating re-creates.
 
 #![allow(unused_imports)]
 use std::fs::{self, File, OpenOptions};
@@ -63,14 +60,8 @@ pub fn create_existing_preserves_content_without_truncate() {
     check!(fs::remove_file(&path));
 }
 
-/// `create_new(true)` on a missing path creates it (correct std semantics:
-/// `create_new` implies creation, like O_CREAT|O_EXCL). XFAIL PFC-10,
-/// empirically confirmed on the Renode image 2026-07-07: the rust fork
-/// serializes `create_file` and `create_new` as independent booleans and never
-/// combines them, while the server's key-creation branch only runs when
-/// `create_file` is set -- so `create_new` WITHOUT `.create(true)` falls
-/// through every basis and the open errors ("unable to find key ..."). See
-/// PFC-10.
+/// `create_new(true)` on a missing path creates it without `.create(true)`:
+/// `create_new` implies creation, like O_CREAT|O_EXCL.
 pub fn create_new_creates_missing() {
     let tmp = TmpDict::new("create_new_missing");
     let path = tmp.path("f");
@@ -100,9 +91,7 @@ pub fn create_new_fails_on_existing() {
 }
 
 /// `truncate(true)` on an existing file clears it before the subsequent write
-/// lands -- verified by content read-back (never by metadata: PFC-5 makes
-/// `metadata().len()` always 0, but the *actual key bytes* are genuinely
-/// replaced, which is all a read-back checks).
+/// lands.
 pub fn truncate_flag_on_existing_clears_and_writes() {
     let tmp = TmpDict::new("truncate_existing");
     let path = tmp.path("f");
@@ -193,8 +182,7 @@ pub fn create_and_truncate_on_existing() {
 // ("creating or truncating a file requires write or append access", "must
 // specify at least one of read, write, or append access") before ever
 // touching the OS. The xous fork's sys/fs implementation performs no such
-// validation -- these are documented xous semantics (not bugs), asserted as
-// what actually happens per the XFAIL discipline.
+// validation. These are documented xous semantics, asserted as they are.
 // ---------------------------------------------------------------------------
 
 /// `truncate(true)` with only `read(true)` set (no `write`) is accepted and
@@ -244,14 +232,9 @@ pub fn write_succeeds_through_read_only_handle() {
 
 /// `append(true).truncate(true)` together: upstream rejects this combination
 /// client-side ("invalid_options") before ever reaching the OS; xous performs
-/// no such validation and forwards both bits to the server. Fixed PFC-2:
-/// `open_key` used to capture the key length into `len` *before* the truncate
-/// branch physically emptied the key, and seeded `FileHandle.offset` from that
-/// stale `len` because `append` was set, landing the follow-up write at the
-/// old (pre-truncate) offset with zero-fill below it. The truncate branch now
-/// resets the snapshot after emptying the key, so the combo behaves like
-/// OS-level O_APPEND|O_TRUNC: truncate to empty, then a single subsequent
-/// write is the entire new content, as asserted here.
+/// no such validation and forwards both bits to the server. The combination
+/// must behave like OS-level O_APPEND|O_TRUNC: truncate to empty, then a
+/// single subsequent write is the entire new content.
 pub fn append_and_truncate_together_stale_offset() {
     let tmp = TmpDict::new("append_and_truncate_together");
     let path = tmp.path("f");
@@ -330,7 +313,7 @@ pub fn double_create_truncates_each_time() {
     check!(fs::remove_file(&path));
 }
 
-/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// This theme's tests (aggregated by tests::all_tests).
 pub const TESTS: &[(&str, fn())] = &[
     ("openflags::create_missing_creates_and_writes", create_missing_creates_and_writes as fn()),
     (
@@ -359,5 +342,3 @@ pub const TESTS: &[(&str, fn())] = &[
     ("openflags::create_new_and_create_together", create_new_and_create_together as fn()),
     ("openflags::double_create_truncates_each_time", double_create_truncates_each_time as fn()),
 ];
-
-pub const XFAILS: &[(&str, &str)] = &[];

--- a/services/pddb-fs-tests/src/tests/paths.rs
+++ b/services/pddb-fs-tests/src/tests/paths.rs
@@ -17,12 +17,8 @@
 //! all survive verbatim into the string PDDB receives, so none of the
 //! resolution/collapsing tricks common on Unix apply here.
 //!
-//! All assertions state the CORRECT/documented behavior; anything uncertain
-//! enough to be a plausible NEW bug is called out in the test's doc comment
-//! (see the crate-level review notes for provisional XFAILs, if any).
-//! Per the assignment brief this theme does not create or unlock any basis
-//! -- every test below probes basis grammar strictly against the always-
-//! mounted default `.System` basis.
+//! This theme does not create or unlock any basis: every test below probes
+//! basis grammar against the always-mounted default `.System` basis.
 
 use std::fs::{self, File};
 use std::io::Write;
@@ -220,8 +216,7 @@ pub fn unicode_dict_and_key_names() {
 /// literal flat dict name, and a flat namespace has no "missing parent" to
 /// trip on -- so `create_dir_all` returns early having created ONLY the dict
 /// literally named `<tmp>/a/b`; the would-be ancestor `<tmp>/a` is never
-/// materialized (empirically confirmed on the suite cold run: this test's
-/// original two-dicts assertion FAILed with `<tmp>/a` absent). A key created
+/// materialized. A key created
 /// at `<tmp>/a/b/c` is visible in a `read_dir` of `<tmp>/a/b` (the dict that
 /// literally owns it) but `<tmp>/a/b` never appears as an entry when reading
 /// `<tmp>` itself: PDDB has no real directory tree at any depth.
@@ -407,7 +402,7 @@ pub fn root_path_stat_single_colon_errors() {
     assert!(!Path::new(":").exists(), "bare ':' should not report as existing");
 }
 
-/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// This theme's tests (aggregated by tests::all_tests).
 pub const TESTS: &[(&str, fn())] = &[
     (
         "paths::basis_prefix_explicit_default_matches_unprefixed",
@@ -433,5 +428,3 @@ pub const TESTS: &[(&str, fn())] = &[
     ("paths::root_path_stat_empty_string_is_dict", root_path_stat_empty_string_is_dict as fn()),
     ("paths::root_path_stat_single_colon_errors", root_path_stat_single_colon_errors as fn()),
 ];
-
-pub const XFAILS: &[(&str, &str)] = &[];

--- a/services/pddb-fs-tests/src/tests/persist.rs
+++ b/services/pddb-fs-tests/src/tests/persist.rs
@@ -44,7 +44,7 @@ const DICT: &str = "pddbtest.persist";
 const SUBDICT: &str = "pddbtest.persist_sub";
 
 const MARKER_SMALL_LEN: usize = 100;
-const MARKER_MEDIUM_LEN: usize = 2 * 1024; // 2 KiB -- still under the 4 KiB truncate/re-create hazard line
+const MARKER_MEDIUM_LEN: usize = 2 * 1024;
 const MARKER_SMALL_SEED: u32 = 0x5EED_0064;
 const MARKER_MEDIUM_SEED: u32 = 0x5EED_0800;
 
@@ -76,11 +76,7 @@ fn sub_path(i: usize) -> String { format!("{}/sub_{}", SUBDICT, i) }
 pub fn verify_markers() {
     // The ghost check is unconditional: on a fresh flash it's trivially
     // absent (nothing ever created it), and on a warm run it must have
-    // stayed absent since last run's delete_then_persist removed it (PFC-11
-    // is about a stale-handle WRITE resurrecting a deleted key within the
-    // SAME run/process; a brand-new process has no such stale handle, so a
-    // clean disappearance across a restart is exactly the correct contract
-    // to assert here).
+    // stayed absent since last run's delete_then_persist removed it.
     assert!(
         !Path::new(&ghost_path()).exists(),
         "ghost key is present at process start -- it should have stayed deleted across the restart"
@@ -120,9 +116,7 @@ pub fn verify_markers() {
 
 /// VERIFY (runs second, before any writer in this process): the subdict
 /// doubles as a readdir-after-remount check. On the cold run the subdict
-/// doesn't exist yet (Path::exists() is unaffected by PFC-9 -- that bug is
-/// specifically about fs::read_dir on a MISSING dict returning an empty Ok
-/// instead of erroring, not about Path::exists()), so this logs and passes.
+/// doesn't exist yet, so this logs and passes.
 /// On the warm run the subdict must already hold exactly the 5 keys the
 /// previous process's write_markers left behind -- neither more nor fewer.
 pub fn dict_survives() {
@@ -152,14 +146,8 @@ pub fn dict_survives() {
 }
 
 /// WRITE (runs after the verifiers): (re)write every marker deterministically
-/// and read each back within this run. Every overwrite here targets a key
-/// that (if it exists at all) is well under the 4 KiB large-pool hazard line
-/// (100 B / 2 KiB / 64 B), so re-creating it is safe per the SERVER-CRASH
-/// HAZARD rule.
+/// and read each back within this run.
 pub fn write_markers() {
-    // create_dir on an already-existing dict is a (silent, PFC-6) no-op
-    // success on this backend, so calling it unconditionally on both the
-    // cold and the warm run is safe and idempotent.
     check!(fs::create_dir(DICT));
     check!(fs::create_dir(SUBDICT));
 
@@ -168,7 +156,6 @@ pub fn write_markers() {
     assert_eq!(check!(fs::read(small_path())), small, "marker_small did not read back intact this run");
 
     let medium = gen_marker(MARKER_MEDIUM_LEN, MARKER_MEDIUM_SEED);
-    assert!(medium.len() < 4096, "marker_medium must stay under the 4 KiB truncate hazard line");
     check!(fs::write(medium_path(), &medium));
     assert_eq!(check!(fs::read(medium_path())), medium, "marker_medium did not read back intact this run");
 
@@ -192,7 +179,7 @@ pub fn delete_then_persist() {
     assert!(!Path::new(&path).exists(), "ghost key still present immediately after remove_file");
 }
 
-/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// This theme's tests (aggregated by tests::all_tests).
 /// Order is load-bearing: verifiers first, writers last (see file header).
 pub const TESTS: &[(&str, fn())] = &[
     ("persist::verify_markers", verify_markers as fn()),
@@ -200,5 +187,3 @@ pub const TESTS: &[(&str, fn())] = &[
     ("persist::write_markers", write_markers as fn()),
     ("persist::delete_then_persist", delete_then_persist as fn()),
 ];
-
-pub const XFAILS: &[(&str, &str)] = &[];

--- a/services/pddb-fs-tests/src/tests/persist.rs
+++ b/services/pddb-fs-tests/src/tests/persist.rs
@@ -148,8 +148,11 @@ pub fn dict_survives() {
 /// WRITE (runs after the verifiers): (re)write every marker deterministically
 /// and read each back within this run.
 pub fn write_markers() {
-    check!(fs::create_dir(DICT));
-    check!(fs::create_dir(SUBDICT));
+    for dict in [DICT, SUBDICT] {
+        if !Path::new(dict).exists() {
+            check!(fs::create_dir(dict));
+        }
+    }
 
     let small = gen_marker(MARKER_SMALL_LEN, MARKER_SMALL_SEED);
     check!(fs::write(small_path(), &small));

--- a/services/pddb-fs-tests/src/tests/rw.rs
+++ b/services/pddb-fs-tests/src/tests/rw.rs
@@ -40,8 +40,7 @@ pub fn io_smoke_test() {
 }
 
 /// Ported from upstream `file_test_io_non_positional_read`: two sequential
-/// reads into disjoint halves of one buffer must land contiguously (no seeks
-/// involved, so no PFC-3 exposure).
+/// reads into disjoint halves of one buffer must land contiguously.
 pub fn io_non_positional_read() {
     let tmp = TmpDict::new("io_non_positional_read");
     let path = tmp.path("file");
@@ -67,9 +66,7 @@ pub fn io_non_positional_read() {
     assert_eq!(read_str, message);
 }
 
-/// Ported from upstream `file_test_io_seek_and_tell_smoke_test`. Only a
-/// forward `SeekFrom::Start` is used, so this stays outside PFC-3's blast
-/// radius and must pass.
+/// Ported from upstream `file_test_io_seek_and_tell_smoke_test`.
 pub fn io_seek_and_tell_smoke_test() {
     let tmp = TmpDict::new("io_seek_and_tell_smoke_test");
     let path = tmp.path("file");
@@ -96,14 +93,10 @@ pub fn io_seek_and_tell_smoke_test() {
     assert_eq!(tell_pos_post_read, message.len() as u64);
 }
 
-/// Ported faithfully from upstream `file_test_io_seek_and_write` -- this is
-/// the maintainer's exact overwrite-idiom symptom report: write, seek back
-/// into the middle, write again, and read the whole thing back through a
-/// fresh handle. The in-place overwrite lands entirely within the existing
-/// length (3 + 10 == 13 == the original length), so it never grows the key
-/// and never re-creates it -- small-pool in-place update is the one path
-/// PFC-1 does NOT afflict (backend/dictionary.rs ~748-751), so this must
-/// pass.
+/// Ported from upstream `file_test_io_seek_and_write`: write, seek back into
+/// the middle, write again, and read the whole thing back through a fresh
+/// handle. The overwrite lands within the existing length (3 + 10 == 13), so
+/// the key is updated in place and never grows.
 pub fn io_seek_and_write() {
     let tmp = TmpDict::new("io_seek_and_write");
     let path = tmp.path("file");
@@ -127,12 +120,8 @@ pub fn io_seek_and_write() {
     assert_eq!(read_str, final_msg);
 }
 
-/// Ported from upstream `file_test_io_seek_shakedown`. Exercises negative
-/// `SeekFrom::End`/`SeekFrom::Current` offsets, which is exactly PFC-3
-/// territory: the server used to cast the offset with `as u64` before
-/// `checked_sub`, so any negative seek errored out (services/pddb/src/
-/// libstd/mod.rs seek_key/seek_from_point). Was XFAIL PFC-3; now pins the
-/// fix.
+/// Ported from upstream `file_test_io_seek_shakedown`: negative
+/// `SeekFrom::End` and `SeekFrom::Current` offsets.
 pub fn io_seek_shakedown() {
     let tmp = TmpDict::new("io_seek_shakedown");
     let path = tmp.path("file");
@@ -165,18 +154,13 @@ pub fn io_seek_shakedown() {
 }
 
 /// Ported from upstream `file_test_io_eof`: a freshly-created, never-written
-/// file reads back 0 bytes, repeatedly, at EOF. No seeks, no growth -- must
-/// pass. Fixture deviation from upstream (empirical, cold run 2026-07-07):
-/// `.create(true)` is added alongside `create_new` because on xous
-/// `create_new` alone can never create a missing file (PFC-10; the open
-/// errored and this test failed before reaching its EOF subject). PFC-10
-/// itself is pinned by openflags::create_new_creates_missing.
+/// file reads back 0 bytes, repeatedly, at EOF.
 pub fn io_eof() {
     let tmp = TmpDict::new("io_eof");
     let path = tmp.path("file");
     let mut buf = [0; 256];
     {
-        let oo = OpenOptions::new().create(true).create_new(true).write(true).read(true).clone();
+        let oo = OpenOptions::new().create_new(true).write(true).read(true).clone();
         let mut rw = check!(oo.open(&path));
         assert_eq!(check!(rw.read(&mut buf)), 0);
         assert_eq!(check!(rw.read(&mut buf)), 0);
@@ -185,12 +169,11 @@ pub fn io_eof() {
 }
 
 /// Xous-specific: a matrix of `SeekFrom::Start`-only seeks (0, mid, last
-/// byte, exactly at EOF). Never passes a negative offset to seek_from_point,
-/// so this must pass regardless of PFC-3.
+/// byte, exactly at EOF).
 pub fn seek_start_matrix() {
     let tmp = TmpDict::new("seek_start_matrix");
     let path = tmp.path("file");
-    let content = b"0123456789ABCDEF"; // 16 bytes, well under the 4 KiB hazard line
+    let content = b"0123456789ABCDEF"; // 16 bytes
     {
         let mut f = check!(File::create(&path));
         check!(f.write_all(content));
@@ -211,10 +194,8 @@ pub fn seek_start_matrix() {
 
 /// Xous-specific: negative `SeekFrom::End`/`SeekFrom::Current` offsets in
 /// isolation (End coverage that smoke::seek_negative_current doesn't
-/// exercise). Correct POSIX behavior: `End(-3)` on a 10-byte file lands at 7;
-/// a subsequent `Current(-5)` from 10 lands at 5. Was XFAIL PFC-3 (the
-/// server's `by as u64` cast before `checked_sub` made every negative offset
-/// error); now pins the fix.
+/// exercise). `End(-3)` on a 10-byte file lands at 7; a subsequent
+/// `Current(-5)` from 10 lands at 5.
 pub fn seek_negative_offsets() {
     let tmp = TmpDict::new("seek_negative_offsets");
     let path = tmp.path("file");
@@ -239,14 +220,10 @@ pub fn seek_negative_offsets() {
     check!(fs::remove_file(&path));
 }
 
-/// Xous-specific: open-time-length staleness (PFC-5, fixed). `write_key` in
-/// services/pddb/src/libstd/mod.rs used to advance only `file.offset`, never
-/// `file.length`, while `seek_key`'s `SeekFrom::End` branch seeks from
-/// `file.length` (captured at *open* time). `write_key` now advances
-/// `file.length` alongside the offset, so on a freshly-created (open-time
-/// length 0) handle, writing bytes through that SAME handle and then asking
-/// `SeekFrom::End(0)` reports the file's current true end, as POSIX
-/// requires. Must pass.
+/// Xous-specific: `SeekFrom::End(0)` through the handle that just grew the
+/// file must report the current end, not the length captured at open time
+/// (`seek_key` in services/pddb/src/libstd/mod.rs seeks End from the
+/// handle's cached length).
 pub fn seek_end_after_write_staleness() {
     let tmp = TmpDict::new("seek_end_after_write_staleness");
     let path = tmp.path("file");
@@ -259,8 +236,7 @@ pub fn seek_end_after_write_staleness() {
          through this same handle, not the length captured when it was opened"
     );
     drop(f);
-    // A freshly-opened handle picks up the true persisted length correctly --
-    // this half is not the bug, and pins down that the data itself is intact.
+    // A freshly-opened handle sees the persisted length and content.
     let mut f2 = check!(File::open(&path));
     assert_eq!(check!(f2.seek(SeekFrom::End(0))), 5);
     check!(f2.seek(SeekFrom::Start(0)));
@@ -272,12 +248,10 @@ pub fn seek_end_after_write_staleness() {
 }
 
 /// Xous-specific: seek past the current EOF, write past the gap, and read
-/// the whole thing back through a fresh handle. Confirmed by reading
-/// backend/dictionary.rs `key_update`: extending a small-pool key zero-fills
-/// the vector out to `offset` before splicing in the new bytes, so the gap
-/// must read back as zeros (POSIX sparse-file semantics) -- and because this
-/// growth's `kcache.len` update is the *grow* path (not the truncate path),
-/// it is unaffected by PFC-1. Must pass.
+/// the whole thing back through a fresh handle. `key_update` in
+/// backend/dictionary.rs zero-fills a small-pool key out to `offset` before
+/// splicing in the new bytes, so the gap must read back as zeros (POSIX
+/// sparse-file semantics).
 pub fn seek_past_eof_write_gap() {
     let tmp = TmpDict::new("seek_past_eof_write_gap");
     let path = tmp.path("file");
@@ -297,7 +271,7 @@ pub fn seek_past_eof_write_gap() {
 /// extending a pre-existing small file (never truncating it -- append-mode
 /// open must not truncate; services/pddb/src/libstd/mod.rs open_key sets
 /// `offset: if append { len } else { 0 }` and takes no truncate branch for a
-/// plain append open). Total size stays well under 4 KiB.
+/// plain append open).
 pub fn append_mode_multi_write() {
     let tmp = TmpDict::new("append_mode_multi_write");
     let path = tmp.path("file");
@@ -315,7 +289,6 @@ pub fn append_mode_multi_write() {
         check!(f.write_all(b"CCC"));
     }
     let expected = [base.as_slice(), b"AAA", b"BBB", b"CCC"].concat();
-    assert!(expected.len() < 4096, "test data must stay under the 4 KiB large-pool hazard line");
     assert_eq!(read_back(&path), expected);
     check!(fs::remove_file(&path));
 }
@@ -340,7 +313,7 @@ pub fn read_zero_length_buffer_and_empty_file() {
     check!(fs::remove_file(&path));
 }
 
-/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// This theme's tests (aggregated by tests::all_tests).
 pub const TESTS: &[(&str, fn())] = &[
     ("rw::io_smoke_test", io_smoke_test as fn()),
     ("rw::io_non_positional_read", io_non_positional_read as fn()),
@@ -355,6 +328,3 @@ pub const TESTS: &[(&str, fn())] = &[
     ("rw::append_mode_multi_write", append_mode_multi_write as fn()),
     ("rw::read_zero_length_buffer_and_empty_file", read_zero_length_buffer_and_empty_file as fn()),
 ];
-
-pub const XFAILS: &[(&str, &str)] = &[];
-

--- a/services/pddb-fs-tests/src/tests/sizes.rs
+++ b/services/pddb-fs-tests/src/tests/sizes.rs
@@ -1,7 +1,6 @@
 //! Theme `sizes`: allocation-pool boundaries and size-driven paths.
 //!
-//! Ground truth (services/pddb/src/backend), all verified by reading the
-//! actual source (not assumed):
+//! Ground truth (services/pddb/src/backend):
 //!
 //! - `VPAGE_SIZE = PAGE_SIZE - size_of::<Nonce>() - size_of::<Tag>() - size_of::<JournalType>()`
 //!   (backend/hw.rs:60). `PAGE_SIZE = SPINOR_ERASE_SIZE = 0x1000 = 4096` (services/spinor/src/api.rs:6).
@@ -18,9 +17,7 @@
 //!   (backend/dictionary.rs ~595-644) detects `kcache.reserved < (data.len() + offset)`, extracts the key's
 //!   full current content, removes it, and recurses with the complete data at offset 0, at which point the
 //!   *fresh-key* branch above decides the pool again. This is the internal small->large "graduation" path
-//!   exercised by several tests below; it is a `key_update` growth, not the user-level
-//!   `File::create`/`.truncate(true)`-over-an-existing-key SERVER-CRASH HAZARD (PFC-1) -- no test here ever
-//!   truncates an existing key in place.
+//!   exercised by several tests below.
 
 #![allow(unused_imports)]
 use std::fs::{self, File, OpenOptions};
@@ -132,10 +129,7 @@ pub fn one_byte_file() {
 /// SMALL_CAPACITY, which `key_update` handles by extracting the small-pool
 /// key's full content, removing it, and recursing with the complete data at
 /// offset 0 -- landing in the large pool (backend/dictionary.rs ~595-644,
-/// the "update/extend" path; see the module doc comment). This is the
-/// internal small->large graduation, *not* the user-level truncate/re-create
-/// SERVER-CRASH HAZARD (PFC-1) -- the handle here is never closed and
-/// reopened with truncate semantics.
+/// the "update/extend" path; see the module doc comment).
 pub fn growth_small_to_large_same_handle() {
     let tmp = TmpDict::new("growth_small_to_large_same_handle");
     let path = tmp.path("grow");
@@ -160,10 +154,7 @@ pub fn growth_small_to_large_same_handle() {
 /// reopened with `.append(true)` and extended by 8 KiB. Append never
 /// truncates -- services/pddb/src/libstd/mod.rs `open_key` sets `offset: if
 /// append { len } else { 0 }` and takes no truncate branch for a plain
-/// append open (see also rw::append_mode_multi_write) -- so re-opening the
-/// path here is safe even though it already holds content, unlike a
-/// `File::create`/`.truncate(true)` re-open of an existing >= 4 KiB key
-/// (PFC-1).
+/// append open (see also rw::append_mode_multi_write).
 pub fn growth_across_reopen_append() {
     let tmp = TmpDict::new("growth_across_reopen_append");
     let path = tmp.path("append_grow");
@@ -188,13 +179,9 @@ pub fn growth_across_reopen_append() {
     check!(fs::remove_file(&path));
 }
 
-/// Shrink via the SAFE pattern: `remove_file` (a full unlink -- never a
-/// truncate of an existing key in place) followed by a fresh `File::create`
-/// at a smaller size. This is the mandated workaround for
-/// the SERVER-CRASH HAZARD (truncating re-create of an existing large-pool
-/// key, PFC-1): `path` is fully unlinked before the smaller content is ever
-/// written, so the final `File::create` targets a genuinely non-existent
-/// key, not a truncate of an existing one.
+/// Shrink by unlink and re-create: `remove_file` a large-pool key, then a
+/// fresh `File::create` at a smaller size (the truncate-in-place shrink is
+/// smoke::overwrite_shorter_large).
 pub fn shrink_safe_pattern() {
     let tmp = TmpDict::new("shrink_safe_pattern");
     let path = tmp.path("shrink");
@@ -207,10 +194,10 @@ pub fn shrink_safe_pattern() {
     }
     assert_eq!(read_back(&path), big, "initial large content mismatch");
 
-    check!(fs::remove_file(&path)); // full unlink -- no truncate involved
+    check!(fs::remove_file(&path));
     assert!(File::open(&path).is_err(), "file still openable after remove_file");
 
-    let small = b"tiny-after-shrink"; // small pool, genuinely fresh key
+    let small = b"tiny-after-shrink"; // small pool, fresh key
     {
         let mut f = check!(File::create(&path));
         check!(f.write_all(small));
@@ -371,7 +358,7 @@ pub fn write_offset_spanning_pool_boundary() {
     check!(fs::remove_file(&path));
 }
 
-/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// This theme's tests (aggregated by tests::all_tests).
 pub const TESTS: &[(&str, fn())] = &[
     ("sizes::boundary_below_threshold", boundary_below_threshold as fn()),
     ("sizes::boundary_at_threshold", boundary_at_threshold as fn()),
@@ -386,5 +373,3 @@ pub const TESTS: &[(&str, fn())] = &[
     ("sizes::seek_read_page_spanning_32kib", seek_read_page_spanning_32kib as fn()),
     ("sizes::write_offset_spanning_pool_boundary", write_offset_spanning_pool_boundary as fn()),
 ];
-
-pub const XFAILS: &[(&str, &str)] = &[];

--- a/services/pddb-fs-tests/src/tests/smoke.rs
+++ b/services/pddb-fs-tests/src/tests/smoke.rs
@@ -1,6 +1,4 @@
-//! Seed tests exercising the harness machinery and pinning known PFC bugs.
-//! All assertions state the CORRECT behavior; known failures are registered in
-//! the XFAILS table in mod.rs — never weaken an assertion here.
+//! Seed tests exercising the harness machinery and the basic file lifecycle.
 
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -37,12 +35,8 @@ pub fn overwrite_shorter_small() {
 }
 
 /// Same as overwrite_shorter_small, but the first write lands the key in the
-/// large pool (>= ~4 KiB). Regression test for PFC-1: the truncating
-/// re-create used to PANIC the pddb server (`PageAlignedVa::from(0)` unwrap
-/// at services/pddb/src/backend/types.rs, killing pddb's main thread), so
-/// this test was DISABLED until the large-key truncate arm in
-/// backend/dictionary.rs was fixed to truncate the length only, like the
-/// small-pool arm. Now a normal expected-pass test.
+/// large pool (>= ~4 KiB), which takes a different truncate path in
+/// backend/dictionary.rs.
 pub fn overwrite_shorter_large() {
     let tmp = TmpDict::new("overwrite_shorter_large");
     let path = tmp.path("large");
@@ -51,10 +45,8 @@ pub fn overwrite_shorter_large() {
 }
 
 fn overwrite_shorter_inner(path: &str, first_len: usize) {
-    // Step logging (log::info is ignored by the sentinel parser): the large
-    // variant used to crash the WHOLE pddb server (PageAlignedVa::from(0)
-    // unwrap, backend/types.rs, bug PFC-1); the markers pinned down the
-    // killing request and stay useful if the truncate path ever regresses.
+    // Step logging (log::info is ignored by the sentinel parser) so a server
+    // crash can be pinned to the request that caused it.
     let mut rng = XorShift::new(first_len as u32);
     let mut first = vec![0u8; first_len];
     rng.fill(&mut first);
@@ -87,9 +79,7 @@ fn overwrite_shorter_inner(path: &str, first_len: usize) {
     assert_eq!(readback, second, "truncating overwrite did not read back intact");
 }
 
-/// SeekFrom::Current with a negative offset must rewind. Was XFAIL PFC-3
-/// (the server cast the offset with `as u64`, so any negative seek errored
-/// out); now pins the fix.
+/// SeekFrom::Current with a negative offset must rewind.
 pub fn seek_negative_current() {
     let tmp = TmpDict::new("seek_negative_current");
     let path = tmp.path("seek");
@@ -108,16 +98,10 @@ pub fn seek_negative_current() {
 }
 
 /// Closing one file must not affect other open handles in the same process.
-/// Pins the PFC-4 fix: CloseKeyStd used to drop the whole per-process fd
-/// table, killing B's handle when A closed.
 ///
-/// Ordering is load-bearing: all of B's I/O results are collected first and B
-/// is dropped explicitly BEFORE any panic. While PFC-4 was live, B's fd was
-/// dead after A closed, and PFC-7 makes `File::drop` panic on a failed close
-/// -- if that drop ran during panic-unwind (e.g. `check!` firing while B is
-/// still in scope) it would be a fatal double panic that aborts the whole
-/// runner. Dropped in a normal context, the drop panic is caught like any
-/// other.
+/// B's I/O results are collected first and B is dropped before any assertion:
+/// a `File::drop` that panics on a failed close would otherwise run during
+/// unwind and abort the whole runner as a double panic.
 pub fn two_files_close_one() {
     let tmp = TmpDict::new("two_files_close_one");
     let path_a = tmp.path("a");
@@ -129,7 +113,7 @@ pub fn two_files_close_one() {
     let seek_res = b.seek(SeekFrom::Start(0));
     let mut buf = Vec::new();
     let read_res = b.read_to_end(&mut buf);
-    drop(b); // may panic itself (PFC-7 close unwrap); catchable here
+    drop(b); // a panic here is caught like any other
     check!(write_res);
     assert_eq!(check!(seek_res), 0);
     check!(read_res);
@@ -138,7 +122,7 @@ pub fn two_files_close_one() {
     check!(fs::remove_file(&path_b));
 }
 
-/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// This theme's tests (aggregated by tests::all_tests).
 pub const TESTS: &[(&str, fn())] = &[
     ("smoke::create_write_read", create_write_read as fn()),
     ("smoke::overwrite_shorter_small", overwrite_shorter_small as fn()),
@@ -146,16 +130,7 @@ pub const TESTS: &[(&str, fn())] = &[
     ("smoke::seek_negative_current", seek_negative_current as fn()),
     ("smoke::two_files_close_one", two_files_close_one as fn()),
     ("smoke::create_new_existing", create_new_existing as fn()),
-    // smoke::overwrite_shorter_large (registered above) was DISABLED, not
-    // XFAIL, from the 2026-07-07 harness pilot until the PFC-1 fix landed:
-    // the truncating re-create of an existing 8 KiB key panicked the pddb
-    // server (PageAlignedVa::from(0) unwrap in backend/types.rs), and a dead
-    // server hangs every subsequent test. The large-key truncate arm in
-    // backend/dictionary.rs now truncates the length only, mirroring the
-    // small-pool arm, so the test is a normal expected-pass entry.
 ];
-
-pub const XFAILS: &[(&str, &str)] = &[];
 
 /// `create_new` on an existing path must fail. Don't assert the ErrorKind: the
 /// xous backend surfaces the collision as an internal DiskFull retcode that

--- a/services/pddb-fs-tests/src/tests/unsupported.rs
+++ b/services/pddb-fs-tests/src/tests/unsupported.rs
@@ -3,19 +3,15 @@
 //! Characterization facts: rename, set_len, fsync/datasync, File::flush,
 //! permissions, canonicalize, and link all map to ErrorKind::Unsupported on
 //! xous today -- this is documented client-side stub behavior (no server
-//! opcode exists for any of them), not a PFC-tracked bug, so these tests
-//! assert the Unsupported kind directly with no XFAIL entry. try_clone is
-//! grouped with these in the forbidden-API list for the same reason and is
-//! asserted the same way. fs::read_link (on a regular, non-symlink file) and
-//! fs::set_permissions are NOT in that documented list -- research suggests
-//! InvalidInput and a silent no-op respectively, but neither is confirmed, so
-//! those two tests characterize the actual observed behavior instead of
-//! asserting a specific kind (still requiring is_err()/data-intact as
-//! appropriate) per the error-assertion rule.
+//! opcode exists for any of them), so these tests assert the Unsupported
+//! kind directly. try_clone is grouped with these in the forbidden-API list
+//! for the same reason and is asserted the same way. fs::read_link (on a
+//! regular, non-symlink file) and fs::set_permissions are NOT in that
+//! documented list, so those two tests characterize the observed behavior
+//! instead of asserting a specific kind (still requiring is_err() or
+//! data-intact as appropriate).
 //! Every test verifies pre-existing file data survives the failed call via
-//! read-back, per the SERVER-CRASH HAZARD / read-back rules; all files here
-//! are a few bytes, well under the 4 KiB large-pool truncate hazard, and each
-//! is created exactly once (no truncating re-create).
+//! read-back.
 
 #![allow(unused_imports)]
 use std::fs::{self, File, OpenOptions};
@@ -428,7 +424,7 @@ pub fn try_clone_unsupported() {
     check!(fs::remove_file(&path));
 }
 
-/// This theme's registry (aggregated by tests::all_tests / all_xfails).
+/// This theme's tests (aggregated by tests::all_tests).
 pub const TESTS: &[(&str, fn())] = &[
     ("unsupported::rename_unsupported", rename_unsupported as fn()),
     ("unsupported::set_len_unsupported", set_len_unsupported as fn()),
@@ -441,5 +437,3 @@ pub const TESTS: &[(&str, fn())] = &[
     ("unsupported::set_permissions_characterize", set_permissions_characterize as fn()),
     ("unsupported::try_clone_unsupported", try_clone_unsupported as fn()),
 ];
-
-pub const XFAILS: &[(&str, &str)] = &[];


### PR DESCRIPTION
With the PDDB fix series merged and toolkit 1.98.1.1 current, every entry left in the XFAIL registry passes, so a cold run on dev ends red on xpass=5. The five entries go (PFC-5, 6, 9, 10) and the workflow header now expects pass=113 fail=0 xfail=0 xpass=0.

The comments in the suite told the history of each bug it once pinned. That belongs in the commit log, where the fix commits describe it, so the comments now say only what a test asserts and why the code looks the way it does. The crate rules in tests/mod.rs and the README no longer claim metadata length is always 0, the eleven empty per-theme tables are one XFAILS const, and the io_eof fixture drops the .create(true) that was added to work around PFC-10.

One real bug fell out: the persist writer called create_dir on its existing dicts and relied on the error being swallowed. With that error now reported, the warm run's first create_dir panics under check!. It creates them only when missing.

Cold and warm runs green on dev 60232fbdc with the driver from the keyboard PR, pass=113 fail=0 xfail=0 xpass=0 both legs, offline audit clean; renode-test emulation/tests/pddb-fs.robot with that PR's robot file OK in 559 s.