### PR TITLE
Address potential weakness in FIDO HMAC secret extension

### DIFF
--- a/apps-baosec/dc34-vault/src/fido2.rs
+++ b/apps-baosec/dc34-vault/src/fido2.rs
@@ -19,6 +19,8 @@ pub(crate) fn fido2_handler(
     allow_host: Arc<AtomicBool>,
     opensk_mutex: Arc<Mutex<i32>>,
     animate: Arc<AtomicBool>,
+    is_unused: Arc<AtomicBool>,
+    used_set: Arc<AtomicBool>,
 ) {
     // spawn the FIDO2 USB handler
     let _ = thread::spawn({
@@ -30,6 +32,8 @@ pub(crate) fn fido2_handler(
 
             let env = XousEnv::new(conn, animate);
             let mut ctap = dc34_vault::Ctap::new(env, Instant::now());
+            is_unused.store(ctap.is_unused(), Ordering::SeqCst);
+            used_set.store(true, Ordering::SeqCst);
             loop {
                 match ctap.env().main_hid_connection().u2f_wait_incoming() {
                     Ok(msg) => {

--- a/apps-baosec/dc34-vault/src/lib.rs
+++ b/apps-baosec/dc34-vault/src/lib.rs
@@ -18,7 +18,8 @@
 #[macro_use]
 extern crate arrayref;
 
-use crate::ctap::hid::HidPacket;
+use crate::ctap::storage::pin_hash;
+use crate::ctap::{hid::HidPacket, storage::count_credentials};
 use crate::ctap::main_hid::MainHid;
 #[cfg(feature = "vendor_hid")]
 use crate::ctap::vendor_hid::VendorHid;
@@ -72,6 +73,23 @@ impl<E: Env> Ctap<E> {
             #[cfg(feature = "vendor_hid")]
             vendor_hid,
         }
+    }
+
+    pub fn is_unused(&mut self) -> bool {
+        let master_keys_exist = self.env.store().find_handle(crate::api::key_store::STORAGE_KEY).unwrap().is_some();
+        let residential_credentials = count_credentials(&mut self.env).unwrap();
+        let sig_counter_written = self.env.store().find_handle(crate::ctap::storage::key::GLOBAL_SIGNATURE_COUNTER).unwrap().is_some();
+        let pin_set = pin_hash(&mut self.env).unwrap().is_some();
+
+        log::debug!("master keys: {:?}", master_keys_exist);
+        log::debug!("residentials: {}", residential_credentials);
+        log::debug!("sig_counter_written: {:?}", sig_counter_written);
+        log::debug!("pin_set: {:?}", pin_set);
+
+        !master_keys_exist
+            && residential_credentials == 0
+            && !sig_counter_written
+            && !pin_set
     }
 
     pub fn state(&mut self) -> &mut CtapState {

--- a/apps-baosec/dc34-vault/src/main.rs
+++ b/apps-baosec/dc34-vault/src/main.rs
@@ -139,7 +139,6 @@ fn main() -> ! {
 
     log::info!("menus");
     let menu_sid = xous::create_server().unwrap();
-    let menu_mgr = submenu::create_submenu(conn, actions_conn, menu_sid);
     let tour_menu_sid = xous::create_server().unwrap();
     let tour_menu_mgr = tourmenu::create_submenu(conn, actions_conn, tour_menu_sid);
     let gene_menu_sid = xous::create_server().unwrap();
@@ -190,7 +189,16 @@ fn main() -> ! {
     vault_ui.set_global_config(global_config.clone());
 
     log::info!("Fido2 service");
-    fido2::fido2_handler(conn, allow_host.clone(), opensk_mutex.clone(), animate.clone());
+    let is_fido_unused = Arc::new(AtomicBool::new(false));
+    let is_unused_set = Arc::new(AtomicBool::new(false));
+    fido2::fido2_handler(
+        conn,
+        allow_host.clone(),
+        opensk_mutex.clone(),
+        animate.clone(),
+        is_fido_unused.clone(),
+        is_unused_set.clone(),
+    );
 
     // overrides for testing
     #[cfg(feature = "production")]
@@ -326,6 +334,32 @@ fn main() -> ! {
             "Trusted init state is inconsistent; check that connection count required for keystore is consistent with reality."
         );
     }
+
+    // This block of code fixes a bug that happened in the shipping DC34 badges. An issue with TRNG seeding
+    // was identified that could reduce the original entropy pool to as little as 64 bits. This has since
+    // been fixed. The primary impact is the CRED_RANDOM_SECRET *might* have less entropy than intended -
+    // emphasis on might because the TRNG reseeds itself frequently. However, the most conservative
+    // assumption is that no reseed operation was hit and thus this one secret has less entropy than
+    // desired. This code detects if the device was ever used as a FIDO token (if it was used, then, a
+    // certain set of *other* secrets are on-demand generated). If it hasn't been used, the
+    // CRED_RANDOM_SECRET is regenerated from scratch, fixing the potential issue. If it has been used, a
+    // menu option offering users a one-time ability to regenerate their FIDO token is offered.
+    while !is_unused_set.load(Ordering::SeqCst) {
+        xous::yield_slice();
+    }
+    log::info!("Is FIDO feature unused: {:?}", is_fido_unused.load(Ordering::SeqCst));
+    let offer_reset = keystore.get_owc(FIDO_REINIT).unwrap() == 0;
+    // if the system hasn't been used, just regenerate all the keys without asking.
+    if offer_reset && is_fido_unused.load(Ordering::SeqCst) {
+        // safety: the constant is defined and in-range
+        unsafe { keystore.inc_owc(FIDO_REINIT).unwrap() };
+        pddb.delete_dict("opensk", None).ok();
+        pddb.delete_dict("fido.u2fapps", None).ok();
+        pddb.sync().unwrap();
+        let susres = susres::Susres::new_without_hook(&xns).unwrap();
+        susres.reboot(true).unwrap();
+    }
+    let menu_mgr = submenu::create_submenu(conn, actions_conn, menu_sid, offer_reset);
 
     let mut menu_active = false;
     let mut jig_ready_seen = false;
@@ -1080,6 +1114,33 @@ fn main() -> ! {
                 };
                 kbd_key.write(&map_code.to_le_bytes()).ok();
                 usb.set_key_map(map_code.into());
+            }
+            Some(VaultOp::ResetToken) => {
+                modals.add_list_item("No").unwrap();
+                modals.add_list_item("Yes").unwrap();
+                modals
+                    .get_radiobutton("Regenerate FIDO token? DANGER: permanent loss of existing token data.")
+                    .unwrap();
+                match modals.get_radio_index() {
+                    Ok(code) => {
+                        // the offer_reset check is included here to catch any cases where ResetToken was
+                        // accidentally triggered due to other code bugs. Basically,
+                        // once the FIDO_REINIT has been incremented, it
+                        // should be impossible to enter the path that wipes the FIDO store.
+                        if code == 1 && offer_reset {
+                            // safety: the constant is defined and in-range
+                            unsafe { keystore.inc_owc(FIDO_REINIT).unwrap() };
+                            pddb.delete_dict("opensk", None).ok();
+                            pddb.delete_dict("fido.u2fapps", None).ok();
+                            pddb.sync().unwrap();
+                            let susres = susres::Susres::new_without_hook(&xns).unwrap();
+                            susres.reboot(true).unwrap();
+                        }
+                    }
+                    Err(_) => {
+                        log::error!("Error in user query, cowardly not doing anything");
+                    }
+                };
             }
             Some(VaultOp::Jig) => {
                 *mode.lock().unwrap() = VaultMode::FactoryTest;

--- a/apps-baosec/dc34-vault/src/submenu.rs
+++ b/apps-baosec/dc34-vault/src/submenu.rs
@@ -6,7 +6,12 @@ use ux_api::menu::*;
 use crate::ActionOp;
 use crate::VaultOp;
 
-pub fn create_submenu(vault_conn: xous::CID, actions_conn: xous::CID, menu_mgr: xous::SID) -> MenuMatic {
+pub fn create_submenu(
+    vault_conn: xous::CID,
+    actions_conn: xous::CID,
+    menu_mgr: xous::SID,
+    offer_reset: bool,
+) -> MenuMatic {
     let mut menu_items = Vec::<MenuItem>::new();
 
     menu_items.push(MenuItem {
@@ -87,6 +92,15 @@ pub fn create_submenu(vault_conn: xous::CID, actions_conn: xous::CID, menu_mgr: 
         action_payload: MenuPayload::Scalar([0, 0, 0, 0]),
         close_on_select: true,
     });
+    if offer_reset {
+        menu_items.push(MenuItem {
+            name: String::from("Regen FIDO..."),
+            action_conn: Some(vault_conn),
+            action_opcode: VaultOp::ResetToken.to_u32().unwrap(),
+            action_payload: MenuPayload::Scalar([0, 0, 0, 0]),
+            close_on_select: true,
+        });
+    }
     menu_items.push(MenuItem {
         name: String::from(t!("vault.menu_close", locales::LANG)),
         action_conn: Some(actions_conn),

--- a/apps-baosec/dc34-vault/src/vault_api.rs
+++ b/apps-baosec/dc34-vault/src/vault_api.rs
@@ -75,6 +75,8 @@ pub(crate) enum VaultOp {
     SkipKey = 1026,
     // monkey patch to indicate if BIO hacks are active
     BioActive = 1027,
+    // work-around to offer a token reset due to earlier issues with TRNG
+    ResetToken = 1028,
 }
 
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]

--- a/libs/bao1x-api/src/offsets/common.rs
+++ b/libs/bao1x-api/src/offsets/common.rs
@@ -308,7 +308,8 @@ pub const BOOT1_REVOCATION_OFFSET: usize = LOADER_REVOCATION_OFFSET + PUBKEY_SLO
 /// key slots, from [124..=127].
 pub const BOOT0_REVOCATION_OFFSET: usize = BOOT1_REVOCATION_OFFSET + PUBKEY_SLOTS;
 
-// slots from 128..=255 are totally unused by the boot logic
+// slots from 128..=255 are totally unused by the boot logic, and available to applications for use
+pub const APP_OWC_BEGIN: usize = 128;
 
 // =========== DATA SLOTS ==============
 

--- a/libs/bao1x-checks/Cargo.lock
+++ b/libs/bao1x-checks/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bao1x-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arbitrary-int",
  "bitbybit",

--- a/libs/dc34-api/src/lib.rs
+++ b/libs/dc34-api/src/lib.rs
@@ -24,6 +24,10 @@ pub const SERVER_NAME_VAULT2: &str = "_Vault2_";
 /// are disabled. 128 is the beginning of the 'application' range for OWC.
 pub const FACTORY_ONE_WAY: usize = 128;
 
+/// Flags if FIDO has be re-inited. This is an option users can invoke to
+/// regenerate their FIDO secrets with corrected TRNG seeding code.
+pub const FIDO_REINIT: usize = 129;
+
 // chosen by fair dice roll. guaranteed to be random.
 pub const DC34_HEADER: [u8; 16] = hex!("49db7671 f34435ed 5fddffdf cbb7508a");
 

--- a/libs/keystore-api/src/gen2_api.rs
+++ b/libs/keystore-api/src/gen2_api.rs
@@ -26,7 +26,6 @@ pub enum Opcode {
     SetFlags = 513,
     /// One way counter operations
     GetOneWayCounter = 768,
-    #[cfg(feature = "owc-inc")]
     IncOneWayCounter = 769,
 
     /// Application key operations

--- a/services/keystore/Cargo.toml
+++ b/services/keystore/Cargo.toml
@@ -87,8 +87,8 @@ bao1x = ["utralib/bao1x", "aes/bao1x"]
 debug-hal = ["bao1x-hal/debug-print-duart"]
 debug-swap-sig = []
 
-# Enables incrementing one way counters. Off by default because this API can be, at the very least,
-# used to grief the security layer if not worse
+# Enables incrementing one way counters in the system range. Off by default because this API can be,
+# at the very least, used to grief the security layer if not worse
 owc-inc = ["keystore-api/owc-inc"]
 
 # Enable to allow users to access the application keystore slots

--- a/services/keystore/src/lib.rs
+++ b/services/keystore/src/lib.rs
@@ -1,4 +1,4 @@
-use bao1x_api::{BackupFlags, OneWayEncoding, OneWayErr};
+use bao1x_api::{APP_OWC_BEGIN, BackupFlags, OneWayEncoding, OneWayErr};
 pub use cipher::{
     BlockBackend, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, ParBlocksSizeUser,
     consts::U16, generic_array::GenericArray, inout::InOut,
@@ -239,8 +239,11 @@ impl Keystore {
     /// fit into the `encode_oneway` mechanism, e.g. key revocations, etc.
     ///
     /// All you have to do to be safe is no be super-sure you got the offset right.
-    #[cfg(feature = "owc-inc")]
     pub unsafe fn inc_owc(&self, offset: usize) -> Result<(), OneWayErr> {
+        if !cfg!(feature = "owc-inc") && offset < APP_OWC_BEGIN {
+            return Err(OneWayErr::OutOfBounds);
+        }
+
         let result = xous::send_message(
             self.conn,
             xous::Message::new_blocking_scalar(
@@ -264,17 +267,20 @@ impl Keystore {
     }
 
     /// Automatically increments the correct slot based on the OFFSET encoded in the definition
-    #[cfg(feature = "owc-inc")]
     pub fn inc_owc_coded<T>(&self) -> Result<(), OneWayErr>
     where
         T: OneWayEncoding,
         T::Error: core::fmt::Debug,
     {
         let offset: usize = T::OFFSET;
-        if offset < bao1x_hal::acram::MAX_ONEWAY_COUNTERS {
-            unsafe { self.inc_owc(offset) }
-        } else {
+        if !cfg!(feature = "owc-inc") && offset < APP_OWC_BEGIN {
             Err(OneWayErr::OutOfBounds)
+        } else {
+            if offset < bao1x_hal::acram::MAX_ONEWAY_COUNTERS {
+                unsafe { self.inc_owc(offset) }
+            } else {
+                Err(OneWayErr::OutOfBounds)
+            }
         }
     }
 

--- a/services/keystore/src/lib.rs
+++ b/services/keystore/src/lib.rs
@@ -267,6 +267,7 @@ impl Keystore {
     }
 
     /// Automatically increments the correct slot based on the OFFSET encoded in the definition
+    #[cfg(feature = "bao1x")]
     pub fn inc_owc_coded<T>(&self) -> Result<(), OneWayErr>
     where
         T: OneWayEncoding,

--- a/services/keystore/src/platform/baosec/server.rs
+++ b/services/keystore/src/platform/baosec/server.rs
@@ -1,4 +1,4 @@
-use bao1x_api::{BackupFlags, OneWayErr};
+use bao1x_api::{APP_OWC_BEGIN, BackupFlags, OneWayErr};
 use bao1x_hal::acram::MAX_ONEWAY_COUNTERS;
 use bao1x_hal::board::{BOOKEND_END, BOOKEND_START};
 use bao1x_hal::rram::Reram;
@@ -126,17 +126,20 @@ pub fn keystore(sid: SID) -> ! {
                     if store.is_developer() { scalar.arg1 = 0 } else { scalar.arg1 = 1 }
                 }
             }
-            #[cfg(feature = "owc-inc")]
             Opcode::IncOneWayCounter => {
                 if let Some(scalar) = msg.body.scalar_message_mut() {
                     if [scalar.arg2, scalar.arg3, scalar.arg4] == OWC_MAGIC_INC
                         && scalar.arg1 < MAX_ONEWAY_COUNTERS
                     {
-                        match unsafe { store.owc.inc(scalar.arg1) } {
-                            Ok(_) => {
-                                scalar.arg1 = OneWayErr::None.to_usize().unwrap();
+                        if !cfg!(feature = "owc-inc") && scalar.arg1 < APP_OWC_BEGIN {
+                            scalar.arg1 = OneWayErr::InternalError.to_usize().unwrap();
+                        } else {
+                            match unsafe { store.owc.inc(scalar.arg1) } {
+                                Ok(_) => {
+                                    scalar.arg1 = OneWayErr::None.to_usize().unwrap();
+                                }
+                                Err(e) => scalar.arg1 = e.to_usize().unwrap(),
                             }
-                            Err(e) => scalar.arg1 = e.to_usize().unwrap(),
                         }
                     } else {
                         scalar.arg1 = OneWayErr::InternalError.to_usize().unwrap();

--- a/services/keystore/src/platform/baosec/server.rs
+++ b/services/keystore/src/platform/baosec/server.rs
@@ -132,7 +132,7 @@ pub fn keystore(sid: SID) -> ! {
                         && scalar.arg1 < MAX_ONEWAY_COUNTERS
                     {
                         if !cfg!(feature = "owc-inc") && scalar.arg1 < APP_OWC_BEGIN {
-                            scalar.arg1 = OneWayErr::InternalError.to_usize().unwrap();
+                            scalar.arg1 = OneWayErr::OutOfBounds.to_usize().unwrap();
                         } else {
                             match unsafe { store.owc.inc(scalar.arg1) } {
                                 Ok(_) => {


### PR DESCRIPTION
    Address potential weakness in FIDO HMAC secret extension

    A weakness in the TRNG seeding was identified and fixed in a prior
    patch. The upshot is that the entropy pool could have as little
    as 64 bits of real entropy in it prior to use.

    While the entropy pool does reseed aggressively, and generally
    speaking the FIDO secrets are generated after the PDDB is formatted,
    and so plenty of reseeding should have happened, this is just
    my analysis, and not formally proven. The most conservative assumption
    is that the secret "could" be weak.

    This patch does the following:

    1. If it detects that the FIDO feature is not yet used, it automatically
    wipes the FIDO credentials, forcing a re-generation of everything using
    the patched TRNG. I am assuming most users are in this state, and so,
    this eliminates any doubt about the strength of the secrets.

    2. If the FIDO feature has been used, it offers a menu item inside
    the token menu, "Regen FIDO...", which allows users to opt-in to
    regenerating their FIDO token. This *only* regenerates the FIDO token
    feature; other passwords or TOTPs are left intact.

    3. A one-way counter is incremented once the credentials have been
    regenerated, and the counter is checked onall paths going into the
    regeneration, thus preventing accidental wipe in the future.

    The one-way counter result is checked on all paths into the wiping
    routine, so accidental/adversarial trigger sohuld not be possible.